### PR TITLE
fix(wow): localize achievement guild news notifications

### DIFF
--- a/NerdyPy/modules/wow.py
+++ b/NerdyPy/modules/wow.py
@@ -41,6 +41,8 @@ STALE_DAYS = 30
 
 _NOTIFICATION_STRINGS = {
     "en": {
+        "achievement_title": "Achievement Earned!",
+        "achievement_desc": "**{name}** ({realm}) has earned the achievement **{achievement}**",
         "mount_title": "New Mount Collected!",
         "mount_desc": "**{name}** ({realm}) obtained **{mount}**",
         "boss_title": "Boss Defeated!",
@@ -48,6 +50,8 @@ _NOTIFICATION_STRINGS = {
         "boss_desc_mode": "**{name}** ({realm}) defeated **{boss}** ({mode})",
     },
     "de": {
+        "achievement_title": "Erfolg errungen!",
+        "achievement_desc": "**{name}** ({realm}) hat den Erfolg **{achievement}** errungen",
         "mount_title": "Neues Reittier erhalten!",
         "mount_desc": "**{name}** ({realm}) hat **{mount}** erhalten",
         "boss_title": "Boss besiegt!",
@@ -713,9 +717,12 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
                 achievement = ach_data.get("achievement", {})
                 ach_name = achievement.get("name", "Unknown Achievement")
                 ach_id = achievement.get("id")
+                strings = _NOTIFICATION_STRINGS.get(language, _NOTIFICATION_STRINGS["en"])
                 emb = Embed(
-                    title="Achievement Unlocked!",
-                    description=f"**{char_name}** ({char_realm}) earned **{ach_name}**",
+                    title=strings["achievement_title"],
+                    description=strings["achievement_desc"].format(
+                        name=char_name, realm=char_realm, achievement=ach_name
+                    ),
                     color=COLOR_ACHIEVEMENT,
                     timestamp=activity_time,
                 )

--- a/docs/wow.md
+++ b/docs/wow.md
@@ -219,7 +219,7 @@ When the Blizzard API returns a different canonical name than the roster name:
 
 ### Localization
 
-Boss kill and mount collection notifications respect the guild's configured `Language` setting. Supported languages: `en` (English, default), `de` (German). Unsupported language codes fall back to English. To add a new language, extend the `_NOTIFICATION_STRINGS` dict in `modules/wow.py`.
+Achievement, boss kill, and mount collection notifications respect the guild's configured `Language` setting. Supported languages: `en` (English, default), `de` (German). Unsupported language codes fall back to English. To add a new language, extend the `_NOTIFICATION_STRINGS` dict in `modules/wow.py`.
 
 ## Database Models
 


### PR DESCRIPTION
## Summary

- Achievement guild news notifications were hardcoded in English regardless of the guild's language setting
- Added `achievement_title` and `achievement_desc` keys to `_NOTIFICATION_STRINGS` dict (both `en` and `de`)
- Wired the achievement handler to use localized strings, matching the existing pattern for mount and boss notifications
- Phrasing follows WoW's in-game text ("Erfolg errungen!" / "Achievement Earned!")

## Test plan

- [x] Set guild news language to `de`, verify achievement notifications show "Erfolg errungen!" title and "hat den Erfolg ... errungen" description
- [x] Set guild news language to `en`, verify achievement notifications show "Achievement Earned!" title and "has earned the achievement ..." description
- [x] Verify mount and boss notifications are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)