### PR TITLE
feat: add project.scripts entry points for bot and alembic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ WORKDIR /app
 COPY --from=uv /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock ./
 
-RUN apk add --no-cache git libffi-dev
+RUN apk add --no-cache git libffi-dev \
+    gcc g++ musl-dev python3-dev pkgconf \
+    freetype-dev libpng-dev
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-managed-python --only-group bot
@@ -32,8 +34,6 @@ WORKDIR /app
 RUN adduser -D -H -h /app -u "${UID}" NerdyBot \
  && chown NerdyBot:NerdyBot /app
 
-ENV MPLCONFIGDIR=/tmp/matplotlib
-
 USER NerdyBot
 
 
@@ -42,7 +42,7 @@ FROM runtime AS bot
 ENV PYTHONFAULTHANDLER=1
 
 USER root
-RUN apk add --no-cache ffmpeg opus
+RUN apk add --no-cache ffmpeg opus freetype libpng
 
 USER NerdyBot
 COPY --chown=${UID} --from=builder /app/.venv-bot /app/.venv

--- a/NerdyPy/NerdyPy.py
+++ b/NerdyPy/NerdyPy.py
@@ -382,6 +382,34 @@ def parse_config(config_file=None) -> dict:
     return config
 
 
+def main() -> None:
+    """Entry point for the NerpyBot."""
+    args = parse_arguments()
+    config = parse_config(args.config)
+    intents = get_intents()
+
+    debug = args.debug or str(args.loglevel).upper() == "DEBUG" or args.verbosity > 0
+    loggers = ["nerpybot"]
+    if args.verbosity >= 3 or str(args.loglevel).upper() == "DEBUG":
+        loggers.append("sqlalchemy.engine")
+
+    if "bot" in config:
+        loglevel = "DEBUG" if args.debug else args.loglevel
+        for logger_name in loggers:
+            logging.create_logger(args.verbosity, loglevel, logger_name)
+        bot = NerpyBot(config, intents, debug)
+
+        try:
+            run(bot.start())
+        except LoginFailure:
+            bot.log.error(format_exc())
+            bot.log.error("Failed to login")
+        except KeyboardInterrupt:
+            pass
+    else:
+        raise NerpyException("Bot config not found.")
+
+
 if __name__ == "__main__":
     print(
         """
@@ -396,27 +424,4 @@ if __name__ == "__main__":
 """
     )
 
-    ARGS = parse_arguments()
-    CONFIG = parse_config(ARGS.config)
-    INTENTS = get_intents()
-
-    DEBUG = ARGS.debug or str(ARGS.loglevel).upper() == "DEBUG" or ARGS.verbosity > 0
-    loggers = ["nerpybot"]
-    if ARGS.verbosity >= 3 or str(ARGS.loglevel).upper() == "DEBUG":
-        loggers.append("sqlalchemy.engine")
-
-    if "bot" in CONFIG:
-        loglevel = "DEBUG" if ARGS.debug else ARGS.loglevel
-        for logger_name in loggers:
-            logging.create_logger(ARGS.verbosity, loglevel, logger_name)
-        BOT = NerpyBot(CONFIG, INTENTS, DEBUG)
-
-        try:
-            run(BOT.start())
-        except LoginFailure:
-            BOT.log.error(format_exc())
-            BOT.log.error("Failed to login")
-        except KeyboardInterrupt:
-            pass
-    else:
-        raise NerpyException("Bot config not found.")
+    main()

--- a/NerdyPy/NerdyPy.py
+++ b/NerdyPy/NerdyPy.py
@@ -405,7 +405,7 @@ def main() -> None:
             bot.log.error(format_exc())
             bot.log.error("Failed to login")
         except KeyboardInterrupt:
-            pass
+            bot.log.info("Received KeyboardInterrupt, shutting down.")
     else:
         raise NerpyException("Bot config not found.")
 

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Console script entry points for NerpyBot."""
+
+import sys
+from pathlib import Path
+
+
+def _run_alembic(config_file: str) -> None:
+    try:
+        from alembic.config import main as alembic_main
+    except ImportError:
+        print("alembic not installed. Run: uv sync --group migrations", file=sys.stderr)
+        sys.exit(1)
+    alembic_main(argv=["-c", config_file, *sys.argv[1:]])
+
+
+def alembic_nerpybot() -> None:
+    """Run Alembic with the NerpyBot (full deployment) config."""
+    _run_alembic("alembic-nerpybot.ini")
+
+
+def alembic_humanmusic() -> None:
+    """Run Alembic with the HumanMusic (music-only) config."""
+    _run_alembic("alembic-humanmusic.ini")
+
+
+def bot() -> None:
+    """Run the NerpyBot Discord bot."""
+    # NerdyPy/ must be on sys.path so internal imports (models, utils, modules) resolve.
+    nerdypy_dir = str(Path(__file__).resolve().parent / "NerdyPy")
+    if nerdypy_dir not in sys.path:
+        sys.path.insert(0, nerdypy_dir)
+
+    from NerdyPy import main
+
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "NerpyBot"
 description = "The nerdiest Bot on Discord!"
@@ -9,6 +13,11 @@ authors = [
 license = "GPL-3.0-or-later"
 readme = "README.md"
 requires-python = ">=3.13"
+
+[project.scripts]
+nerpybot = "cli:bot"
+alembic-nerpybot = "cli:alembic_nerpybot"
+alembic-humanmusic = "cli:alembic_humanmusic"
 
 [dependency-groups]
 bot = [
@@ -44,6 +53,9 @@ migrations = [
     "pymysql",
     "pyyaml",
 ]
+
+[tool.setuptools]
+py-modules = ["cli"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/uv.lock
+++ b/uv.lock
@@ -1060,7 +1060,7 @@ wheels = [
 [[package]]
 name = "nerpybot"
 version = "0.5.0"
-source = { virtual = "." }
+source = { editable = "." }
 
 [package.dev-dependencies]
 bot = [


### PR DESCRIPTION
## Summary

- **Bot entry point**: `uv run nerpybot` replaces `uv run python NerdyPy/NerdyPy.py`
- **Alembic entry points**: `uv run alembic-nerpybot` / `uv run alembic-humanmusic` replace verbose `-c` flag invocations
- **Dockerfile fix**: Add C build toolchain to Alpine builder for matplotlib (pre-existing breakage, no musl wheel available)

## Changes

- `cli.py` — Console entry point wrappers with lazy imports and `sys.path` setup for the bot
- `pyproject.toml` — `[build-system]`, `[project.scripts]`, `[tool.setuptools]`
- `NerdyPy/NerdyPy.py` — Extract `main()` from `if __name__` block (backwards-compatible)
- `Dockerfile` — Add `gcc g++ musl-dev pkgconf freetype-dev libpng-dev` to builder, `freetype libpng` to bot runtime
- `uv.lock` — `virtual` → `editable` (consequence of adding build-system)
- `CLAUDE.md` — Updated commands and added gotchas

## Test plan

- [x] `uv run nerpybot --help` shows argument parser
- [x] `uv run alembic-nerpybot heads` returns `002 (head)`
- [x] `uv run alembic-humanmusic heads` returns clean
- [x] `docker buildx build --target bot` succeeds
- [x] `docker buildx build --target migrations` succeeds
- [x] `docker run --rm nerpybot python -c "from NerdyPy import NerpyBot; print('OK')"` passes
- [x] `docker run --rm nerpybot-migrations alembic -c alembic-nerpybot.ini heads` passes
- [x] 150 tests pass, lint clean

Follow-up: #191 (migrate to typer, use entry point in Dockerfile CMD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)