### PR TITLE
feat: bot-moderator role, ephemeral responses, and DM handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,11 +72,17 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 ### Utilities
 `NerdyPy/utils/` contains:
 - `audio.py` - Voice channel audio management
-- `checks.py` - Permission decorators
+- `checks.py` - Permission check functions for voice/moderator commands
 - `conversation.py` - Interactive dialog state management
 - `errors.py` - `NerpyException` for bot-specific errors
 - `format.py` - Text formatting helpers
-- `helpers.py` - General utilities
+- `helpers.py` - General utilities (incl. `send_hidden_message` for ephemeral/DM responses)
+
+### Gotchas
+
+- **`app_commands.checks` only gates slash commands** — Cog-level `@checks.has_permissions()` from `discord.app_commands` does NOT apply to prefix commands. A global `guild_only` check in `setup_hook` protects prefix commands from DM invocation.
+- **`ephemeral=True` is silently ignored on prefix commands** — Always use `send_hidden_message()` from `utils/helpers.py` which falls back to DMs for prefix contexts.
+- **Check functions must be side-effect-free during help** — `DefaultHelpCommand` calls `can_run()` on every command. Check functions in `checks.py` guard against this with `ctx.invoked_with == "help"`.
 
 ## Configuration
 

--- a/NerdyPy/models/botmod.py
+++ b/NerdyPy/models/botmod.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Bot moderator role database model"""
+
+from sqlalchemy import BigInteger, Column
+from utils import database as db
+
+
+class BotModeratorRole(db.BASE):
+    """Database entity model for a per-guild bot-moderator role."""
+
+    __tablename__ = "BotModeratorRole"
+
+    GuildId = Column(BigInteger, primary_key=True)
+    RoleId = Column(BigInteger, nullable=False)
+
+    @classmethod
+    def get(cls, guild_id, session):
+        """Returns the BotModeratorRole entry for the given guild_id."""
+        return session.query(cls).filter(cls.GuildId == guild_id).first()
+
+    @classmethod
+    def delete(cls, guild_id: int, session):
+        """Deletes the BotModeratorRole entry for the given guild_id."""
+        entry = cls.get(guild_id, session)
+        if entry is not None:
+            session.delete(entry)

--- a/NerdyPy/modules/music.py
+++ b/NerdyPy/modules/music.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from discord import Color, Embed, Interaction
-from discord.app_commands import command, guild_only
+from discord.app_commands import guild_only
 from discord.ext.commands import (
     Context,
     GroupCog,
@@ -14,7 +14,7 @@ from discord.ext.commands import (
 
 import utils.format as fmt
 from utils.audio import QueuedSong, QueueMixin
-from utils.checks import is_connected_to_voice
+from utils.checks import is_connected_to_voice, is_in_same_voice_channel_as_bot
 from utils.download import download, fetch_yt_infos
 from utils.errors import NerpyException
 from utils.helpers import send_hidden_message, youtube
@@ -34,20 +34,13 @@ class Music(QueueMixin, GroupCog):
         self.audio = self.bot.audio
 
     @hybrid_command(name="skip")
+    @check(is_in_same_voice_channel_as_bot)
     async def _skip_audio(self, ctx: Context):
         """skip current track"""
         self.bot.log.info(f"{ctx.guild.name} requesting skip!")
         self.audio.stop(ctx.guild.id)
         if isinstance(ctx, Interaction):
             await ctx.followup.send("Skipped current track.")
-
-    @command(name="stop")
-    async def _stop_playing_audio(self, ctx: Context):
-        """bot stops playing audio"""
-        self.audio.stop(ctx.guild.id)
-        self._clear_queue(ctx.guild.id)
-        if isinstance(ctx, Interaction):
-            await ctx.followup.send("Stopped playing audio.")
 
     @hybrid_group(name="queue")
     async def _queue(self, ctx: Context):

--- a/NerdyPy/modules/wow.py
+++ b/NerdyPy/modules/wow.py
@@ -133,9 +133,9 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
         with self.bot.session_scope() as session:
             entry = WoW.get(ctx.guild.id, session)
             if entry is None:
-                await ctx.send("No language set for this guild. Defaulting to English.")
+                await send_hidden_message(ctx, "No language set for this guild. Defaulting to English.")
             else:
-                await ctx.send(f"Current language for this guild is: {entry.Language.upper()}")
+                await send_hidden_message(ctx, f"Current language for this guild is: {entry.Language.upper()}")
 
     @_wow_language.command(name="set")
     async def _wow_language_set(self, ctx: Context, lang: Literal["de", "en"]):
@@ -149,14 +149,14 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
             entry.ModifiedDate = dt.now()
             entry.Language = lang.upper()
 
-        await ctx.send(f"Language set to {lang.upper()} for this guild.")
+        await send_hidden_message(ctx, f"Language set to {lang.upper()} for this guild.")
 
     @_wow_language.command(name="delete", aliases=["remove", "rm", "del"])
     async def _wow_language_delete(self, ctx: Context):
         """Delete the current language setting for the WoW API."""
         with self.bot.session_scope() as session:
             WoW.delete(ctx.guild.id, session)
-        await ctx.send("Language setting removed. Defaulting to English for this guild.")
+        await send_hidden_message(ctx, "Language setting removed. Defaulting to English for this guild.")
 
     @hybrid_command(name="armory", aliases=["search", "char"])
     async def _wow_armory(self, ctx: Context, name: str, realm: str, region: Optional[Literal["eu", "us"]] = "eu"):
@@ -168,7 +168,7 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
             you need to set it.
         """
         try:
