### PR TITLE
fix(wow): demote initial sync summary to debug log level

### DIFF
--- a/NerdyPy/modules/wow.py
+++ b/NerdyPy/modules/wow.py
@@ -1206,7 +1206,7 @@ class WorldofWarcraft(GroupCog, group_name="wow"):
                     config_record.AccountGroupData = json.dumps(temporal_data)
 
         if initial_sync and not rate_limited.is_set():
-            self.bot.log.info(
+            self.bot.log.debug(
                 f"Guild news #{config_id}: initial sync finished in {batch_num} batches — "
                 f"baselined={total_stats['baselined']}, skipped_inactive={total_stats['skipped_inactive']}, "
                 f"skipped_error={total_stats['skipped_error']}, skipped_degraded={total_stats['skipped_degraded']}, "


### PR DESCRIPTION
## Summary
- Demotes the per-guild initial sync summary log (`initial sync finished in N batches — baselined=…, skipped_…=…`) from INFO to DEBUG
- Reduces noise in production logs while keeping the diagnostic detail accessible via `-d` flag

## Test plan
- [x] Start bot normally — verify the sync summary no longer appears in INFO output
- [x] Start bot with `uv run nerpybot -d` — verify the sync summary still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)