### PR TITLE
feat: add account-aware mount dedup and localized notifications (#180)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ NerdyPy/weather_cache.sqlite
 NerpyBot.code-workspace
 config/*.yaml
 !config/*.yaml.example
+docs/plans/
 
 ### macOS template
 # General

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -38,6 +38,7 @@ class WowGuildNewsConfig(db.BASE):
     LastActivityTimestamp = Column(DateTime, nullable=True)
     Enabled = Column(Boolean, default=True)
     CreateDate = Column(DateTime, default=lambda: datetime.now(UTC))
+    AccountGroupData = Column(Text, default="{}")
 
     @classmethod
     def get_by_id(cls, config_id, guild_id, session):

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -23,6 +23,14 @@ class WowGuildNewsConfig(db.BASE):
     __table_args__ = (
         Index("WowGuildNewsConfig_GuildId", "GuildId"),
         Index("WowGuildNewsConfig_Id_GuildId", "Id", "GuildId", unique=True),
+        Index(
+            "WowGuildNewsConfig_Guild_Realm_Region",
+            "GuildId",
+            "WowGuildName",
+            "WowRealmSlug",
+            "Region",
+            unique=True,
+        ),
     )
 
     Id = Column(Integer, primary_key=True)
@@ -51,6 +59,20 @@ class WowGuildNewsConfig(db.BASE):
     @classmethod
     def get_all_by_guild(cls, guild_id, session):
         return session.query(cls).filter(cls.GuildId == guild_id).order_by(asc("Id")).all()
+
+    @classmethod
+    def get_existing(cls, guild_id, wow_guild_name, realm_slug, region, session):
+        """Check if a config already exists for this guild+realm+region combination."""
+        return (
+            session.query(cls)
+            .filter(
+                cls.GuildId == guild_id,
+                cls.WowGuildName == wow_guild_name,
+                cls.WowRealmSlug == realm_slug,
+                cls.Region == region,
+            )
+            .first()
+        )
 
     @classmethod
     def delete(cls, config_id, guild_id, session):

--- a/NerdyPy/modules/wow.py
+++ b/NerdyPy/modules/wow.py
@@ -849,6 +849,20 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
             character_failures = temporal_data.pop("_failures", {})
 
         account_groups = build_account_groups(candidate_list, stored_mounts, temporal_data)
+
+        # Log detected account clusters for debugging
+        clusters: dict[int, list[str]] = {}
+        for (name, realm), gid in account_groups.items():
+            clusters.setdefault(gid, []).append(f"{name}:{realm}")
+        multi = {gid: members for gid, members in clusters.items() if len(members) > 1}
+        if multi:
+            group_strs = [f"  group {gid}: {', '.join(members)}" for gid, members in multi.items()]
+            self.bot.log.debug(f"Guild news #{config_id}: account groups:\n" + "\n".join(group_strs))
+        else:
+            self.bot.log.debug(
+                f"Guild news #{config_id}: no account groups detected ({len(account_groups)} solo chars)"
+            )
+
         reported_by_account = {}  # account_group_id -> set of already-reported mount IDs
         cycle_new_mounts = {}  # (name, realm) -> set of new mount IDs
 

--- a/NerdyPy/utils/account_resolution.py
+++ b/NerdyPy/utils/account_resolution.py
@@ -5,6 +5,7 @@ Uses three signals: name patterns, mount set identity, and temporal correlation.
 """
 
 import difflib
+import json
 import unicodedata
 
 
@@ -45,3 +46,68 @@ def name_similarity_score(name_a: str, name_b: str) -> float:
         return ratio * 0.5
 
     return 0.0
+
+
+def temporal_score(correlated: int, uncorrelated: int) -> float:
+    """Compute confidence from temporal mount/achievement correlation.
+
+    Weak with few events, scales with evidence, caps at 0.8.
+    Variance (uncorrelated events) weakens the signal.
+    """
+    if correlated <= 0:
+        return 0.0
+    if uncorrelated < 0:
+        uncorrelated = 0
+    ratio = correlated / (correlated + uncorrelated)
+    confidence = ratio * min(1.0, correlated / 5)
+    return min(0.8, confidence)
+
+
+def account_confidence(
+    name_a: str,
+    name_b: str,
+    mounts_a: str | None,
+    mounts_b: str | None,
+    temporal_data: dict | None,
+) -> float:
+    """Combine all signals into a single same-account confidence score.
+
+    Args:
+        name_a, name_b: Lowercased character names.
+        mounts_a, mounts_b: JSON-encoded mount ID lists (or None if no stored data).
+        temporal_data: Dict with 'correlated' and 'uncorrelated' counts (or None).
+
+    Returns: 0.0-1.0 confidence score.
+    """
+    scores = []
+
+    ns = name_similarity_score(name_a, name_b)
+    if ns > 0:
+        scores.append(ns)
+
+    if mounts_a and mounts_b:
+        try:
+            ids_a = set(json.loads(mounts_a))
+            ids_b = set(json.loads(mounts_b))
+        except (ValueError, TypeError):
+            pass  # corrupt data — skip mount signal
+        else:
+            if len(ids_a) > 50 and len(ids_b) > 50:
+                overlap = len(ids_a & ids_b)
+                total = len(ids_a | ids_b)
+                jaccard = overlap / total
+                if jaccard >= 0.95:
+                    scores.append(0.9 * jaccard)
+
+    if temporal_data:
+        ts = temporal_score(temporal_data.get("correlated", 0), temporal_data.get("uncorrelated", 0))
+        if ts > 0:
+            scores.append(ts)
+
+    if not scores:
+        return 0.0
+
+    base = max(scores)
+    confirming = sum(1 for s in scores if s > 0.2)
+    boost = max(0, (confirming - 1)) * 0.1
+    return min(1.0, base + boost)

--- a/NerdyPy/utils/account_resolution.py
+++ b/NerdyPy/utils/account_resolution.py
@@ -137,7 +137,7 @@ def build_account_groups(
 
     Args:
         candidates: List of {"name": str, "realm": str, ...} dicts.
-        stored_mounts: Mapping of (name, realm) -> object with .KnownMountIds attribute.
+        stored_mounts: Mapping of (name, realm) -> JSON-encoded mount ID string (or None).
         temporal_data: Mapping of pair_key -> {"correlated": int, "uncorrelated": int}.
 
     Returns:
@@ -167,10 +167,8 @@ def build_account_groups(
         key_a = (ca["name"], ca["realm"])
         key_b = (cb["name"], cb["realm"])
 
-        stored_a = stored_mounts.get(key_a)
-        stored_b = stored_mounts.get(key_b)
-        mounts_a = stored_a.KnownMountIds if stored_a else None
-        mounts_b = stored_b.KnownMountIds if stored_b else None
+        mounts_a = stored_mounts.get(key_a)
+        mounts_b = stored_mounts.get(key_b)
 
         pair_key = make_pair_key(key_a, key_b)
         t_data = temporal_data.get(pair_key)

--- a/NerdyPy/utils/account_resolution.py
+++ b/NerdyPy/utils/account_resolution.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Heuristics for grouping WoW characters by likely Battle.net account.
+
+Uses three signals: name patterns, mount set identity, and temporal correlation.
+"""
+
+import difflib
+import unicodedata
+
+
+def strip_diacritics(name: str) -> str:
+    """Normalize a character name for comparison by removing diacritics.
+
+    Examples: 'Morza\u0302' -> 'morza', 'MorzA' -> 'morza'
+    """
+    nfkd = unicodedata.normalize("NFKD", name.lower())
+    return "".join(c for c in nfkd if not unicodedata.combining(c))
+
+
+def name_similarity_score(name_a: str, name_b: str) -> float:
+    """Score 0.0-1.0 indicating how likely two character names belong to the same player.
+
+    Checks (in priority order):
+    1. Exact match after diacritics removal (score 0.9)
+    2. Shared prefix >= 3 chars covering >= 40% of the shorter name (score 0.3-0.5)
+    3. General sequence similarity >= 0.6 (score 0.3-0.5)
+    """
+    norm_a = strip_diacritics(name_a)
+    norm_b = strip_diacritics(name_b)
+
+    if norm_a == norm_b:
+        return 0.9
+
+    prefix_len = 0
+    for a, b in zip(norm_a, norm_b):
+        if a != b:
+            break
+        prefix_len += 1
+    shorter = min(len(norm_a), len(norm_b))
+    if shorter > 0 and prefix_len >= 3 and prefix_len / shorter >= 0.4:
+        return 0.3 + 0.2 * (prefix_len / shorter)
+
+    ratio = difflib.SequenceMatcher(None, norm_a, norm_b).ratio()
+    if ratio >= 0.6:
+        return ratio * 0.5
+
+    return 0.0

--- a/database-migrations/nerpybot/versions/002_add_accountgroupdata.py
+++ b/database-migrations/nerpybot/versions/002_add_accountgroupdata.py
@@ -1,0 +1,48 @@
+"""add AccountGroupData to WowGuildNewsConfig
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-02-16
+
+"""
+
+import logging
+from typing import Sequence, Union
+
+from alembic import context, op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+log = logging.getLogger(__name__)
+
+TABLE = "WowGuildNewsConfig"
+COLUMN = "AccountGroupData"
+
+
+def _table_exists() -> bool | None:
+    """Return whether the table exists, or None in offline mode."""
+    if context.is_offline_mode():
+        return None
+    bind = op.get_bind()
+    return TABLE in set(sa.inspect(bind).get_table_names())
+
+
+def upgrade() -> None:
+    exists = _table_exists()
+    if exists is not None and not exists:
+        log.info("Skipping %s.%s — table does not exist", TABLE, COLUMN)
+        return
+    op.add_column(TABLE, sa.Column(COLUMN, sa.Text(), nullable=True, server_default="{}"))
+
+
+def downgrade() -> None:
+    exists = _table_exists()
+    if exists is not None and not exists:
+        log.info("Skipping %s.%s — table does not exist", TABLE, COLUMN)
+        return
+    op.drop_column(TABLE, COLUMN)

--- a/database-migrations/nerpybot/versions/003_add_unique_guild_config.py
+++ b/database-migrations/nerpybot/versions/003_add_unique_guild_config.py
@@ -1,0 +1,26 @@
+"""add unique constraint for guild config
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-02-16
+"""
+
+from alembic import op
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "WowGuildNewsConfig_Guild_Realm_Region",
+        "WowGuildNewsConfig",
+        ["GuildId", "WowGuildName", "WowRealmSlug", "Region"],
+        unique=True,
+    )
+
+
+def downgrade():
+    op.drop_index("WowGuildNewsConfig_Guild_Realm_Region", table_name="WowGuildNewsConfig")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def db_engine():
     from models.admin import GuildPrefix  # noqa: F401
     from models.reminder import ReminderMessage  # noqa: F401
     from models.tagging import Tag, TagEntry  # noqa: F401
+    from models.wow import WowGuildNewsConfig, WowCharacterMounts  # noqa: F401
 
     BASE.metadata.create_all(engine)
     yield engine

--- a/tests/modules/test_wow_setup.py
+++ b/tests/modules/test_wow_setup.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Tests for guild news setup duplicate detection."""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from models.wow import WowGuildNewsConfig
+
+
+class TestUniqueGuildConfig:
+    """Verify unique constraint on (GuildId, WowGuildName, WowRealmSlug, Region)."""
+
+    def _make_config(self, **overrides):
+        defaults = {
+            "GuildId": 123456,
+            "ChannelId": 789,
+            "WowGuildName": "test-guild",
+            "WowRealmSlug": "blackrock",
+            "Region": "eu",
+            "Language": "en",
+            "Enabled": True,
+        }
+        defaults.update(overrides)
+        return WowGuildNewsConfig(**defaults)
+
+    def test_duplicate_raises_integrity_error(self, db_session):
+        """Inserting same guild+realm+region for same Discord guild should fail."""
+        db_session.add(self._make_config())
+        db_session.flush()
+
+        db_session.add(self._make_config(ChannelId=999))
+        with pytest.raises(IntegrityError):
+            db_session.flush()
+
+    def test_different_realm_is_allowed(self, db_session):
+        """Different realm slug should not conflict."""
+        db_session.add(self._make_config())
+        db_session.add(self._make_config(WowRealmSlug="azshara"))
+        db_session.flush()
+
+    def test_different_discord_guild_is_allowed(self, db_session):
+        """Different Discord guild should not conflict."""
+        db_session.add(self._make_config())
+        db_session.add(self._make_config(GuildId=999999))
+        db_session.flush()
+
+    def test_different_region_is_allowed(self, db_session):
+        """Same guild on different region should not conflict."""
+        db_session.add(self._make_config())
+        db_session.add(self._make_config(Region="us"))
+        db_session.flush()
+
+
+class TestGetExisting:
+    """Verify the get_existing classmethod for duplicate lookup."""
+
+    def test_finds_existing(self, db_session):
+        config = WowGuildNewsConfig(
+            GuildId=123456,
+            ChannelId=789,
+            WowGuildName="test-guild",
+            WowRealmSlug="blackrock",
+            Region="eu",
+            Language="en",
+            Enabled=True,
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        result = WowGuildNewsConfig.get_existing(123456, "test-guild", "blackrock", "eu", db_session)
+        assert result is not None
+        assert result.Id == config.Id
+
+    def test_returns_none_when_no_match(self, db_session):
+        result = WowGuildNewsConfig.get_existing(123456, "test-guild", "blackrock", "eu", db_session)
+        assert result is None

--- a/tests/utils/test_account_resolution.py
+++ b/tests/utils/test_account_resolution.py
@@ -228,8 +228,8 @@ class TestBuildAccountGroups:
             {"name": "beta", "realm": "r1"},
         ]
         stored = {
-            ("alpha", "r1"): type("Obj", (), {"KnownMountIds": mounts})(),
-            ("beta", "r1"): type("Obj", (), {"KnownMountIds": mounts})(),
+            ("alpha", "r1"): mounts,
+            ("beta", "r1"): mounts,
         }
         groups = build_account_groups(candidates, stored_mounts=stored, temporal_data={})
         assert groups[("alpha", "r1")] == groups[("beta", "r1")]
@@ -265,8 +265,8 @@ class TestBuildAccountGroups:
         ]
         mounts = json.dumps(list(range(1, 201)))
         stored = {
-            ("morza", "r1"): type("Obj", (), {"KnownMountIds": mounts})(),
-            ("morzb", "r1"): type("Obj", (), {"KnownMountIds": mounts})(),
+            ("morza", "r1"): mounts,
+            ("morzb", "r1"): mounts,
         }
         groups = build_account_groups(candidates, stored_mounts=stored, temporal_data={})
         # morza and morza are grouped by name, morza and morzb by mounts -> all 3 grouped

--- a/tests/utils/test_account_resolution.py
+++ b/tests/utils/test_account_resolution.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""Tests for account resolution heuristics."""
+
+from utils.account_resolution import strip_diacritics, name_similarity_score
+
+
+class TestStripDiacritics:
+    def test_plain_ascii(self):
+        assert strip_diacritics("morza") == "morza"
+
+    def test_circumflex(self):
+        assert strip_diacritics("morza\u0302") == "morza"  # combining circumflex
+
+    def test_precomposed(self):
+        """Precomposed a-circumflex should decompose and strip."""
+        assert strip_diacritics("morz\u00e2") == "morza"
+
+    def test_mixed_case(self):
+        assert strip_diacritics("MorzA") == "morza"
+
+    def test_empty(self):
+        assert strip_diacritics("") == ""
+
+
+class TestNameSimilarityScore:
+    def test_identical_after_diacritics(self):
+        """Morza with and without accent -> 0.9."""
+        score = name_similarity_score("morz\u00e2", "morza")
+        assert score == 0.9
+
+    def test_shared_prefix_alu(self):
+        """alurush / alublood -> shared prefix 'alu' (3 chars)."""
+        score = name_similarity_score("alurush", "alublood")
+        assert 0.3 <= score <= 0.6
+
+    def test_shared_prefix_alu_wush(self):
+        """alurush / aluwush -> shared prefix 'alu' + high similarity."""
+        score = name_similarity_score("alurush", "aluwush")
+        assert 0.3 <= score <= 0.7
+
+    def test_completely_different(self):
+        """thrall / jaina -> 0.0."""
+        score = name_similarity_score("thrall", "jaina")
+        assert score == 0.0
+
+    def test_same_name(self):
+        """Exact same name -> 0.9."""
+        score = name_similarity_score("arthas", "arthas")
+        assert score == 0.9
+
+    def test_short_prefix_ignored(self):
+        """'al' prefix (2 chars) should not trigger prefix matching."""
+        score = name_similarity_score("alpha", "albedo")
+        # 2-char prefix 'al' is below threshold
+        assert score < 0.5

--- a/tests/utils/test_account_resolution.py
+++ b/tests/utils/test_account_resolution.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """Tests for account resolution heuristics."""
 
-from utils.account_resolution import strip_diacritics, name_similarity_score
+import json
+
+from utils.account_resolution import strip_diacritics, name_similarity_score, temporal_score, account_confidence
 
 
 class TestStripDiacritics:
@@ -53,3 +55,137 @@ class TestNameSimilarityScore:
         score = name_similarity_score("alpha", "albedo")
         # 2-char prefix 'al' is below threshold
         assert score < 0.5
+
+
+class TestTemporalScore:
+    def test_no_events(self):
+        assert temporal_score(0, 0) == 0.0
+
+    def test_one_correlated(self):
+        """Single correlated event — weak signal."""
+        score = temporal_score(1, 0)
+        assert 0.1 <= score <= 0.3
+
+    def test_strong_correlation(self):
+        """5+ correlated, 0 uncorrelated — very strong."""
+        score = temporal_score(5, 0)
+        assert score >= 0.7
+
+    def test_mixed_signals(self):
+        """5 correlated, 3 uncorrelated — moderate."""
+        score = temporal_score(5, 3)
+        assert 0.3 <= score <= 0.7
+
+    def test_mostly_uncorrelated(self):
+        """2 correlated, 8 uncorrelated — weak."""
+        score = temporal_score(2, 8)
+        assert score < 0.2
+
+    def test_cap_at_0_8(self):
+        """Even with massive correlation, caps at 0.8."""
+        score = temporal_score(100, 0)
+        assert score <= 0.8
+
+
+class TestAccountConfidence:
+    def test_identical_mount_sets(self):
+        """Two characters with same 200+ mounts -> high confidence."""
+        mounts_a = json.dumps(list(range(1, 201)))
+        mounts_b = json.dumps(list(range(1, 201)))
+        score = account_confidence(
+            name_a="thrall",
+            name_b="jaina",
+            mounts_a=mounts_a,
+            mounts_b=mounts_b,
+            temporal_data=None,
+        )
+        assert score >= 0.7
+
+    def test_similar_names_no_mounts(self):
+        """Diacritics match alone -> high confidence."""
+        score = account_confidence(
+            name_a="morz\u00e2",
+            name_b="morza",
+            mounts_a=None,
+            mounts_b=None,
+            temporal_data=None,
+        )
+        assert score >= 0.7
+
+    def test_different_everything(self):
+        """Different names, different mounts, no temporal -> 0.0."""
+        mounts_a = json.dumps(list(range(1, 201)))
+        mounts_b = json.dumps(list(range(201, 401)))
+        score = account_confidence(
+            name_a="thrall",
+            name_b="jaina",
+            mounts_a=mounts_a,
+            mounts_b=mounts_b,
+            temporal_data=None,
+        )
+        assert score == 0.0
+
+    def test_multiple_signals_boost(self):
+        """Name match + mount identity -> boosted above either alone."""
+        mounts = json.dumps(list(range(1, 201)))
+        score_combined = account_confidence(
+            name_a="morz\u00e2",
+            name_b="morza",
+            mounts_a=mounts,
+            mounts_b=mounts,
+            temporal_data=None,
+        )
+        score_name_only = account_confidence(
+            name_a="morz\u00e2",
+            name_b="morza",
+            mounts_a=None,
+            mounts_b=None,
+            temporal_data=None,
+        )
+        assert score_combined > score_name_only
+
+    def test_prefix_name_plus_temporal(self):
+        """Weak name signal + temporal correlation -> crosses threshold over time."""
+        score = account_confidence(
+            name_a="alurush",
+            name_b="alublood",
+            mounts_a=None,
+            mounts_b=None,
+            temporal_data={"correlated": 5, "uncorrelated": 0},
+        )
+        assert score >= 0.7
+
+    def test_small_mount_set_ignored(self):
+        """Identical mount sets under 50 mounts should not count as strong signal."""
+        mounts = json.dumps(list(range(1, 11)))  # only 10 mounts
+        score = account_confidence(
+            name_a="thrall",
+            name_b="jaina",
+            mounts_a=mounts,
+            mounts_b=mounts,
+            temporal_data=None,
+        )
+        assert score < 0.7
+
+    def test_all_signals_caps_at_1(self):
+        """Even with all signals maxed, confidence should not exceed 1.0."""
+        mounts = json.dumps(list(range(1, 201)))
+        score = account_confidence(
+            name_a="morza",
+            name_b="morza",
+            mounts_a=mounts,
+            mounts_b=mounts,
+            temporal_data={"correlated": 100, "uncorrelated": 0},
+        )
+        assert score <= 1.0
+
+    def test_temporal_only(self):
+        """Strong temporal signal with completely different names and no mounts."""
+        score = account_confidence(
+            name_a="thrall",
+            name_b="jaina",
+            mounts_a=None,
+            mounts_b=None,
+            temporal_data={"correlated": 10, "uncorrelated": 0},
+        )
+        assert score >= 0.7


### PR DESCRIPTION
## Summary

- **Account-aware mount dedup**: Confidence-based account resolution groups characters likely on the same Battle.net account using three signals: name similarity (diacritics, prefixes, sequence matching), mount set identity (Jaccard similarity), and temporal correlation (co-occurring mount acquisitions over time). Only one notification per account group per mount.
- **Localized notification strings**: Boss kill and mount collection embeds now respect the guild's configured language setting (en/de) with English fallback.
- **Schema migration**: Adds `AccountGroupData` column to `WowGuildNewsConfig` for persisting temporal correlation data across poll cycles.

Stacked on #189 (charset fix + degradation guard).

## Test plan

- [x] 198 tests pass (`uv run pytest --cov -v`)
- [x] `ruff check` and `ruff format --check` clean
- [x] Unit tests for `strip_diacritics`, `name_similarity_score`, `temporal_score`, `account_confidence`, `make_pair_key`, `build_account_groups` (33 tests)
- [x] Degradation guard boundary tests (8 tests)
- [x] Manual test with a guild containing known multi-character accounts
- [x] Verify German notification text renders correctly in Discord

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)