-            async with ctx.typing():
+            async with ctx.typing(ephemeral=True):
                 realm = realm.lower()
                 name = name.lower()
                 profile = f"{region}/{realm}/{name}"

--- a/NerdyPy/utils/checks.py
+++ b/NerdyPy/utils/checks.py
@@ -1,13 +1,99 @@
 # -*- coding: utf-8 -*-
 
-from utils.helpers import send_hidden_message
+from models.botmod import BotModeratorRole
+
+
+async def _reject(ctx, msg: str):
+    """Send a check rejection message — ephemeral for interactions, DM for prefix commands.
+
+    Silently does nothing when called during a help-command probe.
+    """
+    if ctx.invoked_with == "help":
+        return
+    if ctx.interaction is not None:
+        await ctx.send(msg, ephemeral=True)
+    else:
+        await ctx.author.send(msg)
+
+
+async def _is_bot_moderator(ctx) -> bool:
+    """Check if the user has bot-moderator privileges (mod perms, bot operator, or configured role)."""
+    perms = ctx.author.guild_permissions
+    if perms.mute_members or perms.manage_channels or perms.administrator or ctx.author.id in ctx.bot.ops:
+        return True
+
+    with ctx.bot.session_scope() as session:
+        entry = BotModeratorRole.get(ctx.guild.id, session)
+        if entry is not None:
+            return any(r.id == entry.RoleId for r in ctx.author.roles)
+
+    return False
 
 
 async def is_connected_to_voice(ctx):
     if ctx.author.voice is None or ctx.author.voice.channel is None:
-        await send_hidden_message(ctx, "I don't know where you are. Please connect to a voice channel.")
+        await _reject(ctx, "I don't know where you are. Please connect to a voice channel.")
         return False
     if not ctx.author.voice.channel.permissions_for(ctx.guild.me).connect:
-        await send_hidden_message(ctx, "I'm not allowed to join you in your current channel.")
+        await _reject(ctx, "I'm not allowed to join you in your current channel.")
         return False
     return True
+
+
+async def is_in_same_voice_channel_as_bot(ctx):
+    bot_voice = ctx.guild.voice_client
+
+    # Bot not in voice — allow; the command will fail gracefully on its own
+    if bot_voice is None:
+        return True
+
+    # User not in any voice channel
+    if ctx.author.voice is None or ctx.author.voice.channel is None:
+        await _reject(ctx, "You need to be in a voice channel to use this command.")
+        return False
+
+    # Same channel — allow
+    if ctx.author.voice.channel == bot_voice.channel:
+        return True
+
+    # Mod / operator override
+    if await _is_bot_moderator(ctx):
+        return True
+
+    await _reject(ctx, "You need to be in the same voice channel as the bot to use this command.")
+    return False
+
+
+async def can_stop_playback(ctx):
+    """Bot-moderator or alone with the bot in the same voice channel."""
+    bot_voice = ctx.guild.voice_client
+    if bot_voice is None:
+        await _reject(ctx, "Nothing is playing right now.")
+        return False
+
+    if await _is_bot_moderator(ctx):
+        return True
+
+    if ctx.author.voice is None or ctx.author.voice.channel is None:
+        await _reject(ctx, "You need to be in a voice channel to use this command.")
+        return False
+
+    if ctx.author.voice.channel != bot_voice.channel:
+        await _reject(ctx, "You need to be in the same voice channel as the bot to use this command.")
+        return False
+
+    # Allow if user is alone with the bot (only 2 members: user + bot)
+    if len(bot_voice.channel.members) <= 2:
+        return True
+
+    await _reject(ctx, "Only moderators can stop playback when others are listening.")
+    return False
+
+
+async def can_leave_voice(ctx):
+    """Bot-moderator only."""
+    if await _is_bot_moderator(ctx):
+        return True
+
+    await _reject(ctx, "Only moderators can make the bot leave the voice channel.")
+    return False

