### PR TITLE
refactor: introduce NerpyBotCog base class and register_before_loop

### DIFF
--- a/NerdyPy/modules/admin.py
+++ b/NerdyPy/modules/admin.py
@@ -14,6 +14,7 @@ from models.botmod import BotModeratorRole
 from models.permissions import PermissionSubscriber
 
 from utils.checks import is_admin_or_operator, require_operator
+from utils.cog import NerpyBotCog
 from utils.errors import NerpyException
 from utils.permissions import build_permissions_embed, check_guild_permissions, required_permissions_for
 
@@ -46,18 +47,13 @@ def _format_remaining(seconds: float) -> str:
 
 
 @app_commands.default_permissions(administrator=True)
-class Admin(Cog):
+class Admin(NerpyBotCog, Cog):
     """cog for administrative usage"""
 
     modrole = app_commands.Group(
         name="modrole", description="Manage the bot-moderator role for this server", guild_only=True
     )
     botpermissions = app_commands.Group(name="botpermissions", description="Check bot permissions", guild_only=True)
-
-    def __init__(self, bot):
-        bot.log.info(f"loaded {__name__}")
-
-        self.bot = bot
 
     async def interaction_check(self, interaction: Interaction) -> bool:
         """Allow administrators and bot operators to use all admin slash commands."""

--- a/NerdyPy/modules/league.py
+++ b/NerdyPy/modules/league.py
@@ -6,6 +6,7 @@ from typing import Literal
 from aiohttp import ClientSession
 from discord import Color, Embed, Interaction, app_commands
 from discord.ext.commands import GroupCog
+from utils.cog import NerpyBotCog
 from utils.errors import NerpyException
 from utils.helpers import error_context
 
@@ -19,13 +20,11 @@ class LeagueCommand(Enum):
 
 @app_commands.guild_only()
 @app_commands.checks.bot_has_permissions(send_messages=True, embed_links=True)
-class League(GroupCog):
+class League(NerpyBotCog, GroupCog):
     """league of legends related stuff"""
 
     def __init__(self, bot):
-        bot.log.info(f"loaded {__name__}")
-
-        self.bot = bot
+        super().__init__(bot)
         self.version = None
         self.config = self.bot.config["league"]
 

--- a/NerdyPy/modules/leavemsg.py
+++ b/NerdyPy/modules/leavemsg.py
@@ -5,6 +5,7 @@ from discord import Interaction, Member, TextChannel, app_commands
 from discord.app_commands import checks
 from discord.ext.commands import Cog, GroupCog
 from models.leavemsg import LeaveMessage
+from utils.cog import NerpyBotCog
 
 from utils.errors import NerpyException
 from utils.permissions import validate_channel_permissions
@@ -15,12 +16,8 @@ DEFAULT_LEAVE_MESSAGE = "{member} left the server :("
 
 @app_commands.default_permissions(administrator=True)
 @app_commands.guild_only()
-class LeaveMsg(GroupCog, group_name="leavemsg"):
+class LeaveMsg(NerpyBotCog, GroupCog, group_name="leavemsg"):
     """Cog for managing server leave messages"""
-
-    def __init__(self, bot):
-        bot.log.info(f"loaded {__name__}")
-        self.bot = bot
 
     @Cog.listener()
     async def on_member_remove(self, member: Member) -> None:

--- a/NerdyPy/modules/music.py
+++ b/NerdyPy/modules/music.py
@@ -5,22 +5,21 @@ from discord.ext.commands import GroupCog
 
 from utils.audio import QueuedSong, QueueMixin
 from utils.checks import can_stop_playback, is_connected_to_voice
+from utils.cog import NerpyBotCog
 from utils.download import download, fetch_yt_infos
 from utils.helpers import error_context, youtube
 
 
 @app_commands.guild_only()
 @app_commands.checks.bot_has_permissions(send_messages=True, speak=True)
-class Music(QueueMixin, GroupCog):
+class Music(NerpyBotCog, QueueMixin, GroupCog):
     """Command group for sound and text tags"""
 
     queue_group = app_commands.Group(name="queue", description="Manage the Playlist Queue")
     play = app_commands.Group(name="play", description="Play music from YouTube and more")
 
     def __init__(self, bot):
-        bot.log.info(f"loaded {__name__}")
-
-        self.bot = bot
+        super().__init__(bot)
         self.config = self.bot.config["music"]
         self.queue = {}
         self.audio = self.bot.audio

--- a/NerdyPy/modules/raidplaner.py
+++ b/NerdyPy/modules/raidplaner.py
@@ -6,16 +6,12 @@ from enum import Enum
 from discord import Embed
 from discord.ext.commands import Cog, Context, command
 from models.raidplaner import RaidEncounter, RaidEncounterRole, RaidEvent, RaidTemplate
+from utils.cog import NerpyBotCog
 from utils.conversation import Conversation
 
 
-class RaidPlaner(Cog):
+class RaidPlaner(NerpyBotCog, Cog):
     """cog for administrative usage"""
-
-    def __init__(self, bot):
-        bot.log.info(f"loaded {__name__}")
-
-        self.bot = bot
 
     @command()
     async def raidplaner(self, ctx: Context):

--- a/NerdyPy/modules/reactionrole.py
+++ b/NerdyPy/modules/reactionrole.py
@@ -5,6 +5,7 @@ from discord.app_commands import checks
 from discord.ext.commands import Cog, GroupCog
 
 from models.reactionrole import ReactionRoleEntry, ReactionRoleMessage
