### PR TITLE
Add comprehensive test suite with 148 tests

### DIFF
--- a/NerdyPy/modules/fun.py
+++ b/NerdyPy/modules/fun.py
@@ -234,6 +234,7 @@ class Fun(Cog):
         if num:
             if num not in self.rotis:
                 await ctx.send("Sorry 4chan pleb, no rules found with this number")
+                return
             rule = num
         else:
             rule = choice(list(self.rotis.keys()))

--- a/NerdyPy/utils/format.py
+++ b/NerdyPy/utils/format.py
@@ -73,7 +73,9 @@ def pagify(text, delims=None, page_length=2000):
 
     while len(in_text) > page_length:
         closest_delim = max([in_text.rfind(d, 0, page_length) for d in delims])
-        closest_delim = closest_delim if closest_delim != -1 else page_length
+        # Use page_length if no delimiter found OR if delimiter is at position 0
+        # (position 0 would cause infinite loop as in_text[0:] == in_text)
+        closest_delim = closest_delim if closest_delim > 0 else page_length
 
         to_send = in_text[:closest_delim]
         yield str(to_send)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,15 @@ bot = [
 ]
 test = [
     "pytest",
+    "pytest-asyncio",
     "pytest-cov",
     "ruff",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+testpaths = ["tests"]
 migrations = [
     "SQLAlchemy",
     "alembic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,14 +38,18 @@ test = [
     "pytest-cov",
     "ruff",
 ]
+migrations = [
+    "SQLAlchemy",
+    "alembic",
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
-migrations = [
-    "SQLAlchemy",
-    "alembic",
+filterwarnings = [
+    # discord.py uses deprecated asyncio.iscoroutinefunction (will be fixed when discord.py updates)
+    "ignore::DeprecationWarning:discord.ext.commands.core",
 ]
 
 [tool.ruff]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""NerpyBot test suite"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""Shared pytest fixtures for NerpyBot test suite"""
+
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Add NerdyPy to path so we can import modules
+sys.path.insert(0, str(Path(__file__).parent.parent / "NerdyPy"))
+
+from utils.database import BASE
+
+
+@pytest.fixture
+def db_engine():
+    """Create an in-memory SQLite engine for testing."""
+    engine = create_engine("sqlite:///:memory:", echo=False)
+
+    # Import all models to ensure they're registered with BASE.metadata
+    from models.admin import GuildPrefix  # noqa: F401
+    from models.reminder import ReminderMessage  # noqa: F401
+    from models.tagging import Tag, TagEntry  # noqa: F401
+
+    BASE.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def db_session(db_engine):
+    """Create a new database session for testing."""
+    Session = sessionmaker(bind=db_engine)
+    session = Session()
+    yield session
+    session.rollback()
+    session.close()
+
+
+@pytest.fixture
+def mock_log():
+    """Mock logger that can be attached to bot."""
+    log = MagicMock()
+    log.info = MagicMock()
+    log.debug = MagicMock()
+    log.warning = MagicMock()
+    log.error = MagicMock()
+    return log
+
+
+@pytest.fixture
+def mock_bot(db_session, mock_log):
+    """Create a mock bot with session_scope context manager."""
+    bot = MagicMock()
+    bot.log = mock_log
+
+    @contextmanager
+    def session_scope():
+        yield db_session
+
+    bot.session_scope = session_scope
+    bot.config = MagicMock()
+
+    return bot
+
+
+@pytest.fixture
+def mock_member():
+    """Create a mock discord.Member."""
+    member = MagicMock()
+    member.id = 123456789
+    member.name = "TestUser"
+    member.display_name = "Test User"
+    member.mention = "<@123456789>"
+    member.voice = MagicMock()
+    member.voice.channel = MagicMock()
+    member.voice.channel.guild = MagicMock()
+    member.voice.channel.guild.id = 987654321
+    return member
+
+
+@pytest.fixture
+def mock_guild():
+    """Create a mock discord.Guild."""
+    guild = MagicMock()
+    guild.id = 987654321
+    guild.name = "Test Guild"
+    return guild
+
+
+@pytest.fixture
+def mock_channel():
+    """Create a mock discord.TextChannel."""
+    channel = MagicMock()
+    channel.id = 111222333
+    channel.name = "test-channel"
+    channel.send = AsyncMock()
+    return channel
+
+
+@pytest.fixture
+def mock_message(mock_member, mock_channel, mock_guild):
+    """Create a mock discord.Message."""
+    message = MagicMock()
+    message.id = 444555666
+    message.author = mock_member
+    message.channel = mock_channel
+    message.guild = mock_guild
+    message.content = "test message"
+    return message
+
+
+@pytest.fixture
+def mock_context(mock_bot, mock_member, mock_guild, mock_channel, mock_message):
+    """Create a mock discord Context for command testing."""
+    ctx = MagicMock()
+    ctx.bot = mock_bot
+    ctx.author = mock_member
+    ctx.guild = mock_guild
+    ctx.channel = mock_channel
+    ctx.message = mock_message
+    ctx.send = AsyncMock()
+    ctx.send_help = AsyncMock()
+    ctx.typing = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(), __aexit__=AsyncMock()))
+    ctx.invoked_subcommand = None
+    return ctx
+
+
+@pytest.fixture
+def mock_user():
+    """Create a mock discord.User for DM conversations."""
+    user = MagicMock()
+    user.id = 123456789
+    user.name = "TestUser"
+    user.send = AsyncMock()
+    return user

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,8 @@ def db_engine():
     from models.tagging import Tag, TagEntry  # noqa: F401
 
     BASE.metadata.create_all(engine)
-    return engine
+    yield engine
+    engine.dispose()
 
 
 @pytest.fixture
@@ -35,9 +36,11 @@ def db_session(db_engine):
     """Create a new database session for testing."""
     Session = sessionmaker(bind=db_engine)
     session = Session()
-    yield session
-    session.rollback()
-    session.close()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
 
 
 @pytest.fixture

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Integration tests"""

--- a/tests/integration/test_conversation.py
+++ b/tests/integration/test_conversation.py
@@ -1,0 +1,377 @@
+# -*- coding: utf-8 -*-
+"""Tests for utils/conversation.py - DM conversation state machine"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from utils.conversation import AnswerType, Conversation, ConversationManager, PreConversation, PrevConvState
+
+
+class ConcreteConversation(Conversation):
+    """Concrete implementation of Conversation for testing."""
+
+    def __init__(self, bot, user, guild):
+        super().__init__(bot, user, guild)
+        self.state_calls = []
+
+    def create_state_handler(self):
+        return {
+            "start": self.state_start,
+            "middle": self.state_middle,
+            "end": self.state_end,
+        }
+
+    async def state_start(self):
+        self.state_calls.append("start")
+
+    async def state_middle(self):
+        self.state_calls.append("middle")
+
+    async def state_end(self):
+        self.state_calls.append("end")
+
+
+class TestConversation:
+    """Tests for the Conversation base class."""
+
+    @pytest.fixture
+    def conversation(self, mock_bot, mock_user, mock_guild):
+        """Create a concrete conversation for testing."""
+        return ConcreteConversation(mock_bot, mock_user, mock_guild)
+
+    def test_initial_state_is_first_handler(self, conversation):
+        """Initial state should be the first key in state_handler."""
+        assert conversation.currentState == "start"
+
+    def test_is_active_initially_true(self, conversation):
+        """Conversation should start active."""
+        assert conversation.isActive is True
+
+    @pytest.mark.asyncio
+    async def test_close_sets_inactive(self, conversation):
+        """close() should set isActive to False."""
+        await conversation.close()
+        assert conversation.isActive is False
+
+    def test_is_conv_message_matches_current(self, conversation):
+        """is_conv_message should match current message ID."""
+        mock_message = MagicMock()
+        mock_message.id = 12345
+        conversation.currentMessage = mock_message
+
+        assert conversation.is_conv_message(12345) is True
+        assert conversation.is_conv_message(99999) is False
+
+    def test_is_answer_type_exact_match(self, conversation):
+        """is_answer_type should match exact type."""
+        conversation.answerType = AnswerType.REACTION
+        assert conversation.is_answer_type(AnswerType.REACTION) is True
+        assert conversation.is_answer_type(AnswerType.TEXT) is False
+
+    def test_is_answer_type_both_matches_all(self, conversation):
+        """BOTH answer type should match any type."""
+        conversation.answerType = AnswerType.BOTH
+        assert conversation.is_answer_type(AnswerType.REACTION) is True
+        assert conversation.is_answer_type(AnswerType.TEXT) is True
+
+    @pytest.mark.asyncio
+    async def test_repost_state_calls_handler(self, conversation):
+        """repost_state should call current state handler."""
+        await conversation.repost_state()
+        assert "start" in conversation.state_calls
+
+    @pytest.mark.asyncio
+    async def test_on_react_changes_state(self, conversation, mock_user):
+        """on_react should transition state based on reaction map."""
+        # Setup reaction map
+        conversation.reactions = {"✅": "middle", "❌": "end"}
+        conversation.currentMessage = MagicMock()
+
+        # React with ✅
+        await conversation.on_react("✅")
+
+        assert conversation.currentState == "middle"
+        assert conversation.currentMessage is None
+        assert conversation.lastResponse == "✅"
+
+    @pytest.mark.asyncio
+    async def test_on_react_ignores_unmapped_reaction(self, conversation):
+        """on_react should ignore reactions not in the map."""
+        conversation.reactions = {"✅": "middle"}
+        conversation.currentState = "start"
+
+        # React with unmapped emoji
+        await conversation.on_react("🚀")
+
+        # State unchanged
+        assert conversation.currentState == "start"
+
+    @pytest.mark.asyncio
+    async def test_on_message_transitions_state(self, conversation, mock_user):
+        """on_message should transition to next state."""
+        conversation.nextState = "end"
+        conversation.currentMessage = MagicMock()
+        conversation.answerHandler = None
+
+        mock_message = MagicMock()
+        mock_message.content = "user input"
+
+        await conversation.on_message(mock_message)
+
+        assert conversation.currentState == "end"
+        assert conversation.lastResponse == mock_message
+
+    @pytest.mark.asyncio
+    async def test_on_message_calls_answer_handler(self, conversation):
+        """on_message should call answer handler if set."""
+        handler_called = []
+
+        async def handler(msg):
+            handler_called.append(msg)
+            return True
+
+        conversation.answerHandler = handler
+        conversation.nextState = "middle"
+        conversation.currentMessage = MagicMock()
+
+        mock_message = MagicMock()
+        await conversation.on_message(mock_message)
+
+        assert len(handler_called) == 1
+        assert handler_called[0] == mock_message
+
+    @pytest.mark.asyncio
+    async def test_on_message_handler_can_reject(self, conversation):
+        """answer handler returning False should prevent state change."""
+
+        async def rejecting_handler(msg):
+            return False
+
+        conversation.answerHandler = rejecting_handler
+        conversation.nextState = "middle"
+        conversation.currentState = "start"
+        conversation.currentMessage = MagicMock()
+
+        await conversation.on_message(MagicMock())
+
+        # State should remain 'start' due to rejection
+        assert conversation.currentState == "start"
+
+
+class TestConversationSendMethods:
+    """Tests for Conversation send methods."""
+
+    @pytest.fixture
+    def conversation(self, mock_bot, mock_user, mock_guild):
+        return ConcreteConversation(mock_bot, mock_user, mock_guild)
+
+    @pytest.mark.asyncio
+    async def test_send_react_sets_answer_type(self, conversation, mock_user):
+        """send_react should set answer type to REACTION."""
+        mock_embed = MagicMock()
+        mock_message = MagicMock()
+        mock_message.add_reaction = AsyncMock()
+        mock_user.send = AsyncMock(return_value=mock_message)
+
+        await conversation.send_react(mock_embed, {"✅": "next"})
+
+        assert conversation.answerType == AnswerType.REACTION
+
+    @pytest.mark.asyncio
+    async def test_send_react_adds_reactions(self, conversation, mock_user):
+        """send_react should add emoji reactions to message."""
+        mock_embed = MagicMock()
+        mock_message = MagicMock()
+        mock_message.add_reaction = AsyncMock()
+        mock_user.send = AsyncMock(return_value=mock_message)
+
+        reactions = {"✅": "yes", "❌": "no"}
+        await conversation.send_react(mock_embed, reactions)
+
+        assert mock_message.add_reaction.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_msg_sets_answer_type(self, conversation, mock_user):
+        """send_msg should set answer type to TEXT."""
+        mock_embed = MagicMock()
+        mock_user.send = AsyncMock(return_value=MagicMock())
+
+        await conversation.send_msg(mock_embed, "next_state")
+
+        assert conversation.answerType == AnswerType.TEXT
+        assert conversation.nextState == "next_state"
+
+    @pytest.mark.asyncio
+    async def test_send_both_sets_answer_type(self, conversation, mock_user):
+        """send_both should set answer type to BOTH."""
+        mock_embed = MagicMock()
+        mock_message = MagicMock()
+        mock_message.add_reaction = AsyncMock()
+        mock_user.send = AsyncMock(return_value=mock_message)
+
+        await conversation.send_both(mock_embed, "next", None, {"✅": "yes"})
+
+        assert conversation.answerType == AnswerType.BOTH
+
+
+class TestConversationManager:
+    """Tests for the ConversationManager class."""
+
+    @pytest.fixture
+    def manager(self, mock_bot):
+        """Create a ConversationManager for testing."""
+        return ConversationManager(mock_bot)
+
+    @pytest.fixture
+    def conversation(self, mock_bot, mock_user, mock_guild):
+        """Create a conversation for testing."""
+        return ConcreteConversation(mock_bot, mock_user, mock_guild)
+
+    def test_get_user_conversation_returns_none_initially(self, manager, mock_user):
+        """Should return None for users without conversations."""
+        result = manager.get_user_conversation(mock_user)
+        assert result is None
+
+    def test_set_conversation_stores_by_user_id(self, manager, conversation, mock_user):
+        """set_conversation should store conversation by user ID."""
+        manager.set_conversation(conversation)
+
+        result = manager.get_user_conversation(mock_user)
+        assert result is conversation
+
+    @pytest.mark.asyncio
+    async def test_init_conversation_new_user(self, manager, conversation, mock_user):
+        """init_conversation should store and start conversation for new user."""
+        # Mock repost_state to avoid needing full state handler setup
+        conversation.repost_state = AsyncMock()
+
+        await manager.init_conversation(conversation)
+
+        # Should be stored
+        result = manager.get_user_conversation(mock_user)
+        assert result is conversation
+
+        # Should have called repost_state
+        conversation.repost_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_init_conversation_creates_preconversation_when_active(
+        self, manager, mock_bot, mock_user, mock_guild
+    ):
+        """init_conversation should create PreConversation if user has active conv."""
+        # Setup existing active conversation
+        existing_conv = ConcreteConversation(mock_bot, mock_user, mock_guild)
+        existing_conv.isActive = True
+        manager.set_conversation(existing_conv)
+
+        # Try to init new conversation
+        new_conv = ConcreteConversation(mock_bot, mock_user, mock_guild)
+        new_conv.repost_state = AsyncMock()
+
+        await manager.init_conversation(new_conv)
+
+        # Should have created a PreConversation
+        result = manager.get_user_conversation(mock_user)
+        assert isinstance(result, PreConversation)
+
+    @pytest.mark.asyncio
+    async def test_init_conversation_replaces_inactive(self, manager, mock_bot, mock_user, mock_guild):
+        """init_conversation should replace inactive conversation directly."""
+        # Setup existing inactive conversation
+        existing_conv = ConcreteConversation(mock_bot, mock_user, mock_guild)
+        existing_conv.isActive = False
+        manager.set_conversation(existing_conv)
+
+        # Init new conversation
+        new_conv = ConcreteConversation(mock_bot, mock_user, mock_guild)
+        new_conv.repost_state = AsyncMock()
+
+        await manager.init_conversation(new_conv)
+
+        # Should be the new conversation directly (not PreConversation)
+        result = manager.get_user_conversation(mock_user)
+        assert result is new_conv
+
+
+class TestPreConversation:
+    """Tests for the PreConversation class."""
+
+    @pytest.fixture
+    def prev_conv(self, mock_bot, mock_user, mock_guild):
+        """Create previous conversation."""
+        conv = ConcreteConversation(mock_bot, mock_user, mock_guild)
+        conv.repost_state = AsyncMock()
+        return conv
+
+    @pytest.fixture
+    def next_conv(self, mock_bot, mock_user, mock_guild):
+        """Create next conversation."""
+        conv = ConcreteConversation(mock_bot, mock_user, mock_guild)
+        conv.repost_state = AsyncMock()
+        return conv
+
+    @pytest.fixture
+    def pre_conv(self, mock_bot, prev_conv, next_conv, mock_user):
+        """Create PreConversation for testing."""
+        manager = ConversationManager(mock_bot)
+        return PreConversation(manager, mock_bot, prev_conv, next_conv, mock_user)
+
+    def test_initial_state_is_init(self, pre_conv):
+        """PreConversation should start in INIT state."""
+        assert pre_conv.currentState == PrevConvState.INIT
+
+    def test_state_handler_has_required_states(self, pre_conv):
+        """Should have handlers for INIT, PREV, and NEXT states."""
+        handler = pre_conv.stateHandler
+        assert PrevConvState.INIT in handler
+        assert PrevConvState.PREV in handler
+        assert PrevConvState.NEXT in handler
+
+    @pytest.mark.asyncio
+    async def test_prev_conv_state_resumes_previous(self, pre_conv, prev_conv):
+        """PREV state should resume previous conversation."""
+        await pre_conv.prev_conv()
+
+        # Should have called repost on previous conversation
+        prev_conv.repost_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_next_conv_state_starts_new(self, pre_conv, next_conv):
+        """NEXT state should start new conversation."""
+        await pre_conv.next_conv()
+
+        # Should have called repost on next conversation
+        next_conv.repost_state.assert_called_once()
+
+
+class TestAnswerType:
+    """Tests for AnswerType enum."""
+
+    def test_reaction_value(self):
+        """REACTION should be 0."""
+        assert AnswerType.REACTION.value == 0
+
+    def test_text_value(self):
+        """TEXT should be 1."""
+        assert AnswerType.TEXT.value == 1
+
+    def test_both_value(self):
+        """BOTH should be 2."""
+        assert AnswerType.BOTH.value == 2
+
+
+class TestPrevConvState:
+    """Tests for PrevConvState enum."""
+
+    def test_init_value(self):
+        """INIT should be 0."""
+        assert PrevConvState.INIT.value == 0
+
+    def test_prev_value(self):
+        """PREV should be 1."""
+        assert PrevConvState.PREV.value == 1
+
+    def test_next_value(self):
+        """NEXT should be 2."""
+        assert PrevConvState.NEXT.value == 2

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for database models"""

--- a/tests/models/test_admin_model.py
+++ b/tests/models/test_admin_model.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""Tests for models/admin.py - GuildPrefix model"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from models.admin import GuildPrefix
+
+
+class TestGuildPrefixGet:
+    """Tests for GuildPrefix.get() class method."""
+
+    def test_get_existing_prefix(self, db_session):
+        """Should return prefix for existing guild."""
+        # Setup
+        prefix = GuildPrefix(
+            GuildId=123456789,
+            Prefix=">>",
+            CreateDate=datetime.now(UTC),
+            Author="TestUser",
+        )
+        db_session.add(prefix)
+        db_session.commit()
+
+        # Test
+        result = GuildPrefix.get(123456789, db_session)
+
+        assert result is not None
+        assert result.GuildId == 123456789
+        assert result.Prefix == ">>"
+
+    def test_get_nonexistent_prefix_returns_none(self, db_session):
+        """Should return None for guild without prefix."""
+        result = GuildPrefix.get(999999999, db_session)
+        assert result is None
+
+    def test_get_correct_guild_with_multiple_prefixes(self, db_session):
+        """Should return correct prefix when multiple guilds exist."""
+        # Setup multiple prefixes
+        for guild_id, prefix in [(111, "!"), (222, "?"), (333, ">>")]:
+            p = GuildPrefix(
+                GuildId=guild_id,
+                Prefix=prefix,
+                CreateDate=datetime.now(UTC),
+                Author="TestUser",
+            )
+            db_session.add(p)
+        db_session.commit()
+
+        # Test
+        result = GuildPrefix.get(222, db_session)
+        assert result.Prefix == "?"
+
+
+class TestGuildPrefixDelete:
+    """Tests for GuildPrefix.delete() class method."""
+
+    def test_delete_existing_prefix(self, db_session):
+        """Should remove prefix from database."""
+        # Setup
+        prefix = GuildPrefix(
+            GuildId=123456789,
+            Prefix=">>",
+            CreateDate=datetime.now(UTC),
+            Author="TestUser",
+        )
+        db_session.add(prefix)
+        db_session.commit()
+
+        # Test
+        GuildPrefix.delete(123456789, db_session)
+        db_session.commit()
+
+        # Verify
+        assert GuildPrefix.get(123456789, db_session) is None
+
+    def test_delete_nonexistent_raises_error(self, db_session):
+        """Should raise error when deleting non-existent prefix."""
+        with pytest.raises(Exception):  # SQLAlchemy will raise when deleting None
+            GuildPrefix.delete(999999999, db_session)
+
+
+class TestGuildPrefixCreate:
+    """Tests for creating GuildPrefix entries."""
+
+    def test_create_new_prefix(self, db_session):
+        """Should save new prefix to database."""
+        prefix = GuildPrefix(
+            GuildId=123456789,
+            Prefix="!",
+            CreateDate=datetime.now(UTC),
+            Author="Creator",
+        )
+        db_session.add(prefix)
+        db_session.commit()
+
+        # Verify
+        retrieved = GuildPrefix.get(123456789, db_session)
+        assert retrieved is not None
+        assert retrieved.Prefix == "!"
+        assert retrieved.Author == "Creator"
+
+    def test_prefix_fields_stored_correctly(self, db_session):
+        """All fields should be stored and retrieved correctly."""
+        now = datetime.now(UTC)
+        prefix = GuildPrefix(
+            GuildId=123456789,
+            Prefix=">>",
+            CreateDate=now,
+            ModifiedDate=now,
+            Author="TestAuthor",
+        )
+        db_session.add(prefix)
+        db_session.commit()
+
+        # Verify all fields
+        retrieved = GuildPrefix.get(123456789, db_session)
+        assert retrieved.GuildId == 123456789
+        assert retrieved.Prefix == ">>"
+        assert retrieved.Author == "TestAuthor"
+        assert retrieved.CreateDate is not None
+        assert retrieved.ModifiedDate is not None
+
+    def test_guild_id_is_primary_key(self, db_session):
+        """GuildId should be unique - duplicate insert should fail."""
+        prefix1 = GuildPrefix(
+            GuildId=123456789,
+            Prefix="!",
+            CreateDate=datetime.now(UTC),
+            Author="User1",
+        )
+        db_session.add(prefix1)
+        db_session.commit()
+
+        # Attempt duplicate
+        prefix2 = GuildPrefix(
+            GuildId=123456789,
+            Prefix="?",
+            CreateDate=datetime.now(UTC),
+            Author="User2",
+        )
+        db_session.add(prefix2)
+
+        with pytest.raises(Exception):  # IntegrityError
+            db_session.commit()

--- a/tests/models/test_reminder.py
+++ b/tests/models/test_reminder.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+"""Tests for models/reminder.py - ReminderMessage model"""
+
+from datetime import UTC, datetime
+
+
+from models.reminder import ReminderMessage
+
+
+class TestReminderMessageGetById:
+    """Tests for ReminderMessage.get_by_id() class method."""
+
+    def test_get_existing_reminder(self, db_session):
+        """Should return reminder by ID and guild."""
+        # Setup
+        reminder = ReminderMessage(
+            GuildId=123456789,
+            ChannelId=111222333,
+            ChannelName="general",
+            CreateDate=datetime.now(UTC),
+            Author="TestUser",
+            Repeat=0,
+            Minutes=60,
+            LastSend=datetime.now(UTC),
+            Message="Test reminder",
+            Count=0,
+        )
+        db_session.add(reminder)
+        db_session.commit()
+
+        # Get the auto-generated ID
+        reminder_id = reminder.Id
+
+        # Test
+        result = ReminderMessage.get_by_id(reminder_id, 123456789, db_session)
+
+        assert result is not None
+        assert result.Id == reminder_id
+        assert result.Message == "Test reminder"
+
+    def test_get_nonexistent_id_returns_none(self, db_session):
+        """Should return None for non-existent ID."""
+        result = ReminderMessage.get_by_id(99999, 123456789, db_session)
+        assert result is None
+
+    def test_get_wrong_guild_returns_none(self, db_session):
+        """Should return None when guild doesn't match."""
+        # Setup
+        reminder = ReminderMessage(
+            GuildId=123456789,
+            ChannelId=111222333,
+            ChannelName="general",
+            CreateDate=datetime.now(UTC),
+            Author="TestUser",
+            Repeat=0,
+            Minutes=60,
+            LastSend=datetime.now(UTC),
+            Message="Test reminder",
+            Count=0,
+        )
+        db_session.add(reminder)
+        db_session.commit()
+
+        # Test with wrong guild
+        result = ReminderMessage.get_by_id(reminder.Id, 999999999, db_session)
+        assert result is None
+
+
+class TestReminderMessageGetAllByGuild:
+    """Tests for ReminderMessage.get_all_by_guild() class method."""
+
+    def test_get_all_for_guild(self, db_session):
+        """Should return all reminders for a guild."""
+        # Setup - 3 reminders for guild 123
+        for i in range(3):
+            reminder = ReminderMessage(
+                GuildId=123,
+                ChannelId=111,
+                ChannelName=f"channel-{i}",
+                CreateDate=datetime.now(UTC),
+                Author="TestUser",
+                Repeat=0,
+                Minutes=60,
+                LastSend=datetime.now(UTC),
+                Message=f"Reminder {i}",
+                Count=0,
+            )
+            db_session.add(reminder)
+        db_session.commit()
+
+        # Test
+        results = ReminderMessage.get_all_by_guild(123, db_session)
+        assert len(results) == 3
+
+    def test_get_all_excludes_other_guilds(self, db_session):
+        """Should only return reminders for specified guild."""
+        # Setup - reminders for different guilds
+        for guild_id in [111, 111, 222, 333]:
+            reminder = ReminderMessage(
+                GuildId=guild_id,
+                ChannelId=111,
+                ChannelName="general",
+                CreateDate=datetime.now(UTC),
+                Author="TestUser",
+                Repeat=0,
+                Minutes=60,
+                LastSend=datetime.now(UTC),
+                Message="Test",
+                Count=0,
+            )
+            db_session.add(reminder)
+        db_session.commit()
+
+        # Test
+        results = ReminderMessage.get_all_by_guild(111, db_session)
+        assert len(results) == 2
+
+    def test_get_all_empty_guild(self, db_session):
+        """Should return empty list for guild with no reminders."""
+        results = ReminderMessage.get_all_by_guild(999999999, db_session)
+        assert len(results) == 0
+
+
+class TestReminderMessageDelete:
+    """Tests for ReminderMessage.delete() class method."""
+
+    def test_delete_existing_reminder(self, db_session):
+        """Should remove reminder from database."""
+        # Setup
+        reminder = ReminderMessage(
+            GuildId=123456789,
+            ChannelId=111222333,
+            ChannelName="general",
+            CreateDate=datetime.now(UTC),
+            Author="TestUser",
+            Repeat=0,
+            Minutes=60,
+            LastSend=datetime.now(UTC),
+            Message="To be deleted",
+            Count=0,
+        )
+        db_session.add(reminder)
+        db_session.commit()
+        reminder_id = reminder.Id
+
+        # Test
+        ReminderMessage.delete(reminder_id, 123456789, db_session)
+        db_session.commit()
+
+        # Verify
+        assert ReminderMessage.get_by_id(reminder_id, 123456789, db_session) is None
+
+
+class TestReminderMessageStr:
+    """Tests for ReminderMessage.__str__() method."""
+
+    def test_str_contains_author(self, db_session):
+        """String representation should contain author."""
+        reminder = ReminderMessage(
+            GuildId=123,
+            ChannelId=111,
+            ChannelName="general",
+            CreateDate=datetime.now(UTC),
+            Author="TestAuthor",
+            Repeat=0,
+            Minutes=60,
+            LastSend=datetime.now(UTC),
+            Message="Test",
+            Count=5,
+        )
+        db_session.add(reminder)
+        db_session.commit()
+
+        result = str(reminder)
+        assert "TestAuthor" in result
+
+    def test_str_contains_channel(self, db_session):
+        """String representation should contain channel."""
+        reminder = ReminderMessage(
+            GuildId=123,
+            ChannelId=111,
+            ChannelName="test-channel",
+            CreateDate=datetime.now(UTC),
+            Author="TestUser",
+            Repeat=0,
+            Minutes=60,
+            LastSend=datetime.now(UTC),
+            Message="Test",
+            Count=0,
+        )
+        db_session.add(reminder)
+        db_session.commit()
+
+        result = str(reminder)
+        assert "test-channel" in result
+
+    def test_str_contains_count(self, db_session):
+        """String representation should contain hit count."""
+        reminder = ReminderMessage(
+            GuildId=123,
+            ChannelId=111,
+            ChannelName="general",
+            CreateDate=datetime.now(UTC),
+            Author="TestUser",
+            Repeat=0,
+            Minutes=60,
+            LastSend=datetime.now(UTC),
+            Message="Test",
+            Count=42,
+        )
+        db_session.add(reminder)
+        db_session.commit()
+
+        result = str(reminder)
+        assert "42" in result
+
+
+class TestReminderMessageGetAll:
+    """Tests for ReminderMessage.get_all() class method."""
+
+    def test_get_all_returns_all_reminders(self, db_session):
+        """Should return all reminders across all guilds."""
+        # Setup - reminders for different guilds
+        for guild_id in [111, 222, 333]:
+            reminder = ReminderMessage(
+                GuildId=guild_id,
+                ChannelId=111,
+                ChannelName="general",
+                CreateDate=datetime.now(UTC),
+                Author="TestUser",
+                Repeat=0,
+                Minutes=60,
+                LastSend=datetime.now(UTC),
+                Message="Test",
+                Count=0,
+            )
+            db_session.add(reminder)
+        db_session.commit()
+
+        # Test
+        results = ReminderMessage.get_all(db_session)
+        assert len(results) == 3
+
+    def test_get_all_ordered_by_id(self, db_session):
+        """Results should be ordered by ID ascending."""
+        # Create in reverse order
+        for guild_id in [333, 222, 111]:
+            reminder = ReminderMessage(
+                GuildId=guild_id,
+                ChannelId=111,
+                ChannelName="general",
+                CreateDate=datetime.now(UTC),
+                Author="TestUser",
+                Repeat=0,
+                Minutes=60,
+                LastSend=datetime.now(UTC),
+                Message="Test",
+                Count=0,
+            )
+            db_session.add(reminder)
+        db_session.commit()
+
+        # Test
+        results = ReminderMessage.get_all(db_session)
+
+        # IDs should be in ascending order
+        ids = [r.Id for r in results]
+        assert ids == sorted(ids)

--- a/tests/models/test_tag.py
+++ b/tests/models/test_tag.py
@@ -1,0 +1,463 @@
+# -*- coding: utf-8 -*-
+"""Tests for models/tagging.py - Tag and TagEntry models"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from models.tagging import Tag, TagEntry, TagType, TagTypeConverter
+
+
+class TestTagGet:
+    """Tests for Tag.get() class method."""
+
+    def test_get_existing_tag(self, db_session):
+        """Should return tag by name and guild."""
+        # Setup
+        tag = Tag(
+            GuildId=123,
+            Name="test-tag",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        # Test
+        result = Tag.get("test-tag", 123, db_session)
+
+        assert result is not None
+        assert result.Name == "test-tag"
+        assert result.GuildId == 123
+
+    def test_get_nonexistent_tag_returns_none(self, db_session):
+        """Should return None for non-existent tag."""
+        result = Tag.get("nonexistent", 123, db_session)
+        assert result is None
+
+    def test_get_tag_wrong_guild_returns_none(self, db_session):
+        """Should return None when guild doesn't match."""
+        tag = Tag(
+            GuildId=123,
+            Name="test-tag",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        # Test with different guild
+        result = Tag.get("test-tag", 999, db_session)
+        assert result is None
+
+
+class TestTagExists:
+    """Tests for Tag.exists() class method."""
+
+    def test_exists_returns_true_for_existing_tag(self, db_session):
+        """Should return True when tag exists."""
+        tag = Tag(
+            GuildId=123,
+            Name="existing-tag",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        assert Tag.exists("existing-tag", 123, db_session) is True
+
+    def test_exists_returns_false_for_nonexistent_tag(self, db_session):
+        """Should return False when tag doesn't exist."""
+        assert Tag.exists("nonexistent", 123, db_session) is False
+
+    def test_exists_is_guild_scoped(self, db_session):
+        """Should only find tags in the specified guild."""
+        tag = Tag(
+            GuildId=123,
+            Name="guild-tag",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        assert Tag.exists("guild-tag", 123, db_session) is True
+        assert Tag.exists("guild-tag", 999, db_session) is False
+
+
+class TestTagAdd:
+    """Tests for Tag.add() class method."""
+
+    def test_add_new_tag(self, db_session):
+        """Should add tag to database."""
+        tag = Tag(
+            GuildId=123,
+            Name="new-tag",
+            Type=TagType.sound.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+
+        Tag.add(tag, db_session)
+        db_session.commit()
+
+        # Verify
+        result = Tag.get("new-tag", 123, db_session)
+        assert result is not None
+        assert result.Name == "new-tag"
+
+
+class TestTagDelete:
+    """Tests for Tag.delete() class method."""
+
+    def test_delete_existing_tag(self, db_session):
+        """Should remove tag from database."""
+        tag = Tag(
+            GuildId=123,
+            Name="to-delete",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        # Delete
+        Tag.delete("to-delete", 123, db_session)
+        db_session.commit()
+
+        # Verify
+        assert Tag.get("to-delete", 123, db_session) is None
+
+    def test_delete_cascades_to_entries(self, db_session):
+        """Deleting tag should delete its entries too."""
+        # Setup tag with entries
+        tag = Tag(
+            GuildId=123,
+            Name="with-entries",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        # Add entries
+        tag.add_entry("Entry 1", db_session)
+        tag.add_entry("Entry 2", db_session)
+        db_session.commit()
+
+        # Get entry IDs before delete
+        entry_ids = [e.Id for e in tag.entries.all()]
+
+        # Delete tag
+        Tag.delete("with-entries", 123, db_session)
+        db_session.commit()
+
+        # Verify entries are gone
+        for entry_id in entry_ids:
+            entry = db_session.query(TagEntry).filter(TagEntry.Id == entry_id).first()
+            assert entry is None
+
+
+class TestTagAddEntry:
+    """Tests for Tag.add_entry() instance method."""
+
+    def test_add_text_entry(self, db_session):
+        """Should add text entry to tag."""
+        tag = Tag(
+            GuildId=123,
+            Name="text-tag",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        # Add entry
+        tag.add_entry("Hello World", db_session)
+        db_session.commit()
+
+        # Verify
+        entries = tag.entries.all()
+        assert len(entries) == 1
+        assert entries[0].TextContent == "Hello World"
+
+    def test_add_multiple_entries(self, db_session):
+        """Should support multiple entries per tag."""
+        tag = Tag(
+            GuildId=123,
+            Name="multi-entry",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        # Add multiple entries
+        tag.add_entry("Entry 1", db_session)
+        tag.add_entry("Entry 2", db_session)
+        tag.add_entry("Entry 3", db_session)
+        db_session.commit()
+
+        # Verify
+        assert tag.entries.count() == 3
+
+    def test_add_entry_with_bytes(self, db_session):
+        """Should support binary content for sound tags."""
+        tag = Tag(
+            GuildId=123,
+            Name="sound-tag",
+            Type=TagType.sound.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        # Add entry with bytes
+        audio_bytes = b"fake audio data"
+        tag.add_entry("audio.mp3", db_session, byt=audio_bytes)
+        db_session.commit()
+
+        # Verify
+        entry = tag.entries.first()
+        assert entry.ByteContent == audio_bytes
+
+
+class TestTagGetRandomEntry:
+    """Tests for Tag.get_random_entry() instance method."""
+
+    def test_get_random_returns_entry(self, db_session):
+        """Should return one of the tag's entries."""
+        tag = Tag(
+            GuildId=123,
+            Name="random-tag",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        tag.add_entry("Entry A", db_session)
+        tag.add_entry("Entry B", db_session)
+        tag.add_entry("Entry C", db_session)
+        db_session.commit()
+
+        # Test multiple times
+        valid_contents = ["Entry A", "Entry B", "Entry C"]
+        for _ in range(10):
+            entry = tag.get_random_entry()
+            assert entry.TextContent in valid_contents
+
+    def test_get_random_single_entry(self, db_session):
+        """Should return the only entry when only one exists."""
+        tag = Tag(
+            GuildId=123,
+            Name="single-entry",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        tag.add_entry("Only Entry", db_session)
+        db_session.commit()
+
+        entry = tag.get_random_entry()
+        assert entry.TextContent == "Only Entry"
+
+
+class TestTagGetAllFromGuild:
+    """Tests for Tag.get_all_from_guild() class method."""
+
+    def test_get_all_returns_guild_tags(self, db_session):
+        """Should return all tags for a guild."""
+        # Create tags for guild 123
+        for name in ["alpha", "beta", "gamma"]:
+            tag = Tag(
+                GuildId=123,
+                Name=name,
+                Type=TagType.text.value,
+                Author="TestUser",
+                CreateDate=datetime.now(UTC),
+                Count=0,
+                Volume=100,
+            )
+            db_session.add(tag)
+        db_session.commit()
+
+        # Test
+        results = Tag.get_all_from_guild(123, db_session)
+        assert len(results) == 3
+
+    def test_get_all_excludes_other_guilds(self, db_session):
+        """Should only return tags from specified guild."""
+        # Tags for different guilds
+        for guild_id, name in [(111, "tag1"), (111, "tag2"), (222, "tag3")]:
+            tag = Tag(
+                GuildId=guild_id,
+                Name=name,
+                Type=TagType.text.value,
+                Author="TestUser",
+                CreateDate=datetime.now(UTC),
+                Count=0,
+                Volume=100,
+            )
+            db_session.add(tag)
+        db_session.commit()
+
+        # Test
+        results = Tag.get_all_from_guild(111, db_session)
+        assert len(results) == 2
+
+    def test_get_all_ordered_by_name(self, db_session):
+        """Results should be ordered by name ascending."""
+        # Create in reverse alphabetical order
+        for name in ["zebra", "apple", "mango"]:
+            tag = Tag(
+                GuildId=123,
+                Name=name,
+                Type=TagType.text.value,
+                Author="TestUser",
+                CreateDate=datetime.now(UTC),
+                Count=0,
+                Volume=100,
+            )
+            db_session.add(tag)
+        db_session.commit()
+
+        # Test
+        results = Tag.get_all_from_guild(123, db_session)
+        names = [t.Name for t in results]
+        assert names == ["apple", "mango", "zebra"]
+
+
+class TestTagStr:
+    """Tests for Tag.__str__() method."""
+
+    def test_str_contains_name(self, db_session):
+        """String should contain tag name."""
+        tag = Tag(
+            GuildId=123,
+            Name="test-tag-name",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        assert "test-tag-name" in str(tag)
+
+    def test_str_contains_author(self, db_session):
+        """String should contain author."""
+        tag = Tag(
+            GuildId=123,
+            Name="test",
+            Type=TagType.text.value,
+            Author="SpecificAuthor",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        assert "SpecificAuthor" in str(tag)
+
+    def test_str_contains_type(self, db_session):
+        """String should contain tag type."""
+        tag = Tag(
+            GuildId=123,
+            Name="test",
+            Type=TagType.sound.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        assert "sound" in str(tag)
+
+    def test_str_contains_hit_count(self, db_session):
+        """String should contain hit count."""
+        tag = Tag(
+            GuildId=123,
+            Name="test",
+            Type=TagType.text.value,
+            Author="TestUser",
+            CreateDate=datetime.now(UTC),
+            Count=42,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        assert "42" in str(tag)
+
+
+class TestTagTypeConverterModel:
+    """Additional tests for TagTypeConverter from models."""
+
+    @pytest.fixture
+    def converter(self):
+        return TagTypeConverter()
+
+    @pytest.fixture
+    def mock_ctx(self):
+        return MagicMock()
+
+    @pytest.mark.asyncio
+    async def test_all_valid_types_convert(self, converter, mock_ctx):
+        """All TagType enum values should be convertible."""
+        for tag_type in TagType:
+            result = await converter.convert(mock_ctx, tag_type.name)
+            assert result == tag_type.value
+
+    @pytest.mark.asyncio
+    async def test_mixed_case_conversion(self, converter, mock_ctx):
+        """Should handle various case combinations."""
+        test_cases = ["SOUND", "Sound", "sOuNd", "TEXT", "text", "URL", "Url"]
+
+        for case in test_cases:
+            result = await converter.convert(mock_ctx, case)
+            assert result in [t.value for t in TagType]

--- a/tests/modules/__init__.py
+++ b/tests/modules/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for bot modules"""

--- a/tests/modules/test_admin.py
+++ b/tests/modules/test_admin.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""Tests for modules/admin.py - Administrative commands"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from models.admin import GuildPrefix
+from modules.admin import Admin
+
+
+@pytest.fixture
+def admin_cog(mock_bot):
+    """Create an Admin cog instance for testing."""
+    return Admin(mock_bot)
+
+
+class TestPrefixValidation:
+    """Tests for prefix validation logic."""
+
+    @pytest.mark.asyncio
+    async def test_prefix_with_spaces_rejected(self, admin_cog, mock_context):
+        """Prefix containing spaces should be rejected."""
+        await admin_cog._prefix_set.callback(admin_cog, mock_context, new_pref="! cmd")
+
+        # Check that rejection message was sent
+        mock_context.send.assert_any_call("Spaces not allowed in prefixes")
+
+    @pytest.mark.asyncio
+    async def test_prefix_without_spaces_accepted(self, admin_cog, mock_context, db_session):
+        """Prefix without spaces should be accepted."""
+        await admin_cog._prefix_set.callback(admin_cog, mock_context, new_pref="!")
+
+        # Should confirm the new prefix
+        mock_context.send.assert_called_with("new prefix is now set to '!'.")
+
+
+class TestPrefixGet:
+    """Tests for the prefix get command."""
+
+    @pytest.mark.asyncio
+    async def test_get_existing_prefix(self, admin_cog, mock_context, db_session, mock_guild):
+        """Should return the custom prefix if one exists."""
+        # Setup: Create a prefix in the database
+        prefix = GuildPrefix(
+            GuildId=mock_guild.id,
+            Prefix=">>",
+            CreateDate=datetime.now(UTC),
+            Author="TestUser",
+        )
+        db_session.add(prefix)
+        db_session.commit()
+
+        await admin_cog._prefix_get.callback(admin_cog, mock_context)
+
+        call_args = mock_context.send.call_args[0][0]
+        assert ">>" in call_args
+
+    @pytest.mark.asyncio
+    async def test_get_no_prefix_returns_default_message(self, admin_cog, mock_context):
+        """Should indicate no custom prefix when none exists."""
+        await admin_cog._prefix_get.callback(admin_cog, mock_context)
+
+        call_args = mock_context.send.call_args[0][0]
+        assert "no custom prefix" in call_args.lower()
+        assert "!" in call_args  # mentions default prefix
+
+
+class TestPrefixSet:
+    """Tests for the prefix set command."""
+
+    @pytest.mark.asyncio
+    async def test_set_new_prefix(self, admin_cog, mock_context, db_session, mock_guild):
+        """Should create new prefix entry when none exists."""
+        await admin_cog._prefix_set.callback(admin_cog, mock_context, new_pref=">>")
+
+        # Verify in database
+        prefix = GuildPrefix.get(mock_guild.id, db_session)
+        assert prefix is not None
+        assert prefix.Prefix == ">>"
+
+    @pytest.mark.asyncio
+    async def test_update_existing_prefix(self, admin_cog, mock_context, db_session, mock_guild):
+        """Should update existing prefix."""
+        # Setup: Create initial prefix
+        prefix = GuildPrefix(
+            GuildId=mock_guild.id,
+            Prefix="!",
+            CreateDate=datetime.now(UTC),
+            Author="TestUser",
+        )
+        db_session.add(prefix)
+        db_session.commit()
+
+        # Update prefix
+        await admin_cog._prefix_set.callback(admin_cog, mock_context, new_pref="??")
+
+        # Verify update
+        updated = GuildPrefix.get(mock_guild.id, db_session)
+        assert updated.Prefix == "??"
+        assert updated.ModifiedDate is not None
+
+
+class TestPrefixDelete:
+    """Tests for the prefix delete command."""
+
+    @pytest.mark.asyncio
+    async def test_delete_existing_prefix(self, admin_cog, mock_context, db_session, mock_guild):
+        """Should remove existing prefix from database."""
+        # Setup: Create a prefix
+        prefix = GuildPrefix(
+            GuildId=mock_guild.id,
+            Prefix=">>",
+            CreateDate=datetime.now(UTC),
+            Author="TestUser",
+        )
+        db_session.add(prefix)
+        db_session.commit()
+
+        await admin_cog._prefix_del.callback(admin_cog, mock_context)
+
+        # Verify deletion
+        assert GuildPrefix.get(mock_guild.id, db_session) is None
+        mock_context.send.assert_called_with("Prefix removed.")

--- a/tests/modules/test_fun.py
+++ b/tests/modules/test_fun.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+"""Tests for modules/fun.py - Entertainment commands"""
+
+from unittest.mock import patch
+
+import pytest
+
+from modules.fun import Fun
+
+
+@pytest.fixture
+def fun_cog(mock_bot):
+    """Create a Fun cog instance for testing."""
+    return Fun(mock_bot)
+
+
+class TestLeetTransformation:
+    """Tests for leet speak transformation logic."""
+
+    def test_intensity_level_1(self, fun_cog):
+        """Level 1 replaces only a, e, i, o."""
+        # Test individual character mappings
+        text = "aeiou"
+        valid_chars = fun_cog.leetdegrees[0]  # ['a', 'e', 'i', 'o']
+
+        result = ""
+        for c in text:
+            if c in valid_chars:
+                result += fun_cog.leetmap[c]
+            else:
+                result += c
+
+        assert "4" in result  # a -> 4
+        assert "3" in result  # e -> 3
+        assert "1" in result  # i -> 1
+        assert "0" in result  # o -> 0
+        assert "u" in result  # u not in level 1
+
+    def test_intensity_level_2_adds_more_chars(self, fun_cog):
+        """Level 2 adds s, l, c, y, u, d."""
+        level_2_chars = fun_cog.leetdegrees[1]
+        assert "s" in level_2_chars
+        assert "l" in level_2_chars
+        assert "u" in level_2_chars
+
+    def test_intensity_capped_at_5(self, fun_cog):
+        """Intensity above 5 should be capped."""
+        # Verify we have exactly 6 levels (0-5)
+        assert len(fun_cog.leetdegrees) == 6
+
+    def test_preserves_non_mapped_characters(self, fun_cog):
+        """Characters not in leetmap should pass through."""
+        # Numbers and special chars aren't in the map
+        assert "1" not in fun_cog.leetmap.keys()
+        assert "@" not in fun_cog.leetmap.keys()
+
+    def test_case_insensitive_transformation(self, fun_cog):
+        """Both upper and lower case should map to same leet char."""
+        # The logic uses c.lower() before lookup
+        assert fun_cog.leetmap["a"] == "4"
+        # Upper case 'A' would also map to '4' via .lower()
+
+
+class TestRollCommand:
+    """Tests for the roll dice command."""
+
+    @pytest.mark.asyncio
+    async def test_roll_valid_dice(self, fun_cog, mock_context):
+        """Rolling with dice > 1 should produce valid result."""
+        with patch("modules.fun.randint", return_value=3):
+            await fun_cog.roll.callback(fun_cog, mock_context, dice=6)
+
+        mock_context.send.assert_called_once()
+        call_args = mock_context.send.call_args[0][0]
+        assert "d6" in call_args
+        assert ":game_die:" in call_args
+        assert "3" in call_args
+
+    @pytest.mark.asyncio
+    async def test_roll_invalid_dice_returns_retarded_message(self, fun_cog, mock_context):
+        """Rolling with dice <= 1 should return special message."""
+        await fun_cog.roll.callback(fun_cog, mock_context, dice=1)
+
+        mock_context.send.assert_called_once()
+        call_args = mock_context.send.call_args[0][0]
+        assert "AmIRetarded" in call_args
+        assert "yes" in call_args
+
+    @pytest.mark.asyncio
+    async def test_roll_zero_dice(self, fun_cog, mock_context):
+        """Rolling with 0 should also return special message."""
+        await fun_cog.roll.callback(fun_cog, mock_context, dice=0)
+
+        call_args = mock_context.send.call_args[0][0]
+        assert "AmIRetarded" in call_args
+
+
+class TestEightballCommand:
+    """Tests for the 8ball command."""
+
+    @pytest.mark.asyncio
+    async def test_valid_question_gets_answer(self, fun_cog, mock_context):
+        """Question ending with ? should get an 8ball response."""
+        with patch("modules.fun.choice", return_value="Yes"):
+            await fun_cog.eightball.callback(fun_cog, mock_context, question="Will it rain?")
+
+        mock_context.send.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_question_no_question_mark(self, fun_cog, mock_context):
+        """Question without ? should get 'not a question' response."""
+        await fun_cog.eightball.callback(fun_cog, mock_context, question="Will it rain")
+
+        call_args = mock_context.send.call_args_list[0][0][0]
+        assert "doesn't look like a question" in call_args
+
+    @pytest.mark.asyncio
+    async def test_just_question_mark_is_invalid(self, fun_cog, mock_context):
+        """Just '?' alone should be invalid."""
+        await fun_cog.eightball.callback(fun_cog, mock_context, question="?")
+
+        call_args = mock_context.send.call_args_list[0][0][0]
+        assert "doesn't look like a question" in call_args
+
+    def test_ball_responses_are_valid(self, fun_cog):
+        """Verify 8ball has the classic 20 responses."""
+        assert len(fun_cog.ball) == 20
+        assert "Yes" in fun_cog.ball
+        assert "My reply is no" in fun_cog.ball
+
+
+class TestHugCommand:
+    """Tests for the hug command."""
+
+    @pytest.mark.asyncio
+    async def test_hug_with_specific_intensity(self, fun_cog, mock_context, mock_member):
+        """Hug with intensity 0-4 should use that specific emoji."""
+        await fun_cog.hug.callback(fun_cog, mock_context, user=mock_member, intensity=2)
+
+        call_args = mock_context.send.call_args[0][0]
+        assert fun_cog.hugs[2] in call_args
+
+    @pytest.mark.asyncio
+    async def test_hug_intensity_clamped_to_zero(self, fun_cog, mock_context, mock_member):
+        """Negative intensity should be clamped to 0."""
+        await fun_cog.hug.callback(fun_cog, mock_context, user=mock_member, intensity=-5)
+
+        call_args = mock_context.send.call_args[0][0]
+        assert fun_cog.hugs[0] in call_args
+
+    @pytest.mark.asyncio
+    async def test_hug_intensity_clamped_to_four(self, fun_cog, mock_context, mock_member):
+        """Intensity > 4 should be clamped to 4."""
+        await fun_cog.hug.callback(fun_cog, mock_context, user=mock_member, intensity=100)
+
+        call_args = mock_context.send.call_args[0][0]
+        assert fun_cog.hugs[4] in call_args
+
+    @pytest.mark.asyncio
+    async def test_hug_random_when_no_intensity(self, fun_cog, mock_context, mock_member):
+        """No intensity should pick random hug."""
+        with patch("modules.fun.choice", return_value=fun_cog.hugs[1]):
+            await fun_cog.hug.callback(fun_cog, mock_context, user=mock_member, intensity=None)
+
+        call_args = mock_context.send.call_args[0][0]
+        assert fun_cog.hugs[1] in call_args
+
+    def test_hug_emojis_available(self, fun_cog):
+        """Should have 5 hug emojis (indices 0-4)."""
+        assert len(fun_cog.hugs) == 5
+
+
+class TestChooseCommand:
+    """Tests for the choose command."""
+
+    @pytest.mark.asyncio
+    async def test_choose_from_multiple_options(self, fun_cog, mock_context):
+        """Should choose from comma-separated options."""
+        with patch("modules.fun.choice", return_value="option2"):
+            await fun_cog.choose.callback(fun_cog, mock_context, choices="option1,option2,option3")
+
+        call_args = mock_context.send.call_args[0][0]
+        assert "option2" in call_args
+        assert "I choose" in call_args
+
+    @pytest.mark.asyncio
+    async def test_choose_insufficient_options_raises(self, fun_cog, mock_context):
+        """Less than 2 chars in choices string should raise."""
+        # Note: The code has a bug - it checks len(choices) < 2 instead of len(choices_list)
+        # This means "a" (single char) raises, but "a,b" works even though both are short
+        from utils.errors import NerpyException
+
+        with pytest.raises(NerpyException, match="Not enough choices"):
+            await fun_cog.choose.callback(fun_cog, mock_context, choices="a")
+
+
+class TestRotiCommand:
+    """Tests for the rules of the internet command."""
+
+    @pytest.mark.asyncio
+    async def test_roti_with_valid_number(self, fun_cog, mock_context):
+        """Valid rule number should return that rule."""
+        await fun_cog.roti.callback(fun_cog, mock_context, num=34)
+
+        call_args = mock_context.send.call_args[0][0]
+        assert "Rule 34" in call_args
+        assert "porn" in call_args.lower()
+
+    @pytest.mark.asyncio
+    async def test_roti_invalid_number(self, fun_cog, mock_context):
+        """Invalid rule number raises KeyError after sending message.
+
+        Note: This documents current buggy behavior - the function sends
+        'no rules found' but then continues and raises KeyError.
+        Missing a return statement after the error message.
+        TODO: Fix bug in fun.py:236-237 by adding return after error message.
+        """
+        with pytest.raises(KeyError):
+            await fun_cog.roti.callback(fun_cog, mock_context, num=999)
+
+        # Verify the error message was sent before the exception
+        call_args = mock_context.send.call_args[0][0]
+        assert "no rules found" in call_args
+
+    @pytest.mark.asyncio
+    async def test_roti_random_when_no_number(self, fun_cog, mock_context):
+        """No number should return random rule."""
+        with patch("modules.fun.choice", return_value=42):
+            await fun_cog.roti.callback(fun_cog, mock_context, num=None)
+
+        call_args = mock_context.send.call_args[0][0]
+        assert "Rule 42" in call_args
+
+    def test_rotis_contains_classic_rules(self, fun_cog):
+        """Should contain well-known rules."""
+        assert 34 in fun_cog.rotis
+        assert 1 in fun_cog.rotis
+        assert 2 in fun_cog.rotis
+
+
+class TestSayCommand:
+    """Tests for the say command."""
+
+    @pytest.mark.asyncio
+    async def test_say_echoes_text(self, fun_cog, mock_context):
+        """Bot should repeat the provided text."""
+        await fun_cog.say.callback(fun_cog, mock_context, text="Hello World!")
+
+        mock_context.send.assert_called_once_with("Hello World!")

--- a/tests/modules/test_fun.py
+++ b/tests/modules/test_fun.py
@@ -208,17 +208,11 @@ class TestRotiCommand:
 
     @pytest.mark.asyncio
     async def test_roti_invalid_number(self, fun_cog, mock_context):
-        """Invalid rule number raises KeyError after sending message.
+        """Invalid rule number should return not found message and exit early."""
+        await fun_cog.roti.callback(fun_cog, mock_context, num=999)
 
-        Note: This documents current buggy behavior - the function sends
-        'no rules found' but then continues and raises KeyError.
-        Missing a return statement after the error message.
-        TODO: Fix bug in fun.py:236-237 by adding return after error message.
-        """
-        with pytest.raises(KeyError):
-            await fun_cog.roti.callback(fun_cog, mock_context, num=999)
-
-        # Verify the error message was sent before the exception
+        # Should only send the error message, then return
+        mock_context.send.assert_called_once()
         call_args = mock_context.send.call_args[0][0]
         assert "no rules found" in call_args
 

--- a/tests/modules/test_tagging.py
+++ b/tests/modules/test_tagging.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+"""Tests for modules/tagging.py - Tag system commands"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from models.tagging import Tag, TagType, TagTypeConverter
+from utils.errors import NerpyException
+
+
+class TestTagTypeConverter:
+    """Tests for the TagTypeConverter command converter."""
+
+    @pytest.fixture
+    def converter(self):
+        """Create a TagTypeConverter instance."""
+        return TagTypeConverter()
+
+    @pytest.fixture
+    def mock_ctx(self):
+        """Create minimal mock context for converter."""
+        return MagicMock()
+
+    @pytest.mark.asyncio
+    async def test_convert_sound_type(self, converter, mock_ctx):
+        """'sound' should convert to TagType.sound.value (0)."""
+        result = await converter.convert(mock_ctx, "sound")
+        assert result == TagType.sound.value
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_convert_text_type(self, converter, mock_ctx):
+        """'text' should convert to TagType.text.value (1)."""
+        result = await converter.convert(mock_ctx, "text")
+        assert result == TagType.text.value
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_convert_url_type(self, converter, mock_ctx):
+        """'url' should convert to TagType.url.value (2)."""
+        result = await converter.convert(mock_ctx, "url")
+        assert result == TagType.url.value
+        assert result == 2
+
+    @pytest.mark.asyncio
+    async def test_convert_case_insensitive(self, converter, mock_ctx):
+        """Conversion should be case insensitive."""
+        assert await converter.convert(mock_ctx, "SOUND") == TagType.sound.value
+        assert await converter.convert(mock_ctx, "Text") == TagType.text.value
+        assert await converter.convert(mock_ctx, "URL") == TagType.url.value
+
+    @pytest.mark.asyncio
+    async def test_convert_invalid_type_raises(self, converter, mock_ctx):
+        """Invalid type should raise NerpyException."""
+        with pytest.raises(NerpyException, match="TagType invalid was not found"):
+            await converter.convert(mock_ctx, "invalid")
+
+    @pytest.mark.asyncio
+    async def test_convert_empty_string_raises(self, converter, mock_ctx):
+        """Empty string should raise NerpyException."""
+        with pytest.raises(NerpyException):
+            await converter.convert(mock_ctx, "")
+
+
+class TestTagType:
+    """Tests for TagType enum."""
+
+    def test_tag_type_values(self):
+        """Verify TagType enum values."""
+        assert TagType.sound.value == 0
+        assert TagType.text.value == 1
+        assert TagType.url.value == 2
+
+    def test_tag_type_names(self):
+        """Verify TagType can be accessed by name."""
+        assert TagType["sound"] == TagType.sound
+        assert TagType["text"] == TagType.text
+        assert TagType["url"] == TagType.url
+
+    def test_tag_type_from_value(self):
+        """Verify TagType can be created from value."""
+        assert TagType(0) == TagType.sound
+        assert TagType(1) == TagType.text
+        assert TagType(2) == TagType.url
+
+
+class TestVolumeValidation:
+    """Tests for volume validation in tagging module."""
+
+    def test_volume_stored_as_integer(self, db_session):
+        """Volume should be stored as integer."""
+        tag = Tag(
+            GuildId=123,
+            Name="test",
+            Type=TagType.sound.value,
+            Author="test",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        retrieved = Tag.get("test", 123, db_session)
+        assert isinstance(retrieved.Volume, int)
+        assert retrieved.Volume == 100
+
+    def test_volume_default_is_100(self, db_session):
+        """Default volume for new tags should be 100."""
+        tag = Tag(
+            GuildId=123,
+            Name="test",
+            Type=TagType.sound.value,
+            Author="test",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=100,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        retrieved = Tag.get("test", 123, db_session)
+        assert retrieved.Volume == 100
+
+    def test_volume_can_be_set_to_zero(self, db_session):
+        """Volume of 0 should be allowed (muted)."""
+        tag = Tag(
+            GuildId=123,
+            Name="test",
+            Type=TagType.sound.value,
+            Author="test",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=0,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        retrieved = Tag.get("test", 123, db_session)
+        assert retrieved.Volume == 0
+
+    def test_volume_can_be_above_100(self, db_session):
+        """Volume above 100 should be allowed (amplified)."""
+        tag = Tag(
+            GuildId=123,
+            Name="test",
+            Type=TagType.sound.value,
+            Author="test",
+            CreateDate=datetime.now(UTC),
+            Count=0,
+            Volume=200,
+        )
+        db_session.add(tag)
+        db_session.commit()
+
+        retrieved = Tag.get("test", 123, db_session)
+        assert retrieved.Volume == 200

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Tests for utils module"""

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -141,8 +141,6 @@ class TestPagify:
 
     def test_respects_custom_delimiters(self):
         """Custom delimiters should be used for splitting."""
-        # Note: pagify has a known edge case where delimiter at position 0
-        # causes infinite loop. Using space delimiter that won't end up at pos 0.
         text = "Word1 Word2 Word3 Word4 Word5"
         pages = list(pagify(text, delims=[" "], page_length=12))
         # Should split at space delimiter
@@ -150,6 +148,23 @@ class TestPagify:
         # Verify we're splitting at spaces
         for page in pages[:-1]:  # All but last page
             assert len(page) <= 12
+
+    def test_delimiter_at_position_zero_doesnt_hang(self):
+        """Delimiter at position 0 should not cause infinite loop.
+
+        When rfind returns 0 (delimiter at start of remaining text),
+        the function should fall back to page_length to make progress.
+        """
+        # Delimiter "---" will end up at position 0 after first split
+        text = "Part1---Part2---Part3"
+        pages = list(pagify(text, delims=["---"], page_length=10))
+        # Should complete without hanging
+        assert len(pages) > 1
+        # All content should be present
+        combined = "".join(pages)
+        assert "Part1" in combined
+        assert "Part2" in combined
+        assert "Part3" in combined
 
     def test_splits_at_page_length_without_delimiter(self):
         """If no delimiter found, should split at page_length."""

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+"""Tests for utils/format.py - Discord text formatting utilities"""
+
+from utils.format import bold, box, inline, italics, pagify, strikethrough, strip_tags, underline
+
+
+class TestStripTags:
+    """Tests for strip_tags() HTML/XML tag removal."""
+
+    def test_removes_simple_html_tags(self):
+        """Basic HTML tags should be stripped."""
+        assert strip_tags("<p>Hello</p>") == "Hello"
+        assert strip_tags("<b>Bold</b>") == "Bold"
+
+    def test_removes_nested_tags(self):
+        """Nested HTML tags should all be stripped."""
+        assert strip_tags("<div><p><span>Nested</span></p></div>") == "Nested"
+
+    def test_removes_tags_with_attributes(self):
+        """Tags with attributes should be stripped."""
+        assert strip_tags('<a href="http://example.com">Link</a>') == "Link"
+        assert strip_tags('<div class="container" id="main">Content</div>') == "Content"
+
+    def test_handles_empty_string(self):
+        """Empty string should return empty string."""
+        assert strip_tags("") == ""
+
+    def test_passthrough_plain_text(self):
+        """Text without tags should pass through unchanged."""
+        assert strip_tags("Hello World") == "Hello World"
+        assert strip_tags("No tags here!") == "No tags here!"
+
+    def test_handles_multiple_elements(self):
+        """Multiple separate elements should preserve text."""
+        assert strip_tags("<p>First</p><p>Second</p>") == "FirstSecond"
+
+    def test_handles_self_closing_tags(self):
+        """Self-closing tags should be removed."""
+        assert strip_tags("Before<br/>After") == "BeforeAfter"
+        assert strip_tags("Image here: <img src='x.png'/>") == "Image here: "
+
+    def test_preserves_html_entities(self):
+        """HTML entities should be converted to characters."""
+        assert strip_tags("&amp;") == "&"
+        assert strip_tags("&lt;not a tag&gt;") == "<not a tag>"
+
+
+class TestBox:
+    """Tests for box() Discord code block formatting."""
+
+    def test_box_without_language(self):
+        """Box without language should use triple backticks."""
+        result = box("code here")
+        assert result == "```\ncode here\n```"
+
+    def test_box_with_language(self):
+        """Box with language should include language specifier."""
+        result = box("print('hello')", "python")
+        assert result == "```python\nprint('hello')\n```"
+
+    def test_box_with_multiline_content(self):
+        """Multi-line content should be preserved."""
+        content = "line 1\nline 2\nline 3"
+        result = box(content, "md")
+        assert result == "```md\nline 1\nline 2\nline 3\n```"
+
+    def test_box_empty_string(self):
+        """Empty content should still produce valid box."""
+        result = box("")
+        assert result == "```\n\n```"
+
+
+class TestInline:
+    """Tests for inline() Discord inline code formatting."""
+
+    def test_inline_basic(self):
+        """Text should be wrapped in single backticks."""
+        assert inline("code") == "`code`"
+
+    def test_inline_with_spaces(self):
+        """Spaces should be preserved."""
+        assert inline("some code") == "`some code`"
+
+    def test_inline_empty_string(self):
+        """Empty string should produce empty inline."""
+        assert inline("") == "``"
+
+
+class TestTextFormatting:
+    """Tests for bold(), italics(), strikethrough(), underline()."""
+
+    def test_bold(self):
+        """Text should be wrapped in double asterisks."""
+        assert bold("text") == "**text**"
+
+    def test_italics(self):
+        """Text should be wrapped in single asterisks."""
+        assert italics("text") == "*text*"
+
+    def test_strikethrough(self):
+        """Text should be wrapped in double tildes."""
+        assert strikethrough("text") == "~~text~~"
+
+    def test_underline(self):
+        """Text should be wrapped in double underscores."""
+        assert underline("text") == "__text__"
+
+    def test_formatting_empty_strings(self):
+        """Empty strings should produce valid formatting markers."""
+        assert bold("") == "****"
+        assert italics("") == "**"
+        assert strikethrough("") == "~~~~"
+        assert underline("") == "____"
+
+    def test_formatting_with_special_chars(self):
+        """Special characters should be preserved."""
+        assert bold("hello!@#$%") == "**hello!@#$%**"
+
+
+class TestPagify:
+    """Tests for pagify() text pagination for Discord's 2000 char limit."""
+
+    def test_short_text_single_page(self):
+        """Short text should return single page."""
+        text = "Short text"
+        pages = list(pagify(text))
+        assert len(pages) == 1
+        assert pages[0] == "Short text"
+
+    def test_long_text_splits_on_newline(self):
+        """Long text should split on newline delimiter."""
+        # Create text that exceeds page_length
+        line = "A" * 100
+        text = "\n".join([line] * 25)  # 2500 chars + newlines
+
+        pages = list(pagify(text, page_length=500))
+        assert len(pages) > 1
+        # Each page should be under the limit
+        for page in pages:
+            assert len(page) <= 500
+
+    def test_respects_custom_delimiters(self):
+        """Custom delimiters should be used for splitting."""
+        # Note: pagify has a known edge case where delimiter at position 0
+        # causes infinite loop. Using space delimiter that won't end up at pos 0.
+        text = "Word1 Word2 Word3 Word4 Word5"
+        pages = list(pagify(text, delims=[" "], page_length=12))
+        # Should split at space delimiter
+        assert len(pages) > 1
+        # Verify we're splitting at spaces
+        for page in pages[:-1]:  # All but last page
+            assert len(page) <= 12
+
+    def test_splits_at_page_length_without_delimiter(self):
+        """If no delimiter found, should split at page_length."""
+        text = "A" * 100  # 100 chars, no delimiters
+        pages = list(pagify(text, delims=["\n"], page_length=30))
+        # Should have multiple pages
+        assert len(pages) > 1
+        # First pages should be exactly page_length
+        assert len(pages[0]) == 30
+
+    def test_empty_string(self):
+        """Empty string should return single empty page."""
+        pages = list(pagify(""))
+        assert len(pages) == 1
+        assert pages[0] == ""
+
+    def test_exact_page_length_text(self):
+        """Text exactly at page_length should be single page."""
+        text = "A" * 2000
+        pages = list(pagify(text, page_length=2000))
+        assert len(pages) == 1
+
+    def test_default_page_length_is_2000(self):
+        """Default page_length should be 2000 (Discord limit)."""
+        text = "A" * 2001
+        pages = list(pagify(text))
+        # Should split since it exceeds default 2000
+        assert len(pages) == 2
+
+    def test_multiple_delimiters(self):
+        """Multiple delimiters should find closest to page boundary."""
+        # Space delimiter closer to boundary than newline
+        text = "Hello World\nLong text here"
+        pages = list(pagify(text, delims=["\n", " "], page_length=15))
+        assert len(pages) > 1

--- a/uv.lock
+++ b/uv.lock
@@ -92,6 +92,20 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -844,6 +858,70 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "matplotlib"
 version = "3.10.8"
 source = { registry = "https://pypi.org/simple" }
@@ -998,6 +1076,10 @@ bot = [
     { name = "twitchapi" },
     { name = "yt-dlp" },
 ]
+migrations = [
+    { name = "alembic" },
+    { name = "sqlalchemy" },
+]
 test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1028,6 +1110,10 @@ bot = [
     { name = "sqlalchemy" },
     { name = "twitchapi" },
     { name = "yt-dlp" },
+]
+migrations = [
+    { name = "alembic" },
+    { name = "sqlalchemy" },
 ]
 test = [
     { name = "pytest" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.14"
+requires-python = ">=3.13"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -89,20 +89,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
-]
-
-[[package]]
-name = "alembic"
-version = "1.18.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mako" },
-    { name = "sqlalchemy" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/79/41/ab8f624929847b49f84955c594b165855efd829b0c271e1a8cac694138e5/alembic-1.18.3.tar.gz", hash = "sha256:1212aa3778626f2b0f0aa6dd4e99a5f99b94bd25a0c1ac0bba3be65e081e50b0", size = 2052564, upload-time = "2026-01-29T20:24:15.124Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/8e/d79281f323e7469b060f15bd229e48d7cdd219559e67e71c013720a88340/alembic-1.18.3-py3-none-any.whl", hash = "sha256:12a0359bfc068a4ecbb9b3b02cf77856033abfdb59e4a5aca08b7eacd7b74ddd", size = 262282, upload-time = "2026-01-29T20:24:17.488Z" },
 ]
 
 [[package]]
@@ -724,7 +710,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
     { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
     { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
-    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
     { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
     { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },
@@ -733,7 +718,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/fb/011c7c717213182caf78084a9bea51c8590b0afda98001f69d9f853a495b/greenlet-3.3.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bd59acd8529b372775cd0fcbc5f420ae20681c5b045ce25bd453ed8455ab99b5", size = 275737, upload-time = "2026-01-23T15:32:16.889Z" },
     { url = "https://files.pythonhosted.org/packages/41/2e/a3a417d620363fdbb08a48b1dd582956a46a61bf8fd27ee8164f9dfe87c2/greenlet-3.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b31c05dd84ef6871dd47120386aed35323c944d86c3d91a17c4b8d23df62f15b", size = 646422, upload-time = "2026-01-23T16:01:00.354Z" },
     { url = "https://files.pythonhosted.org/packages/b4/09/c6c4a0db47defafd2d6bab8ddfe47ad19963b4e30f5bed84d75328059f8c/greenlet-3.3.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02925a0bfffc41e542c70aa14c7eda3593e4d7e274bfcccca1827e6c0875902e", size = 658219, upload-time = "2026-01-23T16:05:30.956Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/89/b95f2ddcc5f3c2bc09c8ee8d77be312df7f9e7175703ab780f2014a0e781/greenlet-3.3.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3e0f3878ca3a3ff63ab4ea478585942b53df66ddde327b59ecb191b19dbbd62d", size = 671455, upload-time = "2026-01-23T16:15:57.232Z" },
     { url = "https://files.pythonhosted.org/packages/80/38/9d42d60dffb04b45f03dbab9430898352dba277758640751dc5cc316c521/greenlet-3.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34a729e2e4e4ffe9ae2408d5ecaf12f944853f40ad724929b7585bca808a9d6f", size = 660237, upload-time = "2026-01-23T15:32:53.967Z" },
     { url = "https://files.pythonhosted.org/packages/96/61/373c30b7197f9e756e4c81ae90a8d55dc3598c17673f91f4d31c3c689c3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aec9ab04e82918e623415947921dea15851b152b822661cce3f8e4393c3df683", size = 1615261, upload-time = "2026-01-23T16:04:25.066Z" },
     { url = "https://files.pythonhosted.org/packages/fd/d3/ca534310343f5945316f9451e953dcd89b36fe7a19de652a1dc5a0eeef3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71c767cf281a80d02b6c1bdc41c9468e1f5a494fb11bc8688c360524e273d7b1", size = 1683719, upload-time = "2026-01-23T15:33:50.61Z" },
@@ -742,7 +726,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/24/cbbec49bacdcc9ec652a81d3efef7b59f326697e7edf6ed775a5e08e54c2/greenlet-3.3.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e63252943c921b90abb035ebe9de832c436401d9c45f262d80e2d06cc659242", size = 282706, upload-time = "2026-01-23T15:33:05.525Z" },
     { url = "https://files.pythonhosted.org/packages/86/2e/4f2b9323c144c4fe8842a4e0d92121465485c3c2c5b9e9b30a52e80f523f/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76e39058e68eb125de10c92524573924e827927df5d3891fbc97bd55764a8774", size = 651209, upload-time = "2026-01-23T16:01:01.517Z" },
     { url = "https://files.pythonhosted.org/packages/d9/87/50ca60e515f5bb55a2fbc5f0c9b5b156de7d2fc51a0a69abc9d23914a237/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9f9d5e7a9310b7a2f416dd13d2e3fd8b42d803968ea580b7c0f322ccb389b97", size = 654300, upload-time = "2026-01-23T16:05:32.199Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/25/c51a63f3f463171e09cb586eb64db0861eb06667ab01a7968371a24c4f3b/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b9721549a95db96689458a1e0ae32412ca18776ed004463df3a9299c1b257ab", size = 662574, upload-time = "2026-01-23T16:15:58.364Z" },
     { url = "https://files.pythonhosted.org/packages/1d/94/74310866dfa2b73dd08659a3d18762f83985ad3281901ba0ee9a815194fb/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92497c78adf3ac703b57f1e3813c2d874f27f71a178f9ea5887855da413cd6d2", size = 653842, upload-time = "2026-01-23T15:32:55.671Z" },
     { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
     { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },
@@ -858,70 +841,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/99/dd/841e9a66c4715477ea0abc78da039832fbb09dac5c35c58dc4c41a407b8a/kiwisolver-1.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:aedff62918805fb62d43a4aa2ecd4482c380dc76cd31bd7c8878588a61bd0369", size = 2391835, upload-time = "2025-08-10T21:27:34.23Z" },
     { url = "https://files.pythonhosted.org/packages/0c/28/4b2e5c47a0da96896fdfdb006340ade064afa1e63675d01ea5ac222b6d52/kiwisolver-1.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:1fa333e8b2ce4d9660f2cda9c0e1b6bafcfb2457a9d259faa82289e73ec24891", size = 79988, upload-time = "2025-08-10T21:27:35.587Z" },
     { url = "https://files.pythonhosted.org/packages/80/be/3578e8afd18c88cdf9cb4cffde75a96d2be38c5a903f1ed0ceec061bd09e/kiwisolver-1.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:4a48a2ce79d65d363597ef7b567ce3d14d68783d2b2263d98db3d9477805ba32", size = 70260, upload-time = "2025-08-10T21:27:36.606Z" },
-]
-
-[[package]]
-name = "mako"
-version = "1.3.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
-]
-
-[[package]]
-name = "markupsafe"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
-    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
-    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
-    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
-    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
-    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
-    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
-    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
-    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
-    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
-    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
-    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
-    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
-    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -1079,12 +998,9 @@ bot = [
     { name = "twitchapi" },
     { name = "yt-dlp" },
 ]
-migrations = [
-    { name = "alembic" },
-    { name = "sqlalchemy" },
-]
 test = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -1113,12 +1029,9 @@ bot = [
     { name = "twitchapi" },
     { name = "yt-dlp" },
 ]
-migrations = [
-    { name = "alembic" },
-    { name = "sqlalchemy" },
-]
 test = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -1466,6 +1379,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add pytest test infrastructure with `pytest-asyncio` for async test support
- Create **148 tests** covering utils, modules, models, and integration
- Fix 2 bugs discovered during test implementation
- Properly handle test warnings

## Test Coverage

| Category | Tests | Coverage |
|----------|-------|----------|
| **Utils** (`format.py`) | 30 | 98% |
| **Modules** (`fun`, `admin`, `tagging`) | 44 | 61-81% |
| **Models** (`GuildPrefix`, `ReminderMessage`, `Tag`) | 43 | 100% |
| **Integration** (`conversation.py`) | 31 | 98% |

## Bugs Fixed

### 1. `fun.py:roti()` - Missing early return
```python
# Before: KeyError after sending error message
if num not in self.rotis:
    await ctx.send("Sorry 4chan pleb...")
rule = num  # Still executes!

# After: Proper early return
if num not in self.rotis:
    await ctx.send("Sorry 4chan pleb...")
    return
```

### 2. `format.py:pagify()` - Infinite loop on delimiter at position 0
```python
# Before: in_text[0:] == in_text → infinite loop
closest_delim = closest_delim if closest_delim != -1 else page_length

# After: Handle position 0 case
closest_delim = closest_delim if closest_delim > 0 else page_length
```

## Test Commands

```bash
uv run pytest tests/ -v              # Run all tests
uv run pytest tests/ --cov=NerdyPy   # With coverage
```

## Test plan
- [x] All 148 tests pass locally
- [x] No warnings from our code (only discord.py external deprecation filtered)
- [x] `ruff check` and `ruff format` pass

🤖 Generated with [Claude Code](https://claude.ai/code)