### PR TITLE
fix: always delete prefix command messages on check failure

### DIFF
--- a/NerdyPy/utils/audio.py
+++ b/NerdyPy/utils/audio.py
@@ -189,8 +189,8 @@ class Audio:
     def clear_buffer(self, guild_id):
         """Clears the Audio Buffer"""
         if self._has_buffer(guild_id):
-            self.buffer.get(guild_id).pop(BufferKey.QUEUE)
-            self.lastPlayed.pop(guild_id)
+            self.buffer.get(guild_id).pop(BufferKey.QUEUE, None)
+            self.lastPlayed.pop(guild_id, None)
 
     def list_queue(self, guild_id):
         """lists audio queue"""
@@ -202,10 +202,15 @@ class Audio:
     def stop(self, guild_id):
         """Stops current audio from playing"""
         if self._has_buffer(guild_id):
-            self.buffer[guild_id][BufferKey.VOICE_CLIENT].stop()
+            vc = self.buffer[guild_id].get(BufferKey.VOICE_CLIENT)
+            if vc is not None:
+                vc.stop()
 
     async def leave(self, guild_id):
-        await self.buffer[guild_id][BufferKey.VOICE_CLIENT].disconnect()
+        if self._has_buffer(guild_id):
+            vc = self.buffer[guild_id].get(BufferKey.VOICE_CLIENT)
+            if vc is not None:
+                await vc.disconnect()
         self.clear_buffer(guild_id)
 
     @_timeout_manager.before_loop

--- a/NerdyPy/utils/errors.py
+++ b/NerdyPy/utils/errors.py
@@ -1,5 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from discord.ext.commands import CheckFailure
+
 
 class NerpyException(Exception):
+    pass
+
+
+class SilentCheckFailure(CheckFailure):
+    """A check already sent its own rejection message — the error handler should not send another."""
+
     pass


### PR DESCRIPTION
## Summary
- Adds `SilentCheckFailure` exception so check functions (`_reject()`) can signal "I already messaged the user" to the error handler
- Wraps `on_command_error` in `try/finally` so `ctx.message.delete()` runs even on early-return branches (SilentCheckFailure, NoPrivateMessage, DM CheckFailure)
- Hardens `Audio.stop()`/`leave()`/`clear_buffer()` against missing voice clients
- Enables `verify_checks=True` on `DefaultHelpCommand` so users only see commands they can run
- Guards help-command probes in `_reject()` with `SilentCheckFailure` to prevent side effects
- closes #171 

## Context
When a prefix command like `!t test` failed a voice permission check, `_reject()` would send the user a DM explaining the problem, but the original `!t test` message stayed in the channel — because `SilentCheckFailure` caused an early `return` in `on_command_error`, skipping the `ctx.message.delete()` at the bottom.

## Test plan
- [x] Run `!t <tag>` while not in a voice channel — message should be deleted, user gets DM
- [x] Run `!t <tag>` in a channel the bot can't join — message should be deleted, user gets DM
- [x] Run `!stop` / `!leave` when bot isn't playing — no crash
- [x] Run `!help` — only shows commands the user can actually run
- [x] Slash commands (`/t`, `/stop`, `/leave`) continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)