### PR TITLE
fix: add realm autocomplete and fix NoneType crashes in wow armory

### DIFF
--- a/docs/wow.md
+++ b/docs/wow.md
@@ -4,16 +4,17 @@ Blizzard API integration for character lookups and guild news tracking. Uses the
 
 ## Commands
 
-### `/wow armory <name> <realm> [region] [language]`
+### `/wow armory <name> <realm> [language]`
 
 Look up a WoW character profile.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `name` | `str` | *(required)* | Character name |
-| `realm` | `str` | *(required)* | Realm slug (e.g., `thrall`, `blackrock`) |
-| `region` | `Literal["eu", "us"]` | `"eu"` | API region |
+| `realm` | `str` | *(required)* | Realm with region (e.g., `blackrock-eu`, `thrall-us`). Slash commands offer autocomplete suggestions. Plain slugs (e.g., `blackrock`) default to EU. |
 | `language` | `Literal["de", "en"]` | `"en"` | Response language |
+
+**Realm autocomplete:** On first use, the bot fetches all EU and US realms from the Blizzard API and caches them. Slash command users get filtered suggestions as they type. Prefix command users can type `realm-region` manually (e.g., `!wow armory charname blackrock-us`).
 
 **Supports DM usage** — one of the few commands that works outside guilds.
 


### PR DESCRIPTION
## Summary

Closes #174

- Add dynamic realm cache that lazily fetches all EU/US realms from the Blizzard API, with slash command autocomplete suggestions formatted as `"Blackrock (EU)"` → `blackrock-eu`
- Remove the separate `region` parameter — region is now auto-detected from the realm value (e.g. `blackrock-eu`), defaulting to EU for plain slugs
- Fix `TypeError: object of type 'NoneType' has no len()` crash when `character_media()` returns `None` for invalid realms
- Fix same crash type when `_get_best_mythic_keys()` returns `None` (raider.io 404)
- Add realm validation against the cache with a friendly error message
- Make the armory embed publicly visible while keeping errors ephemeral

## Test plan

- [x] Slash command: autocomplete shows realm suggestions when typing
- [x] Slash command: selecting a realm from autocomplete returns the character embed publicly
- [ ] Prefix command: `!wow armory charname blackrock` still works (defaults to EU)
- [ ] Prefix command: `!wow armory charname blackrock-us` picks US region
- [x] Invalid realm gives a friendly ephemeral error instead of a crash
- [x] Invalid character name gives "No Character with this name found" ephemeral error
- [x] `uv run ruff check && uv run ruff format --check` passes
- [x] `uv run pytest` — all 148 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)