### PR TITLE
feat: wow armory DM support and language parameter

### DIFF
--- a/NerdyPy/NerdyPy.py
+++ b/NerdyPy/NerdyPy.py
@@ -133,7 +133,7 @@ class NerpyBot(Bot):
 
         # All commands require a guild context; reject prefix commands in DMs early.
         # Help, debug, and sync are exempt since they can operate globally.
-        _dm_allowed = {"help", "debug", "sync"}
+        _dm_allowed = {"help", "debug", "sync", "armory"}
 
         async def _guild_only_check(ctx: Context) -> bool:
             if ctx.command and ctx.command.qualified_name in _dm_allowed:

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-"""default channel dbmodel"""
+"""wow dbmodel"""
 
-from sqlalchemy import BigInteger, Column, DateTime, Index, String
+from sqlalchemy import BigInteger, Column, Index
 from utils import database as db
 
 
@@ -12,17 +12,3 @@ class WoW(db.BASE):
     __table_args__ = (Index("WoW_GuildId", "GuildId"),)
 
     GuildId = Column(BigInteger, primary_key=True)
-    Language = Column(String(30))
-    CreateDate = Column(DateTime)
-    ModifiedDate = Column(DateTime)
-    Author = Column(String(30))
-
-    @classmethod
-    def get(cls, guild_id, session):
-        """Returns the WoW entry for the given guild_id"""
-        return session.query(WoW).filter(WoW.GuildId == guild_id).first()
-
-    @classmethod
-    def delete(cls, guild_id: int, session):
-        """Deletes the WoW entry for the given guild_id"""
-        session.delete(WoW.get(guild_id, session))

--- a/uv.lock
+++ b/uv.lock
@@ -1272,11 +1272,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.7.1"
+version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/3e/c81eb24fb98b00bc097b9ce5dee6eca020c52619ed95b246aaec2018c511/platformdirs-4.7.1.tar.gz", hash = "sha256:6f4ff8472e482af4b7e67a183fbe63da846a9b34f57d5019c4d112a181003d82", size = 25254, upload-time = "2026-02-13T17:57:16.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/f3/1632085bda21cae242998e27f63d3a2c02cdcdb36cade334fa689f210903/platformdirs-4.9.0.tar.gz", hash = "sha256:d8c98e89c427a101947441c7e77b4cd1c8ea717de6f3885e2aa9c73fce276207", size = 28346, upload-time = "2026-02-14T17:15:37.23Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/82/36dcca0cfa42ad259bf0eb1f7af0d5759710c21928856891631cb47e4771/platformdirs-4.7.1-py3-none-any.whl", hash = "sha256:06ac79ae0c5025949f62711e3f7cd178736515a29bcc669f42a216016cd1dc7a", size = 19070, upload-time = "2026-02-13T17:57:15.67Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/29/d2387317b99bd77344b23d35c7418eb7971cb9000d65209afcbe3a38a539/platformdirs-4.9.0-py3-none-any.whl", hash = "sha256:b02ef5c8ddacd466a19decb2390e52f48ae49a5c41f55646cc45e85320d9aff7", size = 21216, upload-time = "2026-02-14T17:15:35.378Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace guild-level language DB setting with a direct `language` command parameter (`de`/`en`, defaults to `en`)
- Remove `language` subcommands (`get`, `set`, `delete`) and all DB/session usage from the wow module
- Allow `armory` command in DMs by adding it to the `_dm_allowed` set
- Strip `WoW` model down to skeleton (keep `GuildId` PK only, drop unused columns and methods)

## Test plan
- [x] `!armory <name> <realm>` in DMs — works with default English
- [x] `/wow armory <name> <realm>` in DMs — works with default English
- [x] `/wow armory <name> <realm> language:de` — returns German results
- [x] `/wow armory <name> <realm> eu` — English EU locale used
- [x] Verify `language` subcommands no longer appear in help or slash command list

🤖 Generated with [Claude Code](https://claude.com/claude-code)