### PR TITLE
fix(ci): lowercase image names in docker verify steps

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Verify pushed image
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_SHA::7}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME,,}:${GITHUB_SHA::7}"
           docker pull "${IMAGE}"
           docker run --rm "${IMAGE}" python -c "from NerdyPy import NerpyBot; print('OK')"
           echo "✅ NerpyBot image verified"
@@ -130,7 +130,7 @@ jobs:
 
       - name: Verify pushed image
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-database-migrations:${GITHUB_SHA::7}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME,,}-database-migrations:${GITHUB_SHA::7}"
           docker pull "${IMAGE}"
           docker run --rm "${IMAGE}" alembic -c alembic-nerpybot.ini heads
           echo "✅ Migrations image verified"


### PR DESCRIPTION
## Summary

- Fix Docker image verification failing with `invalid reference format: repository name must be lowercase`
- Both verify steps in `docker.yml` used `${{ env.IMAGE_NAME }}` which resolves to `nerdycraft/NerpyBot` (uppercase N from `github.repository`) — Docker rejects this
- Replace with bash `${IMAGE_NAME,,}` parameter expansion to ensure lowercase references

Fixes the failure in: https://github.com/nerdycraft/NerpyBot/actions/runs/22183253258

## Test plan

- [ ] Merge and verify the `Build & Push Docker Images` workflow passes on `main`
- [ ] Confirm both "Verify pushed image" steps succeed for bot and migrations images

🤖 Generated with [Claude Code](https://claude.com/claude-code)