### PR TITLE
refactor: add type hints to format.py and helpers.py, cache weekday names

### DIFF
--- a/NerdyPy/modules/reminder.py
+++ b/NerdyPy/modules/reminder.py
@@ -28,6 +28,8 @@ WEEKDAY_MAP = {
     "Sunday": 6,
 }
 
+_WEEKDAY_NAMES = list(WEEKDAY_MAP.keys())
+
 # Pre-sorted timezone list for autocomplete
 _TZ_NAMES = sorted(available_timezones())
 
@@ -351,7 +353,7 @@ class Reminder(GroupCog, group_name="reminder"):
                 elif (
                     msg.ScheduleType == "weekly" and msg.ScheduleTime is not None and msg.ScheduleDayOfWeek is not None
                 ):
-                    day_name = list(WEEKDAY_MAP.keys())[msg.ScheduleDayOfWeek]
+                    day_name = _WEEKDAY_NAMES[msg.ScheduleDayOfWeek]
                     tz_label = msg.Timezone or "UTC"
                     schedule_info = f"weekly {day_name} at {msg.ScheduleTime.strftime('%H:%M')} {tz_label}"
                 elif (
@@ -481,7 +483,7 @@ class Reminder(GroupCog, group_name="reminder"):
 
             if day_of_week is not None:
                 msg.ScheduleDayOfWeek = day_of_week.value
-                day_name = list(WEEKDAY_MAP.keys())[day_of_week.value]
+                day_name = _WEEKDAY_NAMES[day_of_week.value]
                 changes.append(f"day → {day_name}")
                 timing_changed = True
 

--- a/NerdyPy/utils/format.py
+++ b/NerdyPy/utils/format.py
@@ -1,38 +1,40 @@
 # -*- coding: utf-8 -*-
 """discord and other format functions"""
 
+from collections.abc import Generator
 
-def box(text, lang=""):
+
+def box(text: str, lang: str = "") -> str:
     """discord format for box with optional language highlighting"""
     return f"```{lang}\n{text}\n```"
 
 
-def inline(text):
+def inline(text: str) -> str:
     """discord format for inline box"""
     return f"`{text}`"
 
 
-def italics(text):
-    """discord format for itallic text"""
+def italics(text: str) -> str:
+    """discord format for italic text"""
     return f"*{text}*"
 
 
-def bold(text):
-    """discord format for itallic text"""
+def bold(text: str) -> str:
+    """discord format for bold text"""
     return f"**{text}**"
 
 
-def strikethrough(text):
+def strikethrough(text: str) -> str:
     """discord format for strikethrough text"""
     return f"~~{text}~~"
 
 
-def underline(text):
+def underline(text: str) -> str:
     """discord format for underlining"""
     return f"__{text}__"
 
 
-def pagify(text, delims=None, page_length=2000):
+def pagify(text: str, delims: list[str] | None = None, page_length: int = 2000) -> Generator[str, None, None]:
     """DOES NOT RESPECT MARKDOWN BOXES OR INLINE CODE"""
     if delims is None:
         delims = ["\n"]

--- a/NerdyPy/utils/helpers.py
+++ b/NerdyPy/utils/helpers.py
@@ -4,6 +4,7 @@ import logging
 from traceback import format_exception
 
 from discord import Color, Embed, Interaction
+from discord.ext.commands import Context
 from googleapiclient.discovery import build
 
 log = logging.getLogger("nerpybot")
@@ -18,7 +19,7 @@ def parse_id(value: int | str) -> int:
     return int(value)
 
 
-async def send_hidden_message(interaction: Interaction, msg: str = None, **kwargs):
+async def send_hidden_message(interaction: Interaction, msg: str | None = None, **kwargs) -> None:
     """Send an ephemeral message via slash command interaction."""
     if not interaction.response.is_done():
         return await interaction.response.send_message(msg, ephemeral=True, **kwargs)
@@ -37,9 +38,9 @@ async def send_paginated(
     title: str = None,
     color: Color | int = None,
     ephemeral: bool = False,
-    delims=None,
-    page_length=None,
-):
+    delims: list[str] | None = None,
+    page_length: int | None = None,
+) -> None:
     """Paginate text into Discord embed messages.
 
     Uses ``response.send_message`` for the first page and ``followup.send``
@@ -73,7 +74,7 @@ async def send_paginated(
             await interaction.followup.send(embed=embed, ephemeral=ephemeral)
 
 
-def error_context(source) -> str:
+def error_context(source: Context | Interaction) -> str:
     """Build a log prefix with command, user, and guild info.
 
     Accepts both Interaction (slash) and Context (prefix fallback).
@@ -120,7 +121,7 @@ async def notify_error(bot, context: str, error: Exception) -> None:
             log.debug(f"Could not DM error notification to {uid}: {dm_err}")
 
 
-def youtube(yt_key, return_type, query):
+def youtube(yt_key: str, return_type: str, query: str) -> str | None:
     yt = build("youtube", "v3", developerKey=yt_key)
     search_response = yt.search().list(q=query, part="id,snippet", type="video", maxResults=1).execute()
     items = search_response.get("items", [])


### PR DESCRIPTION
## Summary
- Add type annotations to all 7 functions in `format.py` (`box`, `inline`, `italics`, `bold`, `strikethrough`, `underline`, `pagify`)
- Add type annotations to `youtube()`, `send_hidden_message()`, `send_paginated()`, `error_context()` in `helpers.py`
- Fix docstring typo: "itallic" → "italic" in `italics()`, "itallic" → "bold" in `bold()`
- Cache `_WEEKDAY_NAMES = list(WEEKDAY_MAP.keys())` at module level in `reminder.py` to avoid rebuilding the list on every call

## Test plan
- [x] All 330 tests pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)