### PR TITLE
feat: add server leave message announcements

### DIFF
--- a/NerdyPy/config.yaml.template
+++ b/NerdyPy/config.yaml.template
@@ -8,6 +8,7 @@ bot:
     - admin
     - fun
     - league
+    - leavemsg
     - moderation
     - random
     - reminder

--- a/NerdyPy/models/leavemsg.py
+++ b/NerdyPy/models/leavemsg.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Guild leave message configuration model"""
+
+from sqlalchemy import BigInteger, Boolean, Column, Index, Text
+from utils import database as db
+
+
+class LeaveMessage(db.BASE):
+    """Database entity model for guild leave messages"""
+
+    __tablename__ = "LeaveMessage"
+    __table_args__ = (Index("LeaveMessage_GuildId", "GuildId"),)
+
+    GuildId = Column(BigInteger, primary_key=True)
+    ChannelId = Column(BigInteger, nullable=True)
+    Message = Column(Text, nullable=True)
+    Enabled = Column(Boolean, default=False)
+
+    @classmethod
+    def get(cls, guild_id: int, session):
+        """Returns the LeaveMessage entry for the given guild_id"""
+        return session.query(LeaveMessage).filter(LeaveMessage.GuildId == guild_id).first()
+
+    @classmethod
+    def get_all_enabled(cls, session):
+        """Returns all LeaveMessage entries where enabled"""
+        return session.query(LeaveMessage).filter(LeaveMessage.Enabled.is_(True)).all()
+
+    @classmethod
+    def delete(cls, guild_id: int, session):
+        """Deletes the LeaveMessage entry for the given guild_id"""
+        leave_msg = LeaveMessage.get(guild_id, session)
+        if leave_msg:
+            session.delete(leave_msg)

--- a/NerdyPy/modules/leavemsg.py
+++ b/NerdyPy/modules/leavemsg.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+"""Module for server leave message announcements"""
+
+from discord import Member, TextChannel
+from discord.app_commands import checks
+from discord.ext.commands import Cog, Context, hybrid_group
+from models.leavemsg import LeaveMessage
+
+from utils.errors import NerpyException
+from utils.helpers import empty_subcommand, send_hidden_message
+
+
+DEFAULT_LEAVE_MESSAGE = "{member} left the server :("
+
+
+class LeaveMsg(Cog):
+    """Cog for managing server leave messages"""
+
+    def __init__(self, bot):
+        bot.log.info(f"loaded {__name__}")
+        self.bot = bot
+
+    @Cog.listener()
+    async def on_member_remove(self, member: Member) -> None:
+        """Sends a farewell message when a member leaves the server"""
+        if member.bot:
+            return
+
+        with self.bot.session_scope() as session:
+            leave_config = LeaveMessage.get(member.guild.id, session)
+
+        if leave_config is None or not leave_config.Enabled:
+            return
+
+        channel = member.guild.get_channel(leave_config.ChannelId)
+        if channel is None or not isinstance(channel, TextChannel):
+            self.bot.log.warning(
+                f"Leave channel {leave_config.ChannelId} not found or not a text channel for guild {member.guild.id}"
+            )
+            return
+
+        message = leave_config.Message or DEFAULT_LEAVE_MESSAGE
+        formatted_message = message.format(member=member.display_name)
+
+        try:
+            await channel.send(formatted_message)
+        except Exception as ex:
+            self.bot.log.error(f"Failed to send leave message in guild {member.guild.id}: {ex}")
+
+    @hybrid_group()
+    @checks.has_permissions(administrator=True)
+    async def leavemsg(self, ctx: Context) -> None:
+        """Manage leave messages for the server [administrator]"""
+        await empty_subcommand(ctx)
+
+    @leavemsg.command(name="enable")
+    @checks.has_permissions(administrator=True)
+    async def _leavemsg_enable(self, ctx: Context, channel: TextChannel) -> None:
+        """Enable leave messages in the specified channel. [administrator]
+
+        Parameters
+        ----------
+        ctx
+        channel: TextChannel
+            The channel where leave messages will be sent.
+        """
+        with self.bot.session_scope() as session:
+            leave_config = LeaveMessage.get(ctx.guild.id, session)
+            if leave_config is None:
+                leave_config = LeaveMessage(
+                    GuildId=ctx.guild.id,
+                    ChannelId=channel.id,
+                    Message=DEFAULT_LEAVE_MESSAGE,
+                    Enabled=True,
+                )
+                session.add(leave_config)
+            else:
+                leave_config.ChannelId = channel.id
+                leave_config.Enabled = True
+                if leave_config.Message is None:
+                    leave_config.Message = DEFAULT_LEAVE_MESSAGE
+
+        await send_hidden_message(ctx, f"Leave messages enabled in {channel.mention}.")
+
+    @leavemsg.command(name="disable")
+    @checks.has_permissions(administrator=True)
+    async def _leavemsg_disable(self, ctx: Context) -> None:
+        """Disable leave messages for this server. [administrator]"""
+        with self.bot.session_scope() as session:
+            leave_config = LeaveMessage.get(ctx.guild.id, session)
+            if leave_config is None:
+                raise NerpyException("Leave messages are not configured for this server.")
+            leave_config.Enabled = False
+
+        await send_hidden_message(ctx, "Leave messages disabled.")
+
+    @leavemsg.command(name="message")
+    @checks.has_permissions(administrator=True)
+    async def _leavemsg_message(self, ctx: Context, *, message: str) -> None:
+        """Set a custom leave message. Use {member} as placeholder. [administrator]
+
+        Parameters
+        ----------
+        ctx
+        message: str
+            The message template. Use {member} for the member's display name.
+        """
+        if "{member}" not in message:
+            raise NerpyException("Message must contain {member} placeholder for the member name.")
+
+        with self.bot.session_scope() as session:
+            leave_config = LeaveMessage.get(ctx.guild.id, session)
+            if leave_config is None:
+                raise NerpyException("Please enable leave messages first using `/leavemsg enable #channel`.")
+            leave_config.Message = message
+
+        await send_hidden_message(ctx, f"Leave message updated to: {message}")
+
+    @leavemsg.command(name="status")
+    @checks.has_permissions(administrator=True)
+    async def _leavemsg_status(self, ctx: Context) -> None:
+        """Show current leave message configuration. [administrator]"""
+        with self.bot.session_scope() as session:
+            leave_config = LeaveMessage.get(ctx.guild.id, session)
+
+        if leave_config is None or not leave_config.Enabled:
+            await send_hidden_message(ctx, "Leave messages are not enabled for this server.")
+            return
+
+        channel = ctx.guild.get_channel(leave_config.ChannelId)
+        channel_mention = channel.mention if channel else "Unknown channel"
+        message = leave_config.Message or DEFAULT_LEAVE_MESSAGE
+
+        await send_hidden_message(
+            ctx, f"**Leave messages:** Enabled\n**Channel:** {channel_mention}\n**Message:** {message}"
+        )
+
+
+async def setup(bot):
+    """adds this module to the bot"""
+    await bot.add_cog(LeaveMsg(bot))

--- a/database-migrations/versions/121bb784c68a_added_remindermessage_to_rolechecker.py
+++ b/database-migrations/versions/121bb784c68a_added_remindermessage_to_rolechecker.py
@@ -6,17 +6,13 @@ Create Date: 2023-08-26 12:11:19.204787
 
 """
 
