### PR TITLE
fix: support string-quoted numeric Discord IDs in config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,12 +60,15 @@ docker run --rm -e ALEMBIC_CONFIG=alembic-humanmusic.ini nerpybot-migrations ale
 ## Architecture
 
 ### Documentation
+
 `docs/` contains per-module markdown files documenting commands, database models, background tasks, and data flows. When adding a new module or changing an existing one, update or create the corresponding `docs/<module>.md` file.
 
 ### Entry Point
+
 `NerdyPy/NerdyPy.py` - Contains `NerpyBot` class extending discord.py's `Bot`. Handles module loading, database initialization, and event routing.
 
 ### Module System
+
 Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamically based on `config.yaml`:
 
 - **admin** - Server management, prefix config, command sync
@@ -78,6 +81,7 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - **random** - Random generators
 - **reactionrole** - Reaction-based role assignment
 - **reminder** - Timed user reminders
+- **rolemanage** - Delegated role management (lets specific roles assign other roles via mappings)
 - **search** - Multi-source search (Imgur, Genius, OMDB, IGDB, YouTube)
 - **tagging** - Audio tag management
 - **utility** - Weather, info commands
@@ -85,13 +89,16 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - **wow** - Blizzard API integration
 
 ### Database Layer
+
 - `NerdyPy/models/` - SQLAlchemy ORM models
 - `NerdyPy/utils/database.py` - Session management with context managers
 - `database-migrations/` - Alembic migrations (separate version dirs for `nerpybot/` and `humanmusic/`)
 - Supports SQLite (default), MySQL/MariaDB, PostgreSQL
 
 ### Utilities
+
 `NerdyPy/utils/` contains:
+
 - `audio.py` - Voice channel audio management
 - `checks.py` - Permission check functions for voice/moderator commands
 - `conversation.py` - Interactive dialog state management
@@ -100,6 +107,7 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - `helpers.py` - General utilities (incl. `send_hidden_message` for ephemeral/DM responses)
 - `download.py` - Audio downloading and ffmpeg conversion (yt-dlp)
 - `logging.py` - Dual-handler log setup (stdout for INFO/DEBUG, stderr for WARNING+)
+- `permissions.py` - Per-module bot permission requirements map and guild-level permission audit helpers
 
 ### Gotchas
 
@@ -112,6 +120,7 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 ## Configuration
 
 Copy `NerdyPy/config.yaml.template` to `NerdyPy/config.yaml` and fill in:
+
 - Discord bot token and client ID
 - Operator user IDs (bot admins)
 - Database connection settings

--- a/NerdyPy/NerdyPy.py
+++ b/NerdyPy/NerdyPy.py
@@ -43,7 +43,7 @@ from utils.audio import Audio
 from utils.conversation import AnswerType, ConversationManager
 from utils.database import BASE
 from utils.errors import NerpyException, SilentCheckFailure
-from utils.helpers import error_context, notify_error, send_hidden_message
+from utils.helpers import error_context, notify_error, parse_id, send_hidden_message
 from utils.permissions import build_permissions_embed, check_guild_permissions, required_permissions_for
 
 
@@ -61,9 +61,9 @@ class NerpyBot(Bot):
 
         self.config = config
         self.debug = debug
-        self.client_id = config["bot"]["client_id"]
+        self.client_id = parse_id(config["bot"]["client_id"])
         self.token = config["bot"]["token"]
-        self.ops = config["bot"]["ops"]
+        self.ops = [parse_id(op) for op in config["bot"]["ops"]]
         self.modules = config["bot"]["modules"]
         self.restart = True
         self.log = logging.get_logger("nerpybot")

--- a/NerdyPy/config.yaml.template
+++ b/NerdyPy/config.yaml.template
@@ -1,8 +1,8 @@
 bot:
-  client_id: your_client_id_here
+  client_id: "your_client_id_here"  # quoted to prevent formatter corruption
   token: your_bot_token_here
   ops:
-    - your_discord_id_here
+    - "your_discord_id_here"  # quoted to prevent formatter corruption
   error_spam_threshold: 5
   modules:
     - admin
@@ -52,7 +52,7 @@ league:
 notifications:
   # Discord user IDs to DM when unhandled errors occur
   error_recipients:
-    - your_discord_id_here
+    - "your_discord_id_here"  # quoted to prevent formatter corruption
 
 wow:
   wow_id: your_wow_client_id

--- a/NerdyPy/utils/helpers.py
+++ b/NerdyPy/utils/helpers.py
@@ -10,6 +10,15 @@ from utils.errors import NerpyException
 log = logging.getLogger("nerpybot")
 
 
+def parse_id(value: int | str) -> int:
+    """Coerce a config value to an integer Discord ID.
+
+    Accepts both int and str to guard against YAML formatter corruption
+    of large numeric values.
+    """
+    return int(value)
+
+
 async def send_hidden_message(ctx: Context, msg: str = None, **kwargs):
     """Send a message only visible to the invoking user.
 
@@ -64,7 +73,7 @@ async def notify_error(bot, context: str, error: Exception) -> None:
 
     for uid in recipients:
         try:
-            user = await bot.fetch_user(uid)
+            user = await bot.fetch_user(parse_id(uid))
             await user.send(msg)
         except Exception as dm_err:
             log.debug(f"Could not DM error notification to {uid}: {dm_err}")

--- a/config/humanmusic.yaml.example
+++ b/config/humanmusic.yaml.example
@@ -1,8 +1,8 @@
 bot:
-  client_id: your_client_id_here
+  client_id: "your_client_id_here"  # quoted to prevent formatter corruption
   token: your_bot_token_here
   ops:
-    - your_discord_id_here
+    - "your_discord_id_here"  # quoted to prevent formatter corruption
   error_spam_threshold: 5
   modules:
     - admin
@@ -22,4 +22,4 @@ search:
 notifications:
   # Discord user IDs to DM when unhandled errors occur
   error_recipients:
-    - your_discord_id_here
+    - "your_discord_id_here"  # quoted to prevent formatter corruption

--- a/config/nerpybot.yaml.example
+++ b/config/nerpybot.yaml.example
@@ -1,8 +1,8 @@
 bot:
-  client_id: your_client_id_here
+  client_id: "your_client_id_here"  # quoted to prevent formatter corruption
   token: your_bot_token_here
   ops:
-    - your_discord_id_here
+    - "your_discord_id_here"  # quoted to prevent formatter corruption
   error_spam_threshold: 5
   modules:
     - admin
@@ -44,7 +44,7 @@ league:
 notifications:
   # Discord user IDs to DM when unhandled errors occur
   error_recipients:
-    - your_discord_id_here
+    - "your_discord_id_here"  # quoted to prevent formatter corruption
 
 wow:
   wow_id: your_wow_client_id

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,0 +1,9 @@
+from utils.helpers import parse_id
+
+
+def test_parse_id_from_int():
+    assert parse_id(283746501234567890) == 283746501234567890
+
+
+def test_parse_id_from_string():
+    assert parse_id("283746501234567890") == 283746501234567890


### PR DESCRIPTION
## Summary

- Add `parse_id()` helper to coerce `str | int` config values to `int`, guarding against YAML formatter corruption of large Discord snowflake IDs
- Normalize `client_id` and `ops` at bot init, and `error_recipients` at usage time in `notify_error()`
- Quote all Discord ID placeholders in config templates to prevent IDE auto-formatters (Prettier, YAML formatters) from rewriting them as scientific notation

Closes #186

## Test plan

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run pytest tests/utils/test_helpers.py -v` — new `parse_id` tests pass
- [x] `uv run pytest --cov` — full suite (150 tests) passes
- [x] Verify bot starts with quoted string IDs in `config.yaml` (e.g. `client_id: "123456"`)
- [x] Verify bot starts with bare integer IDs in `config.yaml` (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)