+from utils.cog import NerpyBotCog
 
 from utils.checks import is_role_below_bot
 from utils.helpers import error_context, notify_error, send_paginated
@@ -13,12 +14,8 @@ from utils.permissions import validate_channel_permissions
 
 @app_commands.default_permissions(manage_roles=True)
 @app_commands.guild_only()
-class ReactionRole(GroupCog, group_name="reactionrole"):
+class ReactionRole(NerpyBotCog, GroupCog, group_name="reactionrole"):
     """cog for managing reaction-based role assignment"""
-
-    def __init__(self, bot):
-        bot.log.info(f"loaded {__name__}")
-        self.bot = bot
 
     async def _message_id_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
         with self.bot.session_scope() as session:

--- a/NerdyPy/modules/rolemanage.py
+++ b/NerdyPy/modules/rolemanage.py
@@ -6,16 +6,13 @@ from discord.ext.commands import GroupCog
 
 from models.rolemanage import RoleMapping
 from utils.checks import is_role_assignable, is_role_below_bot
+from utils.cog import NerpyBotCog
 from utils.helpers import error_context, send_paginated
 
 
 @app_commands.guild_only()
-class RoleManage(GroupCog, group_name="rolemanage"):
+class RoleManage(NerpyBotCog, GroupCog, group_name="rolemanage"):
     """cog for delegated role management — lets specific roles assign other roles"""
-
-    def __init__(self, bot):
-        bot.log.info(f"loaded {__name__}")
-        self.bot = bot
 
     def _has_source_role(self, member, mappings):
         """check if the member holds any source role from the given mappings"""

--- a/NerdyPy/modules/tagging.py
+++ b/NerdyPy/modules/tagging.py
@@ -11,6 +11,7 @@ from models.tagging import Tag, TagType
 
 from utils.audio import QueuedSong, QueueMixin
 from utils.checks import can_stop_playback, is_connected_to_voice
+from utils.cog import NerpyBotCog
 from utils.download import download
 from utils.errors import NerpyException
 from utils.helpers import error_context, send_paginated
@@ -18,15 +19,13 @@ from utils.helpers import error_context, send_paginated
 
 @app_commands.guild_only()
 @app_commands.checks.bot_has_permissions(send_messages=True)
-class Tagging(QueueMixin, GroupCog, group_name="tag"):
+class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
     """Command group for sound and text tags"""
 
     queue_group = app_commands.Group(name="queue", description="Manage the Tag Queue")
 
     def __init__(self, bot):
-        bot.log.info(f"loaded {__name__}")
-
-        self.bot = bot
+        super().__init__(bot)
         self.queue = {}
         self.audio = self.bot.audio
 

--- a/NerdyPy/modules/voicecontrol.py
+++ b/NerdyPy/modules/voicecontrol.py
@@ -4,15 +4,12 @@ from discord import Interaction, app_commands
 from discord.ext.commands import Cog
 
 from utils.checks import can_leave_voice, can_stop_playback
+from utils.cog import NerpyBotCog
 
 
 @app_commands.guild_only()
-class VoiceControl(Cog):
+class VoiceControl(NerpyBotCog, Cog):
     """commands for controlling bot voice playback"""
-
-    def __init__(self, bot):
-        bot.log.info(f"loaded {__name__}")
-        self.bot = bot
 
     @app_commands.command(name="stop")
     @app_commands.guild_only()

--- a/NerdyPy/utils/cog.py
+++ b/NerdyPy/utils/cog.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+
+class NerpyBotCog:
+    """Base mixin for NerpyBot cogs — sets ``self.bot`` and logs module load."""
+
+    def __init__(self, bot):
+        super().__init__()
+        self.bot = bot
+        bot.log.info(f"loaded {self.__module__}")

--- a/NerdyPy/utils/helpers.py
+++ b/NerdyPy/utils/helpers.py
@@ -121,6 +121,15 @@ async def notify_error(bot, context: str, error: Exception) -> None:
             log.debug(f"Could not DM error notification to {uid}: {dm_err}")
 
 
+def register_before_loop(bot, loop, label: str):
+    """Register a standard before_loop handler that waits for the bot to be ready."""
+
+    @loop.before_loop
+    async def _before(*_args):
+        bot.log.info(f"{label}: Waiting for Bot to be ready...")
+        await bot.wait_until_ready()
+
+
 def youtube(yt_key: str, return_type: str, query: str) -> str | None:
     yt = build("youtube", "v3", developerKey=yt_key)
     search_response = yt.search().list(q=query, part="id,snippet", type="video", maxResults=1).execute()


### PR DESCRIPTION
## Summary
- New `NerpyBotCog` mixin in `utils/cog.py` — handles `self.bot = bot` assignment and `bot.log.info(f"loaded {self.__module__}")` for all 12 cog modules
- 6 simple modules drop their `__init__` entirely (admin, leavemsg, raidplaner, reactionrole, rolemanage, voicecontrol)
- 6 modules with extra state use `super().__init__(bot)` to delegate the boilerplate
- New `register_before_loop(bot, loop, label)` helper in `utils/helpers.py` replaces 4 identical `before_loop` methods across moderation (2), reminder (1), and wow (1)
- Net reduction of 22 lines across 14 files

## Test plan
- [x] All 330 tests pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)