### PR TITLE
fix: resolve duplicate WoW mount notifications (#180)

### DIFF
--- a/tests/modules/test_wow_mounts.py
+++ b/tests/modules/test_wow_mounts.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""Tests for WoW mount set degradation guard."""
+
+from modules.wow import _should_update_mount_set
+
+
+class TestDegradationGuard:
+    """Tests for _should_update_mount_set — guards against degraded API responses."""
+
+    def test_normal_update_no_removals(self):
+        """Current is a superset of known — should allow update."""
+        known = {1, 2, 3}
+        current = {1, 2, 3, 4, 5}
+        assert _should_update_mount_set(known, current) is True
+
+    def test_small_removal(self):
+        """Small removal (1 mount from 200) — Blizzard revoked a bugged mount."""
+        known = set(range(200))
+        current = set(range(1, 200))  # mount 0 removed
+        assert _should_update_mount_set(known, current) is True
+
+    def test_large_drop(self):
+        """Large drop (100 of 200 gone) — degraded API response."""
+        known = set(range(200))
+        current = set(range(100))  # lost mounts 100-199
+        assert _should_update_mount_set(known, current) is False
+
+    def test_empty_response(self):
+        """API returned nothing — should block update."""
+        known = set(range(200))
+        current = set()
+        assert _should_update_mount_set(known, current) is False
+
+    def test_threshold_boundary_at_limit(self):
+        """Removing exactly max(10, len*0.1) — at boundary, <= means allowed."""
+        known = set(range(200))
+        # threshold = max(10, int(200 * 0.1)) = 20
+        # remove exactly 20 mounts
+        current = set(range(200)) - set(range(20))
+        assert _should_update_mount_set(known, current) is True
+
+    def test_threshold_boundary_one_over(self):
+        """Removing one more than threshold — should block."""
+        known = set(range(200))
+        # threshold = 20, remove 21
+        current = set(range(200)) - set(range(21))
+        assert _should_update_mount_set(known, current) is False
+
+    def test_empty_known_set(self):
+        """First baseline — empty known set should always allow."""
+        known = set()
+        current = {1, 2, 3}
+        assert _should_update_mount_set(known, current) is True
+
+    def test_both_empty(self):
+        """Both empty — no-op, should allow."""
+        known = set()
+        current = set()
+        assert _should_update_mount_set(known, current) is True

--- a/tests/test_db_connection.py
+++ b/tests/test_db_connection.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""Tests for NerpyBot.build_connection_string."""
+
+from NerdyPy.NerdyPy import NerpyBot
+
+
+class TestBuildConnectionString:
+    """Verify connection string building with correct charset handling."""
+
+    def test_sqlite_fallback_when_no_database_config(self):
+        config = {}
+        result = NerpyBot.build_connection_string(config)
+        assert result == "sqlite:///db.db"
+
+    def test_sqlite_has_no_charset(self):
+        config = {}
+        result = NerpyBot.build_connection_string(config)
+        assert "charset" not in result
+
+    def test_mysql_includes_charset_utf8mb4(self):
+        config = {
+            "database": {
+                "db_type": "mysql",
+                "db_name": "nerpybot",
+                "db_username": "user",
+                "db_password": "pass",
+                "db_host": "localhost",
+                "db_port": "3306",
+            }
+        }
+        result = NerpyBot.build_connection_string(config)
+        assert "charset=utf8mb4" in result
+        assert result.startswith("mysql+pymysql://")
+
+    def test_mariadb_includes_charset_utf8mb4(self):
+        config = {
+            "database": {
+                "db_type": "mariadb",
+                "db_name": "nerpybot",
+                "db_username": "user",
+                "db_password": "pass",
+                "db_host": "localhost",
+                "db_port": "3306",
+            }
+        }
+        result = NerpyBot.build_connection_string(config)
+        assert "charset=utf8mb4" in result
+        assert result.startswith("mariadb+pymysql://")
+
+    def test_postgresql_has_no_charset(self):
+        config = {
+            "database": {
+                "db_type": "postgresql",
+                "db_name": "nerpybot",
+                "db_username": "user",
+                "db_password": "pass",
+                "db_host": "localhost",
+                "db_port": "5432",
+            }
+        }
+        result = NerpyBot.build_connection_string(config)
+        assert "charset" not in result
+        assert result.startswith("postgresql://")
+
+    def test_mysql_connection_string_format(self):
+        config = {
+            "database": {
+                "db_type": "mysql",
+                "db_name": "testdb",
+                "db_username": "admin",
+                "db_password": "secret",
+                "db_host": "db.example.com",
+                "db_port": "3306",
+            }
+        }
+        result = NerpyBot.build_connection_string(config)
+        assert result == "mysql+pymysql://admin:secret@db.example.com:3306/testdb?charset=utf8mb4"
+
+    def test_minimal_mysql_config(self):
+        """MySQL with only required fields still gets charset."""
+        config = {
+            "database": {
+                "db_type": "mysql",
+                "db_name": "nerpybot",
+            }
+        }
+        result = NerpyBot.build_connection_string(config)
+        assert "charset=utf8mb4" in result
+        assert result == "mysql+pymysql:///nerpybot?charset=utf8mb4"


### PR DESCRIPTION
## Summary

Fixes the core bugs causing duplicate mount notifications in WoW Guild News (issue #180):

- **Charset fix**: Appends `?charset=utf8mb4` to MySQL/MariaDB connection strings, ensuring PyMySQL negotiates UTF-8 instead of defaulting to `latin1`. This prevents accented character names (e.g., "Morzâ") from being corrupted during DB round-trips, which caused lookups to fail silently and every poll to treat the character as new.
- **Degradation guard**: Adds `_should_update_mount_set()` that blocks mount set updates when the Blizzard API returns a degraded response (set shrinks by more than `max(10, 10%)`). Small legitimate removals (e.g., Blizzard revoking bugged mounts) are still allowed. Includes debug logging of mount diff sizes for operational visibility.

## Test plan

- [x] 7 new tests for `build_connection_string` (MySQL/MariaDB charset, SQLite/PostgreSQL no charset, edge cases)
- [x] 8 new tests for `_should_update_mount_set` (normal updates, degraded responses, boundary cases)
- [x] Full test suite: 165/165 passing
- [x] `ruff check` and `ruff format --check` clean
- [x] Manual test with a guild containing accented character names on MariaDB

Part 1 of 2 — account-aware dedup and localized notifications will follow in a separate PR.

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)