### PR TITLE
feat: add wow guild news tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ NerpyBot is a Discord bot built with discord.py using the Cog extension system. 
 
 ## Development Commands
 
+**Always use `uv run` to execute Python, pytest, ruff, and other tools** — this project is uv-managed and all dependencies live in uv's virtual environment.
+
 ```bash
 # Install dependencies
 uv sync                              # All bot dependencies (default)
@@ -15,21 +17,21 @@ uv sync --group test                 # Include test dependencies
 uv sync --only-group migrations      # Migration tools only
 
 # Run the bot
-python NerdyPy/NerdyPy.py            # Start with default config
-python NerdyPy/NerdyPy.py -d         # Debug logging (no sqlalchemy noise)
-python NerdyPy/NerdyPy.py -l DEBUG   # Debug mode (includes sqlalchemy)
-python NerdyPy/NerdyPy.py -c path    # Custom config file
-python NerdyPy/NerdyPy.py -r         # Auto-restart on failure
+uv run python NerdyPy/NerdyPy.py            # Start with default config
+uv run python NerdyPy/NerdyPy.py -d         # Debug logging (no sqlalchemy noise)
+uv run python NerdyPy/NerdyPy.py -l DEBUG   # Debug mode (includes sqlalchemy)
+uv run python NerdyPy/NerdyPy.py -c path    # Custom config file
+uv run python NerdyPy/NerdyPy.py -r         # Auto-restart on failure
 
 # Code quality
-ruff check                           # Lint
-ruff check --fix                     # Lint with auto-fix
-ruff format                          # Format code
-ruff format --check                  # Check formatting only
+uv run ruff check                    # Lint
+uv run ruff check --fix              # Lint with auto-fix
+uv run ruff format                   # Format code
+uv run ruff format --check           # Check formatting only
 
 # Testing
-pytest                               # Run tests
-pytest --cov                         # With coverage
+uv run pytest                        # Run tests
+uv run pytest --cov                  # With coverage
 
 # Database migrations
 uv sync --group migrations

--- a/NerdyPy/config.yaml.template
+++ b/NerdyPy/config.yaml.template
@@ -51,3 +51,9 @@ league:
 wow:
   wow_id: your_wow_client_id
   wow_secret: your_wow_client_secret
+  # Optional guild news settings (defaults shown)
+  # guild_news:
+  #   poll_interval_minutes: 15
+  #   mount_batch_size: 20
+  #   track_mounts: true
+  #   active_days: 7

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """wow dbmodel"""
 
-from sqlalchemy import BigInteger, Column, Index
+from datetime import UTC, datetime
+
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, ForeignKey, Index, Integer, String, Text, asc
 from utils import database as db
 
 
@@ -12,3 +14,103 @@ class WoW(db.BASE):
     __table_args__ = (Index("WoW_GuildId", "GuildId"),)
 
     GuildId = Column(BigInteger, primary_key=True)
+
+
+class WowGuildNewsConfig(db.BASE):
+    """Tracks which Discord guilds monitor which WoW guilds for news."""
+
+    __tablename__ = "WowGuildNewsConfig"
+    __table_args__ = (
+        Index("WowGuildNewsConfig_GuildId", "GuildId"),
+        Index("WowGuildNewsConfig_Id_GuildId", "Id", "GuildId", unique=True),
+    )
+
+    Id = Column(Integer, primary_key=True)
+    GuildId = Column(BigInteger)
+    ChannelId = Column(BigInteger)
+    WowGuildName = Column(String(100))
+    WowRealmSlug = Column(String(100))
+    Region = Column(String(10))
+    Language = Column(String(5), default="en")
+    MinLevel = Column(Integer, default=10)
+    ActiveDays = Column(Integer, default=7)
+    RosterOffset = Column(Integer, default=0)
+    LastActivityTimestamp = Column(DateTime, nullable=True)
+    Enabled = Column(Boolean, default=True)
+    CreateDate = Column(DateTime, default=lambda: datetime.now(UTC))
+
+    @classmethod
+    def get_by_id(cls, config_id, guild_id, session):
+        return session.query(cls).filter(cls.Id == config_id).filter(cls.GuildId == guild_id).first()
+
+    @classmethod
+    def get_all_enabled(cls, session):
+        return session.query(cls).filter(cls.Enabled.is_(True)).order_by(asc("Id")).all()
+
+    @classmethod
+    def get_all_by_guild(cls, guild_id, session):
+        return session.query(cls).filter(cls.GuildId == guild_id).order_by(asc("Id")).all()
+
+    @classmethod
+    def delete(cls, config_id, guild_id, session):
+        config = cls.get_by_id(config_id, guild_id, session)
+        if config:
+            session.query(WowCharacterMounts).filter(WowCharacterMounts.ConfigId == config.Id).delete()
+            session.delete(config)
+
+    def __str__(self):
+        status = "active" if self.Enabled else "paused"
+        return (
+            f"==== {self.Id} ====\n"
+            f"Guild: {self.WowGuildName} ({self.WowRealmSlug}-{self.Region.upper()})\n"
+            f"Language: {self.Language}\n"
+            f"Status: {status}\n"
+            f"Active Days Filter: {self.ActiveDays}\n"
+        )
+
+
+class WowCharacterMounts(db.BASE):
+    """Stored mount set per player (account-wide, keyed by highest-level char)."""
+
+    __tablename__ = "WowCharacterMounts"
+    __table_args__ = (
+        Index("WowCharacterMounts_ConfigId", "ConfigId"),
+        Index("WowCharacterMounts_Config_Char", "ConfigId", "CharacterName", "RealmSlug", unique=True),
+    )
+
+    Id = Column(Integer, primary_key=True)
+    ConfigId = Column(Integer, ForeignKey("WowGuildNewsConfig.Id"))
+    CharacterName = Column(String(50))
+    RealmSlug = Column(String(100))
+    KnownMountIds = Column(Text, default="[]")
+    LastChecked = Column(DateTime, nullable=True)
+
+    @classmethod
+    def get_by_character(cls, config_id, char_name, realm_slug, session):
+        return (
+            session.query(cls)
+            .filter(cls.ConfigId == config_id)
+            .filter(cls.CharacterName == char_name)
+            .filter(cls.RealmSlug == realm_slug)
+            .first()
+        )
+
+    @classmethod
+    def get_all_by_config(cls, config_id, session):
+        return session.query(cls).filter(cls.ConfigId == config_id).all()
+
+    @classmethod
+    def delete_stale(cls, config_id, active_keys, stale_cutoff, session):
+        """Delete entries for characters no longer in the roster whose LastChecked is older than stale_cutoff.
+
+        active_keys: set of (CharacterName, RealmSlug) currently in the guild roster.
+        Returns the number of deleted entries.
+        """
+        all_entries = cls.get_all_by_config(config_id, session)
+        deleted = 0
+        for entry in all_entries:
+            if (entry.CharacterName, entry.RealmSlug) not in active_keys:
+                if entry.LastChecked and entry.LastChecked < stale_cutoff:
+                    session.delete(entry)
+                    deleted += 1
+        return deleted

--- a/NerdyPy/modules/wow.py
+++ b/NerdyPy/modules/wow.py
@@ -332,7 +332,7 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
             output = ""
             for cfg in configs:
                 channel = ctx.guild.get_channel(cfg.ChannelId)
-                channel_name = channel.mention if channel else f"#{cfg.ChannelId} (deleted)"
+                channel_name = f"#{channel.name}" if channel else f"#{cfg.ChannelId} (deleted)"
                 output += f"{str(cfg)}Channel: {channel_name}\n\n"
             for page in pagify(output, delims=["\n#"], page_length=1990):
                 await send_hidden_message(ctx, box(page, "md"))


### PR DESCRIPTION
## Summary
- Track guild member **achievements**, **boss kills**, and **mount collections** via the Blizzard API and post notification embeds to a configured Discord channel
- New `/wow guildnews` subgroup with commands: `setup`, `remove`, `list`, `pause`, `resume`, `check`
- Background polling loop (15min) using `guild_activity` endpoint for achievements/encounters and per-character `character_mounts_collection_summary` for mount diffing
- Handles Blizzard API rate limits (429), stale character cleanup (30-day grace), character renames, and concurrent batched API calls via `asyncio.Semaphore(5)`

## Test plan
- [x] Bot starts without errors, new tables auto-create
- [x] `/wow guildnews setup <guild> <realm> #channel` validates guild via API
- [x] `/wow guildnews list` shows tracked guilds
- [x] `/wow guildnews check <id>` triggers immediate poll, verify embeds post
- [x] Initial sync processes all batches continuously until all active characters are baselined
- [x] Subsequent polls only process one batch per cycle with offset rotation
- [x] `/wow guildnews pause` / `resume` toggles tracking
- [x] `/wow guildnews remove` deletes config and associated mount data
- [ ] Rate limit (429) gracefully stops batch and resumes next cycle
- [ ] Stale characters (left guild >30 days) are pruned
- [ ] Character renames migrate mount data instead of re-baselining

🤖 Generated with [Claude Code](https://claude.com/claude-code)