### PR TITLE
feat(errors): add error notification throttle & operator suppression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,3 +140,8 @@ Copy `NerdyPy/config.yaml.template` to `NerdyPy/config.yaml` and fill in:
 - **Markdown/YAML**: Prettier (run `prettier --write` on `.md`, `.yml`, `.yaml` files)
 - **Line endings**: LF
 - CI enforces `ruff check` and `ruff format --check` on PRs
+
+## Git
+
+- **Co-Authored-By**: `Co-Authored-By: Claude <noreply@anthropic.com>` (this is a GitHub repo)
+- **`docs/plans/`** is gitignored — never stage or commit plan files

--- a/NerdyPy/NerdyPy.py
+++ b/NerdyPy/NerdyPy.py
@@ -39,6 +39,7 @@ from utils import logging
 from utils.audio import Audio
 from utils.conversation import AnswerType, ConversationManager
 from utils.database import BASE
+from utils.error_throttle import ErrorThrottle
 from utils.errors import NerpyException, SilentCheckFailure
 from utils.helpers import error_context, notify_error, parse_id
 from utils.permissions import build_permissions_embed, check_guild_permissions, required_permissions_for
@@ -82,6 +83,7 @@ class NerpyBot(Bot):
         self.audio = Audio(self)
         self.convMan = ConversationManager(self)
         self._activity_cycle = cycle(ACTIVITIES)
+        self.error_throttle = ErrorThrottle()
 
         # database variables
         db_connection_string = self.build_connection_string(config)

--- a/NerdyPy/utils/error_throttle.py
+++ b/NerdyPy/utils/error_throttle.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+import time
+
+
+class ErrorThrottle:
+    """In-memory error notification throttle with global suppression.
+
+    Dedup key: ``{ExceptionType}:{context}``
+    Throttle window: 15 minutes (``THROTTLE_WINDOW`` seconds).
+    """
+
+    THROTTLE_WINDOW = 900  # 15 minutes
+
+    def __init__(self):
+        self._last_notified: dict[str, float] = {}
+        self._suppressed_count: dict[str, int] = {}
+        self._suppressed_until: float | None = None
+
+    @staticmethod
+    def _make_key(context: str, error: Exception) -> str:
+        return f"{type(error).__name__}:{context}"
+
+    def should_notify(self, context: str, error: Exception) -> bool:
+        """Return True if this error should trigger a DM notification."""
+        if self._suppressed_until is not None and time.monotonic() < self._suppressed_until:
+            return False
+
+        key = self._make_key(context, error)
+        now = time.monotonic()
+        last = self._last_notified.get(key)
+
+        if last is not None and (now - last) < self.THROTTLE_WINDOW:
+            self._suppressed_count[key] = self._suppressed_count.get(key, 0) + 1
+            return False
+
+        self._last_notified[key] = now
+        self._suppressed_count[key] = 0
+        return True
+
+    def suppress(self, seconds: float) -> None:
+        """Suppress all error notifications for *seconds*."""
+        self._suppressed_until = time.monotonic() + seconds
+
+    def resume(self) -> None:
+        """Cancel global suppression."""
+        self._suppressed_until = None
+
+    @property
+    def is_suppressed(self) -> bool:
+        if self._suppressed_until is None:
+            return False
+        return time.monotonic() < self._suppressed_until
+
+    @property
+    def suppressed_remaining(self) -> float | None:
+        """Seconds remaining on global suppression, or None."""
+        if self._suppressed_until is None:
+            return None
+        remaining = self._suppressed_until - time.monotonic()
+        return remaining if remaining > 0 else None
+
+    def get_status(self) -> dict:
+        """Return throttle state for the ``!errors status`` command."""
+        now = time.monotonic()
+        buckets = {}
+        for key, last in self._last_notified.items():
+            buckets[key] = {
+                "last_notified_ago": now - last,
+                "suppressed_count": self._suppressed_count.get(key, 0),
+            }
+        return {
+            "is_suppressed": self.is_suppressed,
+            "suppressed_remaining": self.suppressed_remaining,
+            "throttle_window": self.THROTTLE_WINDOW,
+            "buckets": buckets,
+        }

--- a/NerdyPy/utils/helpers.py
+++ b/NerdyPy/utils/helpers.py
@@ -100,6 +100,10 @@ async def notify_error(bot, context: str, error: Exception) -> None:
     if not recipients:
         return
 
+    if not bot.error_throttle.should_notify(context, error):
+        log.debug(f"Error notification throttled: {type(error).__name__} in {context}")
+        return
+
     tb = "".join(format_exception(type(error), error, error.__traceback__))
     # Truncate traceback to fit Discord's 2000-char message limit
     max_tb = 1400

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NerpyBot
 
