### PR TITLE
fix: improve error handling in audio, reactionrole, and rolemanage

### DIFF
--- a/NerdyPy/modules/reactionrole.py
+++ b/NerdyPy/modules/reactionrole.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from discord import Interaction, Role, TextChannel, app_commands
+from discord import Forbidden, Interaction, NotFound, Role, TextChannel, app_commands
 from discord.app_commands import checks
 from discord.ext.commands import Cog, GroupCog
 
@@ -151,7 +151,8 @@ class ReactionRole(GroupCog, group_name="reactionrole"):
 
         try:
             discord_msg = await channel.fetch_message(msg_id)
-        except Exception:
+        except (NotFound, Forbidden) as ex:
+            self.bot.log.warning(f"{error_context(interaction)}: fetch_message({msg_id}) in #{channel.name}: {ex}")
             await interaction.response.send_message(
                 f"Could not find message `{msg_id}` in {channel.mention}.", ephemeral=True
             )

--- a/NerdyPy/modules/rolemanage.py
+++ b/NerdyPy/modules/rolemanage.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from discord import Interaction, Member, Role, app_commands
+from discord import Forbidden, HTTPException, Interaction, Member, Role, app_commands
 from discord.app_commands import checks
 from discord.ext.commands import GroupCog
 
@@ -149,9 +149,20 @@ class RoleManage(GroupCog, group_name="rolemanage"):
 
         try:
             await member.add_roles(role, reason=f"Delegated role assign by {interaction.user}")
-        except Exception as ex:
-            self.bot.log.error(f"{error_context(interaction)}: failed to assign role {role.name} to {member}: {ex}")
-            await interaction.response.send_message(f"Failed to assign role: {ex}", ephemeral=True)
+        except Forbidden:
+            self.bot.log.error(f"{error_context(interaction)}: forbidden assigning {role.name} to {member}")
+            await interaction.response.send_message(
+                f"I don't have permission to assign **{role.name}**. "
+                "Make sure I have the `Manage Roles` permission and my highest role is above that role.",
+                ephemeral=True,
+            )
+            return
+        except HTTPException as ex:
+            self.bot.log.error(f"{error_context(interaction)}: failed to assign {role.name} to {member}: {ex}")
+            await interaction.response.send_message(
+                f"Discord error while assigning role (HTTP {ex.status}). Please try again.",
+                ephemeral=True,
+            )
             return
 
         await interaction.response.send_message(
@@ -197,9 +208,20 @@ class RoleManage(GroupCog, group_name="rolemanage"):
 
         try:
             await member.remove_roles(role, reason=f"Delegated role remove by {interaction.user}")
-        except Exception as ex:
-            self.bot.log.error(f"{error_context(interaction)}: failed to remove role {role.name} from {member}: {ex}")
-            await interaction.response.send_message(f"Failed to remove role: {ex}", ephemeral=True)
+        except Forbidden:
+            self.bot.log.error(f"{error_context(interaction)}: forbidden removing {role.name} from {member}")
+            await interaction.response.send_message(
+                f"I don't have permission to remove **{role.name}**. "
+                "Make sure I have the `Manage Roles` permission and my highest role is above that role.",
+                ephemeral=True,
+            )
+            return
+        except HTTPException as ex:
+            self.bot.log.error(f"{error_context(interaction)}: failed to remove {role.name} from {member}: {ex}")
+            await interaction.response.send_message(
+                f"Discord error while removing role (HTTP {ex.status}). Please try again.",
+                ephemeral=True,
+            )
             return
 
         await interaction.response.send_message(

--- a/NerdyPy/utils/audio.py
+++ b/NerdyPy/utils/audio.py
@@ -218,7 +218,7 @@ class Audio:
         if self._has_buffer(guild_id):
             if self.buffer[guild_id].get(BufferKey.QUEUE) is not None:
                 return list(self.buffer[guild_id].get(BufferKey.QUEUE).queue)
-        return None
+        return []
 
     def stop(self, guild_id):
         """Stops current audio from playing"""


### PR DESCRIPTION
## Summary
- **audio.py**: Return `[]` instead of `None` from `list_queue()` to prevent `TypeError` when callers slice the result
- **reactionrole.py**: Narrow bare `except Exception` to `(NotFound, Forbidden)` with logging when fetching messages
- **rolemanage.py**: Split broad `except Exception` on `add_roles`/`remove_roles` into specific `Forbidden` and `HTTPException` handlers with actionable user messages (e.g. "Make sure I have the `Manage Roles` permission")

## Test plan
- [x] All 330 tests pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)