### PR TITLE
chore: add return type hints to command methods

### DIFF
--- a/NerdyPy/modules/fun.py
+++ b/NerdyPy/modules/fun.py
@@ -129,7 +129,7 @@ class Fun(Cog):
         }
 
     @hybrid_command()
-    async def roll(self, ctx: Context, dice: int = 6):
+    async def roll(self, ctx: Context, dice: int = 6) -> None:
         """
         Rolls random number (between 1 and user choice)
 
@@ -143,7 +143,7 @@ class Fun(Cog):
             await ctx.send(f"{mention} rolled a 'AmIRetarded'-dice\n\n:game_die: yes :game_die:")
 
     @hybrid_command()
-    async def choose(self, ctx: Context, choices: str):
+    async def choose(self, ctx: Context, choices: str) -> None:
         """
         Makes a choice for you.
         Choices need to be seperated by "," and sentences also need to be encased by "".
@@ -156,7 +156,7 @@ class Fun(Cog):
         await ctx.send(f"{mention} asked me to choose between: {choices}\n\nI choose {choice(choices_list)}")
 
     @hybrid_command(name="8ball", aliases=["8b"])
-    async def eightball(self, ctx: Context, question: str):
+    async def eightball(self, ctx: Context, question: str) -> None:
         """
         Ask 8-Ball a question.
         Question must end with a question mark.
@@ -168,7 +168,7 @@ class Fun(Cog):
         await ctx.send(f"{mention} asked me: {question}\n\n{choice(self.ball)}")
 
     @hybrid_command()
-    async def hug(self, ctx: Context, user: Member, intensity: Optional[int] = None):
+    async def hug(self, ctx: Context, user: Member, intensity: Optional[int] = None) -> None:
         """
         Because everyone likes hugs!
 
@@ -193,7 +193,7 @@ class Fun(Cog):
             await ctx.send(f"{author} {choice(self.hugs)} {name}")
 
     @hybrid_command()
-    async def leet(self, ctx: Context, intensity: int, text: str):
+    async def leet(self, ctx: Context, intensity: int, text: str) -> None:
         """
         convert text into 1337speak
 
@@ -225,7 +225,7 @@ class Fun(Cog):
         await ctx.send(text)
 
     @hybrid_command()
-    async def roti(self, ctx: Context, num: int = None):
+    async def roti(self, ctx: Context, num: int = None) -> None:
         """
         rules of the internet
 
@@ -241,7 +241,7 @@ class Fun(Cog):
         await ctx.send(f"Rule {rule}: {self.rotis[rule]}")
 
     @hybrid_command()
-    async def say(self, ctx: Context, text: str):
+    async def say(self, ctx: Context, text: str) -> None:
         """
         makes the bot say what you want :O
         """

--- a/NerdyPy/modules/league.py
+++ b/NerdyPy/modules/league.py
@@ -27,7 +27,7 @@ class League(GroupCog):
         self.version = None
         self.config = self.bot.config["league"]
 
-    async def _get_latest_version(self):
+    async def _get_latest_version(self) -> str:
         if self.version is None:
             async with ClientSession() as session:
                 async with session.get("https://ddragon.leagueoflegends.com/api/versions.json") as response:
@@ -36,13 +36,13 @@ class League(GroupCog):
         return self.version
 
     # noinspection PyMethodMayBeStatic
-    def _get_url(self, region, cmd: LeagueCommand, arg: str):
+    def _get_url(self, region: str, cmd: LeagueCommand, arg: str) -> str:
         base_url = f"https://{region}.api.riotgames.com/lol/"
         return f"{base_url}{cmd.value}{arg}"
 
     @hybrid_command()
     @rename(summoner_name="name")
-    async def summoner(self, ctx: Context, region: Literal["EUW1", "NA1"], summoner_name: str):
+    async def summoner(self, ctx: Context, region: Literal["EUW1", "NA1"], summoner_name: str) -> None:
         """get information about the summoner"""
         rank = tier = lp = wins = losses = ""
 

--- a/NerdyPy/modules/random.py
+++ b/NerdyPy/modules/random.py
@@ -32,12 +32,12 @@ class Random(Cog):
         ]
 
     @hybrid_command()
-    async def lenny(self, ctx: Context):
+    async def lenny(self, ctx: Context) -> None:
         """Displays a random lenny face."""
         await ctx.send(choice(self.lennys))
 
     @hybrid_command()
-    async def quote(self, ctx: Context):
+    async def quote(self, ctx: Context) -> None:
         """random quote"""
         url = "https://quotesondesign.com/wp-json/wp/v2/posts/?orderby=rand"
 
@@ -52,7 +52,7 @@ class Random(Cog):
                 )
 
     @hybrid_command()
-    async def trump(self, ctx: Context):
+    async def trump(self, ctx: Context) -> None:
         """random trump tweet"""
         url = "https://api.whatdoestrumpthink.com/api/v1/quotes/random"
         trump_pic = "https://www.tolonews.com/sites/default/files/styles/principal_article_image/public/Trumpppp.jpg"
@@ -69,7 +69,7 @@ class Random(Cog):
         await ctx.send(embed=emb)
 
     @hybrid_command()
-    async def xkcd(self, ctx: Context):
+    async def xkcd(self, ctx: Context) -> None:
         """random xkcd comic"""
         url = "https://xkcd.com/"
         urlend = "info.0.json"
@@ -89,7 +89,7 @@ class Random(Cog):
         await ctx.send(data.get("img"))
 
     @hybrid_command()
-    async def bunny(self, ctx: Context):
+    async def bunny(self, ctx: Context) -> None:
         """Why do I have a random bunny gif command???"""
         url = "https://api.bunnies.io/v2/loop/random/?media=gif"
 


### PR DESCRIPTION
## Summary
- Add `-> None` return type hints to `fun.py` commands (7 methods)
- Add `-> None` return type hints to `random.py` commands (5 methods)
- Add `-> None` and `-> str` return type hints to `league.py` methods
- Add parameter type hint for `region` in `_get_url`

Improves IDE support and static analysis coverage.

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Verify commands still execute correctly

🤖 Generated with [Claude Code](https://claude.ai/code)