### PR TITLE
feat: permission audit system and voicecontrol module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - **search** - Multi-source search (Imgur, Genius, OMDB, IGDB, YouTube)
 - **tagging** - Audio tag management
 - **utility** - Weather, info commands
+- **voicecontrol** - Voice stop/leave commands (use instead of moderation for music-only bots)
 - **wow** - Blizzard API integration
 
 ### Database Layer

--- a/NerdyPy/config.yaml.template
+++ b/NerdyPy/config.yaml.template
@@ -10,6 +10,7 @@ bot:
     - league
     - leavemsg
     - moderation
+    - voicecontrol  # voice-only stop/leave (use instead of moderation for music-only bots)
     - random
     - reactionrole
     - rolemanage
@@ -47,6 +48,11 @@ utility:
 
 league:
   riot: your_riot_api_key
+
+notifications:
+  # Discord user IDs to DM when unhandled errors occur
+  error_recipients:
+    - your_discord_id_here
 
 wow:
   wow_id: your_wow_client_id

--- a/NerdyPy/models/permissions.py
+++ b/NerdyPy/models/permissions.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Permission notification subscriber model."""
+
+from sqlalchemy import BigInteger, Column
+from utils import database as db
+
+
+class PermissionSubscriber(db.BASE):
+    """Users who opted in to receive DM notifications about missing bot permissions on startup."""
+
+    __tablename__ = "PermissionSubscriber"
+
+    GuildId = Column(BigInteger, primary_key=True)
+    UserId = Column(BigInteger, primary_key=True)
+
+    @classmethod
+    def get_by_guild(cls, guild_id: int, session) -> list["PermissionSubscriber"]:
+        """Returns all subscribers for a given guild."""
+        return session.query(cls).filter(cls.GuildId == guild_id).all()
+
+    @classmethod
+    def get(cls, guild_id: int, user_id: int, session) -> "PermissionSubscriber | None":
+        """Returns a specific subscription, or None."""
+        return session.query(cls).filter(cls.GuildId == guild_id, cls.UserId == user_id).first()
+
+    @classmethod
+    def delete(cls, guild_id: int, user_id: int, session) -> None:
+        """Removes a subscription."""
+        entry = cls.get(guild_id, user_id, session)
+        if entry is not None:
+            session.delete(entry)

--- a/NerdyPy/modules/music.py
+++ b/NerdyPy/modules/music.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from discord import Color, Embed, Interaction
-from discord.app_commands import guild_only
+from discord import Color, Embed
+from discord.app_commands import checks, guild_only
 from discord.ext.commands import (
     Context,
     GroupCog,
@@ -14,7 +14,7 @@ from discord.ext.commands import (
 
 import utils.format as fmt
 from utils.audio import QueuedSong, QueueMixin
-from utils.checks import is_connected_to_voice, is_in_same_voice_channel_as_bot
+from utils.checks import can_stop_playback, is_connected_to_voice
 from utils.download import download, fetch_yt_infos
 from utils.errors import NerpyException
 from utils.helpers import error_context, send_hidden_message, youtube
@@ -34,12 +34,11 @@ class Music(QueueMixin, GroupCog):
         self.audio = self.bot.audio
 
     @hybrid_command(name="skip")
-    @check(is_in_same_voice_channel_as_bot)
+    @check(can_stop_playback)
     async def _skip_audio(self, ctx: Context):
         """skip current track"""
         self.audio.stop(ctx.guild.id)
-        if isinstance(ctx, Interaction):
-            await ctx.followup.send("Skipped current track.")
+        await send_hidden_message(ctx, "Skipped current track.")
 
     @hybrid_group(name="queue")
     async def _queue(self, ctx: Context):
@@ -67,13 +66,13 @@ class Music(QueueMixin, GroupCog):
                 await send_hidden_message(ctx, "Queue is empty.")
 
     @_queue.command(name="drop")
+    @checks.has_permissions(mute_members=True)
     @has_permissions(mute_members=True)
     async def _drop_queue(self, ctx: Context):
         """drop the playlist entirely"""
         self.audio.stop(ctx.guild.id)
         self._clear_queue(ctx.guild.id)
-        if isinstance(ctx, Interaction):
-            await ctx.followup.send("Cleared the queue and stopped playing audio.")
+        await send_hidden_message(ctx, "Cleared the queue and stopped playing audio.")
 
     @hybrid_group(name="play")
     @check(is_connected_to_voice)

--- a/NerdyPy/modules/reminder.py
+++ b/NerdyPy/modules/reminder.py
@@ -8,7 +8,7 @@ from discord.ext import tasks
 from discord.ext.commands import Context, GroupCog, hybrid_command
 from models.reminder import ReminderMessage
 from utils.format import box, pagify
-from utils.helpers import send_hidden_message
+from utils.helpers import notify_error, send_hidden_message
 
 
 class Reminder(GroupCog, group_name="reminder"):
@@ -45,6 +45,7 @@ class Reminder(GroupCog, group_name="reminder"):
                                     msg.Count += 1
         except Exception as ex:
             self.bot.log.error(f"Reminder loop: {ex}")
+            await notify_error(self.bot, "Reminder background loop", ex)
         self.bot.log.debug("Stop Reminder Loop!")
 
     @hybrid_command(name="create")

--- a/NerdyPy/modules/rolemanage.py
+++ b/NerdyPy/modules/rolemanage.py
@@ -2,7 +2,7 @@
 
 from discord import Member, Role
 from discord.app_commands import checks
-from discord.ext.commands import Cog, Context, hybrid_group
+from discord.ext.commands import Cog, Context, has_permissions, hybrid_group
 
 from models.rolemanage import RoleMapping
 from utils.format import box
@@ -28,6 +28,7 @@ class RoleManage(Cog):
 
     @_rolemanage.command(name="allow")
     @checks.has_permissions(manage_roles=True)
+    @has_permissions(manage_roles=True)
     async def _allow(self, ctx: Context, source_role: Role, target_role: Role):
         """allow a source role to assign a target role [manage_roles]
 