-from typing import Sequence, Union
-
 from alembic import op
 from sqlalchemy import Column, Text
 from sqlalchemy.exc import OperationalError
 
 # revision identifiers, used by Alembic.
 revision: str = "121bb784c68a"
-down_revision: Union[str, None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = None
 
 
 def upgrade() -> None:

--- a/database-migrations/versions/443fdce72be4_renamed_timedmessage_to_remindermessage.py
+++ b/database-migrations/versions/443fdce72be4_renamed_timedmessage_to_remindermessage.py
@@ -6,17 +6,13 @@ Create Date: 2023-11-18 19:08:16.134795
 
 """
 
-from typing import Sequence, Union
-
 from alembic import op
 from sqlalchemy import Column, Text
 from sqlalchemy.exc import OperationalError
 
 # revision identifiers, used by Alembic.
 revision: str = "443fdce72be4"
-down_revision: Union[str, None] = "121bb784c68a"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "121bb784c68a"
 
 
 def upgrade() -> None:

--- a/database-migrations/versions/a1b2c3d4e5f6_add_leave_message_table.py
+++ b/database-migrations/versions/a1b2c3d4e5f6_add_leave_message_table.py
@@ -1,0 +1,41 @@
+"""Add LeaveMessage table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 443fdce72be4
+Create Date: 2025-02-12
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import BigInteger, Boolean, Column, Text
+from sqlalchemy.exc import OperationalError
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "443fdce72be4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    try:
+        op.create_table(
+            "LeaveMessage",
+            Column("GuildId", BigInteger, primary_key=True),
+            Column("ChannelId", BigInteger, nullable=True),
+            Column("Message", Text, nullable=True),
+            Column("Enabled", Boolean, default=False),
+        )
+        op.create_index("LeaveMessage_GuildId", "LeaveMessage", ["GuildId"])
+    except OperationalError as ex:
+        print(ex)
+
+
+def downgrade() -> None:
+    try:
+        op.drop_index("LeaveMessage_GuildId", table_name="LeaveMessage")
+        op.drop_table("LeaveMessage")
+    except OperationalError as ex:
+        print(ex)

--- a/database-migrations/versions/a1b2c3d4e5f6_add_leave_message_table.py
+++ b/database-migrations/versions/a1b2c3d4e5f6_add_leave_message_table.py
@@ -6,17 +6,13 @@ Create Date: 2025-02-12
 
 """
 
-from typing import Sequence, Union
-
 from alembic import op
 from sqlalchemy import BigInteger, Boolean, Column, Text
 from sqlalchemy.exc import OperationalError
 
 # revision identifiers, used by Alembic.
 revision: str = "a1b2c3d4e5f6"
-down_revision: Union[str, None] = "443fdce72be4"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "443fdce72be4"
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary
- Adds new `leavemsg` module that announces when members leave the server
- Configurable per-guild with custom message templates using `{member}` placeholder
- Supports both slash commands and prefix commands via hybrid_group

## Commands
| Command | Description |
|---------|-------------|
| `/leavemsg enable #channel` | Enable leave messages in specified channel |
| `/leavemsg disable` | Disable leave messages |
| `/leavemsg message <text>` | Set custom message (use `{member}` placeholder) |
| `/leavemsg status` | Show current configuration |

## Test plan
- [ ] Enable leave messages with `/leavemsg enable #general`
- [ ] Verify message appears when a member leaves
- [ ] Test custom message with `/leavemsg message Goodbye {member}!`
- [ ] Test disable functionality
- [ ] Verify slash commands and prefix commands both work

Closes #80

🤖 Generated with [Claude Code](https://claude.ai/code)