+![AI-Powered](https://img.shields.io/badge/Developed%20with-AI-blue?style=for-the-badge&logo=anthropic&logoColor=white)
+
 The nerdiest Discord bot! Built with [discord.py](https://discordpy.readthedocs.io/) using the Cog extension system.
 Provides gaming integrations (WoW, League of Legends), moderation, and music playback.
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -62,6 +62,23 @@ Shows bot version and uptime. **Prefix-only, DM-only, operator-only** (user ID m
 
 Toggles debug logging at runtime. **Prefix-only, DM-only, operator-only** (user ID must be in `config.bot.ops`).
 
+### `!errors`
+
+Manage error notification throttling and suppression. **Prefix-only, DM-only, operator-only** (user ID must be in `config.bot.ops`).
+
+**Subcommands:**
+
+| Subcommand       | Description                                                  |
+| ---------------- | ------------------------------------------------------------ |
+| _(none)_         | Show usage help                                              |
+| `status`         | Show current throttle state with per-bucket error details    |
+| `suppress <dur>` | Suppress all error DMs for duration (e.g. `30m`, `2h`, `1d`) |
+| `resume`         | Cancel suppression and resume notifications                  |
+
+**Throttling:** Errors are automatically deduplicated by exception type + context. After the first DM for a given error, identical errors are suppressed for 15 minutes before sending another notification. This is always active — no configuration needed.
+
+**Suppression:** Operators can manually suppress all error DMs for a specified duration. Useful during deployments or known maintenance windows.
+
 ## Database Models
 
 ### `BotModeratorRole`

--- a/tests/modules/test_admin_errors.py
+++ b/tests/modules/test_admin_errors.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""Tests for admin !errors operator commands and duration helpers."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from modules.admin import Admin
+
+
+@pytest.fixture
+def admin_cog(mock_bot):
+    mock_bot.ops = [123456789]
+    mock_bot.error_throttle = MagicMock()
+    return Admin(mock_bot)
+
+
+@pytest.fixture
+def operator_ctx(mock_bot):
+    ctx = MagicMock()
+    ctx.bot = mock_bot
+    ctx.author = MagicMock()
+    ctx.author.id = 123456789  # in ops list
+    # require_operator() falls through to the Interaction branch for plain MagicMock
+    # (not isinstance Context), so provide .user and .client as well.
+    ctx.user = ctx.author
+    ctx.client = mock_bot
+    ctx.send = AsyncMock()
+    return ctx
+
+
+class TestErrorsHelp:
+    @pytest.mark.asyncio
+    async def test_no_action_shows_help(self, admin_cog, operator_ctx):
+        await admin_cog._errors.callback(admin_cog, operator_ctx, action=None)
+        operator_ctx.send.assert_awaited_once()
+        msg = operator_ctx.send.call_args[0][0]
+        assert "!errors status" in msg
+        assert "!errors suppress" in msg
+        assert "!errors resume" in msg
+
+
+class TestErrorsSuppress:
+    @pytest.mark.asyncio
+    async def test_suppress_valid_duration(self, admin_cog, operator_ctx):
+        await admin_cog._errors.callback(admin_cog, operator_ctx, action="suppress", arg="30m")
+        admin_cog.bot.error_throttle.suppress.assert_called_once_with(1800)
+
+    @pytest.mark.asyncio
+    async def test_suppress_missing_duration(self, admin_cog, operator_ctx):
+        await admin_cog._errors.callback(admin_cog, operator_ctx, action="suppress", arg=None)
+        admin_cog.bot.error_throttle.suppress.assert_not_called()
+        msg = operator_ctx.send.call_args[0][0]
+        assert "Usage" in msg
+
+    @pytest.mark.asyncio
+    async def test_suppress_invalid_duration(self, admin_cog, operator_ctx):
+        await admin_cog._errors.callback(admin_cog, operator_ctx, action="suppress", arg="banana")
+        admin_cog.bot.error_throttle.suppress.assert_not_called()
+        msg = operator_ctx.send.call_args[0][0]
+        assert "Invalid" in msg
+
+
+class TestErrorsResume:
+    @pytest.mark.asyncio
+    async def test_resume_when_suppressed(self, admin_cog, operator_ctx):
+        admin_cog.bot.error_throttle.is_suppressed = True
+        await admin_cog._errors.callback(admin_cog, operator_ctx, action="resume")
+        admin_cog.bot.error_throttle.resume.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resume_when_not_suppressed(self, admin_cog, operator_ctx):
+        admin_cog.bot.error_throttle.is_suppressed = False
+        await admin_cog._errors.callback(admin_cog, operator_ctx, action="resume")
+        admin_cog.bot.error_throttle.resume.assert_not_called()
+        msg = operator_ctx.send.call_args[0][0]
+        assert "already active" in msg
+
+
+class TestErrorsStatus:
+    @pytest.mark.asyncio
+    async def test_status_active_with_buckets(self, admin_cog, operator_ctx):
+        admin_cog.bot.error_throttle.get_status.return_value = {
+            "is_suppressed": False,
+            "suppressed_remaining": None,
+            "throttle_window": 900,
+            "buckets": {
+                "ValueError:Reminder loop": {"last_notified_ago": 300.0, "suppressed_count": 2},
+            },
+        }
+        await admin_cog._errors.callback(admin_cog, operator_ctx, action="status")
+        msg = operator_ctx.send.call_args[0][0]
+        assert "\U0001f514" in msg
+        assert "ValueError:Reminder loop" in msg
+        assert "2 suppressed" in msg
+
+    @pytest.mark.asyncio
+    async def test_status_suppressed(self, admin_cog, operator_ctx):
+        admin_cog.bot.error_throttle.get_status.return_value = {
+            "is_suppressed": True,
+            "suppressed_remaining": 5000.0,
+            "throttle_window": 900,
+            "buckets": {},
+        }
+        await admin_cog._errors.callback(admin_cog, operator_ctx, action="status")
+        msg = operator_ctx.send.call_args[0][0]
+        assert "\U0001f507" in msg
+
+    @pytest.mark.asyncio
+    async def test_status_no_buckets(self, admin_cog, operator_ctx):
+        admin_cog.bot.error_throttle.get_status.return_value = {
+            "is_suppressed": False,
+            "suppressed_remaining": None,
+            "throttle_window": 900,
+            "buckets": {},
+        }
+        await admin_cog._errors.callback(admin_cog, operator_ctx, action="status")
+        msg = operator_ctx.send.call_args[0][0]
+        assert "No errors tracked" in msg
+
+
+class TestErrorsUnknownAction:
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, admin_cog, operator_ctx):
+        await admin_cog._errors.callback(admin_cog, operator_ctx, action="foobar")
+        msg = operator_ctx.send.call_args[0][0]
+        assert "Unknown action" in msg
+
+
+class TestParseDuration:
+    def test_minutes(self):
+        assert Admin._parse_duration("30m") == 1800
+
+    def test_hours(self):
+        assert Admin._parse_duration("2h") == 7200
+
+    def test_days(self):
+        assert Admin._parse_duration("1d") == 86400
+
+    def test_with_spaces(self):
+        assert Admin._parse_duration(" 15 m ") == 900
+
+    def test_invalid_returns_none(self):
+        assert Admin._parse_duration("banana") is None
+
+    def test_empty_returns_none(self):
+        assert Admin._parse_duration("") is None
+
+
+class TestFormatRemaining:
+    def test_seconds(self):
+        assert Admin._format_remaining(45) == "45s"
+
+    def test_minutes(self):
+        assert Admin._format_remaining(300) == "5m"
+
+    def test_hours_and_minutes(self):
+        assert Admin._format_remaining(4980) == "1h 23m"
+
+    def test_days_and_hours(self):
+        assert Admin._format_remaining(90000) == "1d 1h"
+
+    def test_exact_hour(self):
+        assert Admin._format_remaining(3600) == "1h"

--- a/tests/utils/test_error_throttle.py
+++ b/tests/utils/test_error_throttle.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+import time
+from unittest.mock import patch
+
+from utils.error_throttle import ErrorThrottle
+
+
+class TestShouldNotify:
+    def test_first_error_always_notifies(self):
+        throttle = ErrorThrottle()
+        assert throttle.should_notify("Reminder loop", ValueError("boom")) is True
+
+    def test_same_error_within_window_is_suppressed(self):
+        throttle = ErrorThrottle()
+        throttle.should_notify("Reminder loop", ValueError("boom"))
+        assert throttle.should_notify("Reminder loop", ValueError("boom")) is False
+
+    def test_different_context_is_separate_bucket(self):
+        throttle = ErrorThrottle()
+        throttle.should_notify("Reminder loop", ValueError("boom"))
+        assert throttle.should_notify("Moderation loop", ValueError("boom")) is True
+
+    def test_different_error_type_is_separate_bucket(self):
+        throttle = ErrorThrottle()
+        throttle.should_notify("Reminder loop", ValueError("boom"))
+        assert throttle.should_notify("Reminder loop", TypeError("boom")) is True
+
+    def test_notifies_again_after_window_expires(self):
+        throttle = ErrorThrottle()
+        throttle.should_notify("Reminder loop", ValueError("boom"))
+
+        # Fast-forward past the throttle window
+        with patch("utils.error_throttle.time") as mock_time:
+            mock_time.monotonic.return_value = time.monotonic() + throttle.THROTTLE_WINDOW + 1
+            assert throttle.should_notify("Reminder loop", ValueError("boom")) is True
+
+
+class TestGlobalSuppression:
+    def test_suppress_blocks_all_notifications(self):
+        throttle = ErrorThrottle()
+        throttle.suppress(3600)
+        assert throttle.should_notify("Reminder loop", ValueError("boom")) is False
+
+    def test_resume_cancels_suppression(self):
+        throttle = ErrorThrottle()
+        throttle.suppress(3600)
+        throttle.resume()
+        assert throttle.should_notify("Reminder loop", ValueError("boom")) is True
+
+    def test_is_suppressed_property(self):
+        throttle = ErrorThrottle()
+        assert throttle.is_suppressed is False
+        throttle.suppress(3600)
+        assert throttle.is_suppressed is True
+        throttle.resume()
+        assert throttle.is_suppressed is False
+
+    def test_suppressed_remaining(self):
+        throttle = ErrorThrottle()
+        assert throttle.suppressed_remaining is None
+        throttle.suppress(3600)
+        remaining = throttle.suppressed_remaining
+        assert remaining is not None
+        assert 3599 < remaining <= 3600
+
+
+class TestBucketTracking:
+    def test_suppressed_count_increments(self):
+        throttle = ErrorThrottle()
+        throttle.should_notify("Reminder loop", ValueError("boom"))
+        throttle.should_notify("Reminder loop", ValueError("boom"))
+        throttle.should_notify("Reminder loop", ValueError("boom"))
+
+        status = throttle.get_status()
+        bucket = status["buckets"]["ValueError:Reminder loop"]
+        assert bucket["suppressed_count"] == 2
+
+    def test_suppressed_count_resets_on_notify(self):
+        throttle = ErrorThrottle()
+        throttle.should_notify("Reminder loop", ValueError("boom"))
+        throttle.should_notify("Reminder loop", ValueError("boom"))  # suppressed, count=1
+
+        with patch("utils.error_throttle.time") as mock_time:
+            mock_time.monotonic.return_value = time.monotonic() + throttle.THROTTLE_WINDOW + 1
+            throttle.should_notify("Reminder loop", ValueError("boom"))  # notifies again, resets count
+
+        status = throttle.get_status()
+        bucket = status["buckets"]["ValueError:Reminder loop"]
+        assert bucket["suppressed_count"] == 0
+
+    def test_get_status_contains_all_buckets(self):
+        throttle = ErrorThrottle()
+        throttle.should_notify("Reminder loop", ValueError("boom"))
+        throttle.should_notify("WoW loop", TypeError("fail"))
+
+        status = throttle.get_status()
+        assert "ValueError:Reminder loop" in status["buckets"]
+        assert "TypeError:WoW loop" in status["buckets"]
+
+    def test_get_status_shows_suppression_state(self):
+        throttle = ErrorThrottle()
+        status = throttle.get_status()
+        assert status["is_suppressed"] is False
+
+        throttle.suppress(3600)
+        status = throttle.get_status()
+        assert status["is_suppressed"] is True
+        assert status["suppressed_remaining"] is not None


### PR DESCRIPTION
## Summary

- Add `ErrorThrottle` utility class with 15-minute dedup window — groups errors by exception type + context, prevents duplicate DMs for recurring errors
- Wire throttle into `notify_error()` — all existing callers (reminder, moderation, wow, reactionrole, slash commands) get throttling automatically
- Add `!errors` operator commands (DM-only, prefix-only):
  - `!errors status` — show per-bucket error details and suppression state
  - `!errors suppress <dur>` — mute all error DMs for a duration (e.g. `30m`, `2h`, `1d`)
  - `!errors resume` — cancel suppression

## Test plan

- [x] 13 unit tests for `ErrorThrottle` (dedup, window expiry, global suppression, bucket tracking)
- [x] 21 tests for `!errors` commands (help, suppress, resume, status, duration parsing, formatting)
- [x] Full suite: 241/241 passing
- [x] Manual: trigger a recurring error (e.g. bad DB column) and verify DMs are throttled to one per 15 minutes
- [x] Manual: `!errors suppress 5m` in bot DMs, verify no error DMs for 5 minutes
- [x] Manual: `!errors status` shows tracked error buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)