### PR TITLE
chore(ci): standardize CI/CD workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,172 +1,188 @@
-name: Build Docker Images
+name: Build & Push Docker Images
 
 on:
   push:
-    branches:
-      - "main"
-    tags:
-      - "v*"
+    branches: [main]
+    tags: ["v*"]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "NerdyPy/**"
+      - "database-migrations/**"
+      - "alembic-*.ini"
+      - ".github/workflows/build.yml"
   pull_request:
-    branches:
-      - "main"
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "NerdyPy/**"
+      - "database-migrations/**"
+      - "alembic-*.ini"
+      - ".github/workflows/build.yml"
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  changed_files:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    outputs:
-      changed_python: ${{ steps.changed_python.outputs.modified_keys }}
-      changed_docker: ${{ steps.changed_docker.outputs.any_changed }}
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Get all src files that have changed
-        id: changed_python
-        uses: tj-actions/changed-files@v47
-        with:
-          files_yaml: |
-            database-migrations:
-              - database-migrations/**
-              - alembic-nerpybot.ini
-              - alembic-humanmusic.ini
-            nerpybot:
-              - NerdyPy/**
-              - '!NerdyPy/**.template'
-              - pyproject.toml
-              - uv.lock
-
-      - name: Get all Docker related files that have changed
-        id: changed_docker
-        uses: tj-actions/changed-files@v47
-        with:
-          files: |
-            Dockerfile
-            .dockerignore
-
-  build_db_migrations:
-    needs:
-      - changed_files
-    if: contains(needs.changed_files.outputs.changed_python, 'database-migrations') || needs.changed_files.outputs.changed_docker == 'true'
+  build-bot:
+    name: Build NerpyBot Image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Docker Container Meta
-        id: docker_meta_database-migrations
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-database-migrations
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Github Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build Database Migrations
-        uses: docker/build-push-action@v6
-        with:
-          target: migrations
-          load: true
-          tags: nerpybot-migrations:smoke-test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Smoke test Database Migrations
-        run: |
-          docker run --rm nerpybot-migrations:smoke-test alembic -c alembic-nerpybot.ini heads
-          docker run --rm -e ALEMBIC_CONFIG=alembic-humanmusic.ini nerpybot-migrations:smoke-test alembic -c alembic-humanmusic.ini heads
-
-      - name: Push Database Migrations
-        if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v6
-        with:
-          target: migrations
-          push: true
-          tags: ${{ steps.docker_meta_database-migrations.outputs.tags }}
-          labels: ${{ steps.docker_meta_database-migrations.outputs.labels }}
-          cache-from: type=gha
-
-  build_nerdybot:
-    needs:
-      - changed_files
-    if: contains(needs.changed_files.outputs.changed_python, 'nerpybot') || needs.changed_files.outputs.changed_docker == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Docker Container Meta
-        id: docker_meta_nerpybot
+      - name: Docker metadata
+        id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Set up QEMU
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Github Container Registry
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Nerpybot
+      - name: Build (PR smoke test)
+        if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
         with:
+          context: .
           target: bot
           load: true
           tags: nerpybot:smoke-test
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Smoke test Nerpybot
+      - name: Smoke test NerpyBot
+        if: github.event_name == 'pull_request'
         run: |
           docker run --rm nerpybot:smoke-test python -c "from NerdyPy import NerpyBot; print('OK')"
 
-      - name: Push Nerpybot
+      - name: Build and push (multi-arch)
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
+          context: .
           target: bot
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.docker_meta_nerpybot.outputs.tags }}
-          labels: ${{ steps.docker_meta_nerpybot.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify pushed image
+        if: github.event_name != 'pull_request'
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_SHA::7}"
+          docker pull "${IMAGE}"
+          docker run --rm "${IMAGE}" python -c "from NerdyPy import NerpyBot; print('OK')"
+          echo "✅ NerpyBot image verified"
+
+  build-migrations:
+    name: Build Migrations Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-database-migrations
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Set up QEMU
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (PR smoke test)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: migrations
+          load: true
+          tags: nerpybot-migrations:smoke-test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test migrations
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm nerpybot-migrations:smoke-test alembic -c alembic-nerpybot.ini heads
+          docker run --rm -e ALEMBIC_CONFIG=alembic-humanmusic.ini nerpybot-migrations:smoke-test alembic -c alembic-humanmusic.ini heads
+
+      - name: Build and push (multi-arch)
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: migrations
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify pushed image
+        if: github.event_name != 'pull_request'
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-database-migrations:${GITHUB_SHA::7}"
+          docker pull "${IMAGE}"
+          docker run --rm "${IMAGE}" alembic -c alembic-nerpybot.ini heads
+          echo "✅ Migrations image verified"

--- a/.github/workflows/release-badge.yml
+++ b/.github/workflows/release-badge.yml
@@ -1,0 +1,40 @@
+name: Update Release Badge
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  update-badge:
+    name: Update Version Badge
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Get version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Update README.md
+        run: |
+          sed -i "s/badge\/Version-.*-green/badge\/Version-${{ env.VERSION }}-green/" README.md
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "docs: Update release badge to version ${{ env.VERSION }}"
+          title: "docs: Update release badge to version ${{ env.VERSION }}"
+          body: |
+            Automated PR to update the version badge in README.md to `${{ env.VERSION }}`.
+
+            Triggered by tag: `${{ github.ref_name }}`
+          branch: docs/update-badge-${{ env.VERSION }}
+          delete-branch: true
+          labels: documentation,automated

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,12 @@
-name: Check Code Formatting and Tests
+name: Tests & Lint
 
 on:
   pull_request:
-    branches:
-      - "main"
+    branches: [main]
 
 jobs:
   lint:
+    name: Ruff Lint & Format Check
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -14,13 +14,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/ruff-action@v3
+      - name: Run Ruff linter
+        uses: astral-sh/ruff-action@v3
         with:
-          args: "--version"
-      - run: ruff check --diff
-      - run: ruff format --check --diff
+          args: "check --output-format=github"
+
+      - name: Run Ruff formatter check
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check --diff"
 
   test:
+    name: Run Tests
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # NerpyBot
 
+[![Release](https://img.shields.io/badge/Version-0.0.0-green?style=for-the-badge)](https://github.com/nerdycraft/NerpyBot/releases)
 ![AI-Powered](https://img.shields.io/badge/Developed%20with-AI-blue?style=for-the-badge&logo=anthropic&logoColor=white)
 
 The nerdiest Discord bot! Built with [discord.py](https://discordpy.readthedocs.io/) using the Cog extension system.


### PR DESCRIPTION
## Summary

- **Rename lint job** to "Ruff Lint & Format Check" for cross-repo consistency
- **Switch to `astral-sh/ruff-action@v3`** (matches PandaProxy pattern, simpler than `uv run ruff`)
- **Replace `tj-actions/changed-files`** with GitHub-native `paths:` filters (fewer dependencies, simpler logic)
- **Add QEMU multi-arch builds** (`linux/amd64` + `linux/arm64`) for both bot and migrations images
- **Add post-push image verification** (pull pushed image back and run smoke test)
- **Add `release-badge.yml`** for automatic version badge updates on tag push
- **Add version badge** to README.md (for release-badge.yml to update)
- **Fix shellcheck SC2086** in `release-badge.yml`

These changes align NerpyBot's CI with the standardized patterns used across the NerdyCraft org.

## Test plan

- [x] Verify `test.yml` lint job runs as "Ruff Lint & Format Check"
- [x] Verify `test.yml` test job runs pytest with coverage
- [x] Verify `build.yml` smoke tests both bot and migrations images on PR
- [ ] Verify `build.yml` builds multi-arch and verifies on push to main
- [ ] Verify `release-badge.yml` syntax is valid (will activate on next tag push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)