### PR TITLE
fix: correct typos and add None checks

### DIFF
--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -46,6 +46,8 @@ class Moderation(Cog):
                     continue
                 if configuration.Enabled and configuration.KickAfter > 0:
                     guild = self.bot.get_guild(configuration.GuildId)
+                    if guild is None:
+                        continue
                     self.bot.log.info(f"Checking for member without role in {guild.name}.")
                     for member in guild.members:
                         if len(member.roles) == 1:
@@ -68,7 +70,7 @@ class Moderation(Cog):
                                         f"Please choose a role until {naturaldate(kick_after)}."
                                     )
         except Exception as ex:
-            self.bot.log.error(f"Error ocurred: {ex}")
+            self.bot.log.error(f"Error occurred: {ex}")
         self.bot.log.debug("Finish Autokicker Loop!")
 
     @tasks.loop(minutes=5)
@@ -110,7 +112,7 @@ class Moderation(Cog):
                     )
                     await message.delete()
         except Exception as ex:
-            self.bot.log.error(f"Error ocurred: {ex}")
+            self.bot.log.error(f"Error occurred: {ex}")
             if channel is not None:
                 self.bot.log.debug(f"Channel: {channel}")
             if message is not None:
@@ -272,7 +274,8 @@ class Moderation(Cog):
             if configurations is not None:
                 msg = "==== AutoDeleter Configuration ====\n"
                 for configuration in configurations:
-                    channel_name = ctx.guild.get_channel(configuration.ChannelId).name
+                    channel = ctx.guild.get_channel(configuration.ChannelId)
+                    channel_name = channel.name if channel else f"Unknown ({configuration.ChannelId})"
                     msg += (
                         f"Channel: {channel_name}, "
                         f"DeleteOlderThan: {configuration.DeleteOlderThan}, "

--- a/NerdyPy/modules/reminder.py
+++ b/NerdyPy/modules/reminder.py
@@ -42,7 +42,7 @@ class Reminder(GroupCog, group_name="reminder"):
                                     msg.LastSend = datetime.now()
                                     msg.Count += 1
         except Exception as ex:
-            self.bot.log.error(f"Error ocurred: {ex}")
+            self.bot.log.error(f"Error occurred: {ex}")
         self.bot.log.debug("Stop Reminder Loop!")
 
     @hybrid_command(name="create")

--- a/NerdyPy/utils/helpers.py
+++ b/NerdyPy/utils/helpers.py
@@ -9,13 +9,13 @@ def send_hidden_message(ctx: Context, msg: str):
     return ctx.send(msg, ephemeral=True)
 
 
-def empty_subcommand(ctx: Context):
+async def empty_subcommand(ctx: Context):
     if ctx.invoked_subcommand is None:
         args = str(ctx.message.clean_content).split(" ")
         if len(args) > 2:
             raise NerpyException("Command not found!")
         elif len(args) <= 1:
-            ctx.send_help(ctx.command)
+            await ctx.send_help(ctx.command)
     return
 
 


### PR DESCRIPTION
## Summary
- Fix "ocurred" → "occurred" typos in error logging (moderation.py, reminder.py)
- Add None check for guild in autokicker loop to prevent NoneType errors
- Add None check for channel in autodeleter list command
- Add missing `await` on `ctx.send_help()` in empty_subcommand helper

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Verify autokicker loop handles missing guilds gracefully
- [x] Verify autodeleter list handles deleted channels

🤖 Generated with [Claude Code](https://claude.ai/code)