--- a/NerdyPy/utils/helpers.py
+++ b/NerdyPy/utils/helpers.py
@@ -5,8 +5,15 @@ from googleapiclient.discovery import build
 from utils.errors import NerpyException
 
 
-async def send_hidden_message(ctx: Context, msg: str):
-    return await ctx.send(msg, ephemeral=True)
+async def send_hidden_message(ctx: Context, msg: str = None, **kwargs):
+    """Send a message only visible to the invoking user.
+
+    Slash commands use ephemeral replies; prefix commands fall back to DMs
+    since ephemeral is silently ignored without an interaction.
+    """
+    if ctx.interaction is not None:
+        return await ctx.send(msg, ephemeral=True, **kwargs)
+    return await ctx.author.send(msg, **kwargs)
 
 
 async def empty_subcommand(ctx: Context):

--- a/tests/modules/test_admin.py
+++ b/tests/modules/test_admin.py
@@ -24,7 +24,7 @@ class TestPrefixValidation:
         await admin_cog._prefix_set.callback(admin_cog, mock_context, new_pref="! cmd")
 
         # Check that rejection message was sent
-        mock_context.send.assert_any_call("Spaces not allowed in prefixes")
+        mock_context.send.assert_any_call("Spaces not allowed in prefixes", ephemeral=True)
 
     @pytest.mark.asyncio
     async def test_prefix_without_spaces_accepted(self, admin_cog, mock_context, db_session):
@@ -32,7 +32,7 @@ class TestPrefixValidation:
         await admin_cog._prefix_set.callback(admin_cog, mock_context, new_pref="!")
 
         # Should confirm the new prefix
-        mock_context.send.assert_called_with("new prefix is now set to '!'.")
+        mock_context.send.assert_called_with("new prefix is now set to '!'.", ephemeral=True)
 
 
 class TestPrefixGet:
@@ -121,4 +121,4 @@ class TestPrefixDelete:
 
         # Verify deletion
         assert GuildPrefix.get(mock_guild.id, db_session) is None
-        mock_context.send.assert_called_with("Prefix removed.")
+        mock_context.send.assert_called_with("Prefix removed.", ephemeral=True)


### PR DESCRIPTION
## Summary

- **Configurable bot-moderator role**: New `BotModeratorRole` model and `modrole` hybrid command group (`get`/`set`/`delete`) allow server admins to designate a role for audio control without broad Discord permissions. The `_is_bot_moderator` check now queries this role in addition to hardcoded permissions.
- **Voice channel checks**: Split `stop`/`leave` into separate commands with dedicated permission checks (`can_stop_playback`, `can_leave_voice`). Added `is_in_same_voice_channel_as_bot` check to `skip` in music and tagging modules.
- **Ephemeral admin responses**: Fixed `send_hidden_message` to DM on prefix commands (ephemeral was silently ignored without an interaction). Converted all admin, moderation, and wow config responses to use it.
- **DM handling**: Global `guild_only` check (exempting `help`) prevents crashes from prefix commands in DMs. `NoPrivateMessage` errors now properly respond to slash interactions. Help is sent via DM with `verify_checks=False` so all commands are listed. DMs allow prefix-free commands.

## Test plan

- [x] Set a bot-moderator role with `/modrole set @Role`, verify users with the role can use `/stop` and `/leave`
- [x] Verify `/modrole get` and `/modrole delete` work correctly
- [x] Confirm admin command responses (prefix, modrole, sync) are ephemeral on slash and DM on prefix
- [x] Test `!help` in DMs — should list all commands, no prefix required
- [x] Test any guild command in DMs — should reply "This command can only be used in a server"
- [x] Test `/stop` in DMs — interaction should respond properly (not "application did not respond")
- [x] Verify `!help` in a guild no longer triggers "Nothing is playing right now" DMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)