@@ -68,6 +69,7 @@ class RoleManage(Cog):
 
     @_rolemanage.command(name="deny")
     @checks.has_permissions(manage_roles=True)
+    @has_permissions(manage_roles=True)
     async def _deny(self, ctx: Context, source_role: Role, target_role: Role):
         """remove a source-to-target role mapping [manage_roles]
 
@@ -89,6 +91,7 @@ class RoleManage(Cog):
 
     @_rolemanage.command(name="list")
     @checks.has_permissions(manage_roles=True)
+    @has_permissions(manage_roles=True)
     async def _list(self, ctx: Context):
         """list all delegated role mappings for this server [manage_roles]"""
         with self.bot.session_scope() as session:

--- a/NerdyPy/modules/tagging.py
+++ b/NerdyPy/modules/tagging.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from io import BytesIO
 
 from discord import FFmpegOpusAudio
-from discord.app_commands import guild_only, rename
+from discord.app_commands import checks, guild_only, rename
 from discord.ext.commands import (
     Cog,
     Context,
@@ -74,6 +74,7 @@ class Tagging(QueueMixin, Cog):
                 await send_hidden_message(ctx, "Queue is empty.")
 
     @_queue.command(name="drop", hidden=True)
+    @checks.has_permissions(mute_members=True)
     @has_permissions(mute_members=True)
     async def _drop_queue(self, ctx: Context):
         """drop the playlist entirely"""

--- a/NerdyPy/modules/voicecontrol.py
+++ b/NerdyPy/modules/voicecontrol.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from discord.ext.commands import Cog, Context, check, hybrid_command
+
+from utils.checks import can_leave_voice, can_stop_playback
+from utils.helpers import send_hidden_message
+
+
+class VoiceControl(Cog):
+    """commands for controlling bot voice playback"""
+
+    def __init__(self, bot):
+        bot.log.info(f"loaded {__name__}")
+        self.bot = bot
+
+    @hybrid_command(name="stop")
+    @check(can_stop_playback)
+    async def _bot_stop_playing(self, ctx: Context):
+        """bot stops playing audio [bot-moderator]"""
+        self.bot.audio.stop(ctx.guild.id)
+        self.bot.audio.clear_buffer(ctx.guild.id)
+        if ctx.interaction is not None:
+            await send_hidden_message(ctx, "\U0001f44d")
+
+    @hybrid_command(name="leave")
+    @check(can_leave_voice)
+    async def _bot_leave_channel(self, ctx: Context):
+        """bot leaves the voice channel [bot-moderator]"""
+        await self.bot.audio.leave(ctx.guild.id)
+        if ctx.interaction is not None:
+            await send_hidden_message(ctx, "\U0001f44b")
+
+
+async def setup(bot):
+    """adds this module to the bot"""
+    await bot.add_cog(VoiceControl(bot))

--- a/NerdyPy/modules/wow.py
+++ b/NerdyPy/modules/wow.py
@@ -13,11 +13,11 @@ from blizzapi import Language, Region, RetailClient
 from discord import Color, Embed, TextChannel
 from discord.app_commands import checks
 from discord.ext import tasks
-from discord.ext.commands import Context, GroupCog, bot_has_permissions, hybrid_command, hybrid_group
+from discord.ext.commands import Context, GroupCog, bot_has_permissions, has_permissions, hybrid_command, hybrid_group
 from models.wow import WowCharacterMounts, WowGuildNewsConfig
 from utils.errors import NerpyException
 from utils.format import box, pagify
-from utils.helpers import send_hidden_message
+from utils.helpers import notify_error, send_hidden_message
 
 
 class WowApiLanguage(Enum):
@@ -256,6 +256,7 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
 
     @_guildnews.command(name="setup")
     @checks.has_permissions(manage_channels=True)
+    @has_permissions(manage_channels=True)
     async def _guildnews_setup(
         self,
         ctx: Context,
@@ -311,6 +312,7 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
 
     @_guildnews.command(name="remove")
     @checks.has_permissions(manage_channels=True)
+    @has_permissions(manage_channels=True)
     async def _guildnews_remove(self, ctx: Context, config_id: int):
         """remove a guild news tracking config [manage_channels]"""
         with self.bot.session_scope() as session:
@@ -339,6 +341,7 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
 
     @_guildnews.command(name="pause")
     @checks.has_permissions(manage_channels=True)
+    @has_permissions(manage_channels=True)
     async def _guildnews_pause(self, ctx: Context, config_id: int):
         """pause guild news tracking [manage_channels]"""
         with self.bot.session_scope() as session:
@@ -351,6 +354,7 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
 
     @_guildnews.command(name="resume")
     @checks.has_permissions(manage_channels=True)
+    @has_permissions(manage_channels=True)
     async def _guildnews_resume(self, ctx: Context, config_id: int):
         """resume guild news tracking [manage_channels]"""
         with self.bot.session_scope() as session:
@@ -395,6 +399,7 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
 
         except Exception as ex:
             self.bot.log.error(f"Guild news loop error: {ex}")
+            await notify_error(self.bot, "Guild news background loop", ex)
         self.bot.log.debug("Stop Guild News Loop!")
 
     @_guild_news_loop.before_loop

--- a/NerdyPy/utils/permissions.py
+++ b/NerdyPy/utils/permissions.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+"""
+Per-module bot permission requirements and guild-level audit helpers.
+"""
+
+from discord import Embed, Guild, Permissions
+
+# Maps module name → set of Permissions flag names the bot needs at runtime.
+# User-level checks (has_permissions) are NOT included — only bot actions.
+# Implicit permissions (view_channel, use_application_commands, etc.) are in _core.
+REQUIRED_PERMISSIONS: dict[str, set[str]] = {
+    # Core bot (always active) — basic visibility, slash commands, prefix-command cleanup
+    "_core": {
+        "view_channel",
+        "send_messages",
+        "send_messages_in_threads",
+        "manage_messages",
+        "read_message_history",
+        "use_application_commands",
+        "use_external_emojis",
+        "use_external_stickers",
+    },
+    "admin": set(),
+    "fun": {"send_messages"},
+    "league": {"send_messages"},
+    "leavemsg": {"send_messages"},
+    "moderation": {"send_messages", "kick_members", "manage_messages", "read_message_history"},
+    "music": {"send_messages", "embed_links", "connect", "speak", "add_reactions", "read_message_history"},
+    "raidplaner": {"send_messages", "add_reactions", "read_message_history"},
+    "random": {"send_messages"},
+    "reactionrole": {
+        "send_messages",
+        "manage_roles",
+        "add_reactions",
+        "manage_messages",
+        "read_message_history",
+    },
+    "rolemanage": {"send_messages", "manage_roles"},
+    "reminder": {"send_messages"},
+    "search": {"send_messages"},
+    "tagging": {"send_messages", "connect", "speak", "add_reactions", "read_message_history"},
+    "utility": {"send_messages", "embed_links"},
+    "voicecontrol": {"send_messages", "connect", "speak"},
+    "wow": {"send_messages", "embed_links"},
+}
+
+
+def required_permissions_for(modules: list[str]) -> Permissions:
+    """Compute the combined Permissions object for a list of enabled modules."""
+    flags: set[str] = set(REQUIRED_PERMISSIONS.get("_core", set()))
+    for mod in modules:
+        flags |= REQUIRED_PERMISSIONS.get(mod, set())
+
+    return Permissions(**{f: True for f in flags})
+
+
+def check_guild_permissions(guild: Guild, required: Permissions) -> list[str]:
+    """Return a list of permission flag names the bot is missing in *guild*."""
+    bot_perms = guild.me.guild_permissions
+    missing = []
+    for perm, needed in required:
+        if needed and not getattr(bot_perms, perm):
+            missing.append(perm)
+    return missing
+
+
+def build_permissions_embed(guild: Guild, missing: list[str], client_id: int, required: Permissions) -> Embed:
+    """Build a Discord Embed reporting missing permissions."""
+    if missing:
+        colour = 0xFF4444
+        desc = "**Missing permissions:**\n" + "\n".join(f"- `{p}`" for p in missing)
+    else:
+        colour = 0x44FF44
+        desc = "All required permissions are granted."
+
+    emb = Embed(title=f"Permission check — {guild.name}", description=desc, color=colour)
+
+    invite_perms = required.value
+    invite_url = (
+        f"https://discord.com/api/oauth2/authorize"
+        f"?client_id={client_id}&permissions={invite_perms}&scope=applications.commands+bot"
+    )
+    emb.add_field(name="Invite link (with correct permissions)", value=f"[Re-invite]({invite_url})", inline=False)
+    return emb

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ docker buildx build --target migrations -t nerpybot-migrations .
 ## Bot Invite Links
 
 - **NerpyBot** — [Invite](https://discord.com/api/oauth2/authorize?client_id=246941850223640576&permissions=582632143842386&scope=applications.commands+bot)
-- **HumanMusic** — [Invite](https://discord.com/api/oauth2/authorize?client_id=883656077357510697&permissions=414467959360&scope=applications.commands+bot)
+- **HumanMusic** — [Invite](https://discord.com/api/oauth2/authorize?client_id=883656077357510697&permissions=414467975744&scope=applications.commands+bot)
 
 ## License
 

--- a/config/humanmusic.yaml.example
+++ b/config/humanmusic.yaml.example
@@ -6,7 +6,7 @@ bot:
   error_spam_threshold: 5
   modules:
     - admin
-    - moderation
+    - voicecontrol
     - music
 
 database:
@@ -15,3 +15,11 @@ database:
 
 audio:
   buffer_limit: 5
+
+search:
+  ytkey: your_youtube_key
+
+notifications:
+  # Discord user IDs to DM when unhandled errors occur
+  error_recipients:
+    - your_discord_id_here

--- a/config/nerpybot.yaml.example
+++ b/config/nerpybot.yaml.example
@@ -10,8 +10,10 @@ bot:
     - league
     - leavemsg
     - moderation
-    - music
+    - voicecontrol
     - random
+    - reactionrole
+    - rolemanage
     - reminder
     - search
     - tagging
@@ -39,6 +41,17 @@ utility:
 league:
   riot: your_riot_api_key
 
+notifications:
+  # Discord user IDs to DM when unhandled errors occur
+  error_recipients:
+    - your_discord_id_here
+
 wow:
   wow_id: your_wow_client_id
   wow_secret: your_wow_client_secret
+  # Optional guild news settings (defaults shown)
+  # guild_news:
+  #   poll_interval_minutes: 15
+  #   mount_batch_size: 20
+  #   track_mounts: true
+  #   active_days: 7

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -55,6 +55,18 @@ Syncs slash commands with Discord. Prefix-only (not a slash command itself).
 - `copy` — Copy global commands to specified guild(s)
 - `clear` — Clear commands from specified guild(s)
 
+### `/botpermissions check`
+
+Checks whether the bot has all required permissions in the current server. Reports missing permissions and provides a re-invite link with the correct permission set. Available to administrators.
+
+### `/botpermissions subscribe`
+
+Subscribe to automatic DM notifications about missing permissions. When the bot restarts and detects missing permissions in this server, subscribed administrators receive a DM with the same report as `/botpermissions check`.
+
+### `/botpermissions unsubscribe`
+
+Stop receiving automatic permission notifications for this server.
+
 ### `debug`
 
 Toggles debug logging at runtime. **Operator-only** (user ID must be in `config.bot.ops`).

--- a/docs/music.md
+++ b/docs/music.md
@@ -52,7 +52,7 @@ Uses the YouTube Data API v3 (`config.search.ytkey`) to find the top result, the
 
 ### `/skip`
 
-Skip the currently playing track. The queue manager automatically starts the next song.
+Skip the currently playing track. The queue manager automatically starts the next song. Any user in the same voice channel as the bot can skip; moderators can skip from anywhere.
 
 ### `/queue list`
 

--- a/uv.lock
+++ b/uv.lock
@@ -1059,7 +1059,7 @@ wheels = [
 
 [[package]]
 name = "nerpybot"
-version = "0.4.14"
+version = "0.5.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- **Voicecontrol module** — Extracts `/stop` and `/leave` from moderation into a standalone Cog so music-only bots don't need `kick_members`/`manage_messages` permissions
- **Permission audit system** — On startup, the bot checks guild permissions against loaded modules and DMs subscribed administrators about any missing permissions
- **Prefix permission enforcement** — Adds `cog_check()` and `@has_permissions()` decorators so prefix commands enforce the same permission gates as their slash counterparts (admin, leavemsg, reactionrole, rolemanage, wow, tagging)
- **Error notification system** — `notify_error()` DMs configured recipients on unhandled errors in background loops and the main error handler
- **Misc** — Updated docs, HumanMusic invite link, version bump
- closes #171 

## Depends on
- #177 (`fix/prefix-cmd-handling`) — base branch

## Test plan
- [x] Load `voicecontrol` without `moderation` — `/stop` and `/leave` work, no permission warnings for kick/manage
- [x] Load both `moderation` + `voicecontrol` — no command conflicts
- [x] `/botpermissions check` reports missing perms correctly
- [x] `/botpermissions subscribe` → restart bot with missing perms → get DM notification
- [x] Prefix commands (`!autokicker`, `!autodeleter`, `!leavemsg`) are denied without correct permissions
- [x] `!stop` / `!leave` suppress emoji response (prefix), `/stop` / `/leave` show ephemeral emoji (slash)
- [x] Error in background loop → configured error_recipients get DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)