### PR TITLE
refactor(download): use Path and tempfile for download directory

### DIFF
--- a/NerdyPy/utils/download.py
+++ b/NerdyPy/utils/download.py
@@ -4,8 +4,9 @@ download and conversion method for Audio Content
 """
 
 import logging
-import os
+import tempfile
 from io import BytesIO
+from pathlib import Path
 
 import ffmpeg
 import requests
@@ -19,13 +20,12 @@ LOG = logging.getLogger("nerpybot")
 FFMPEG_OPTIONS = {"options": "-vn"}
 CACHE = TTLCache(maxsize=100, ttl=600)
 
-DL_DIR = "tmp"
-if not os.path.exists(DL_DIR):
-    os.makedirs(DL_DIR)
+DL_DIR = Path(tempfile.gettempdir()) / "nerpybot-dl"
+DL_DIR.mkdir(exist_ok=True)
 
 YTDL_ARGS = {
     "format": "bestaudio/best",
-    "outtmpl": os.path.join(DL_DIR, "%(id)s"),
+    "outtmpl": str(DL_DIR / "%(id)s"),
     "restrictfilenames": True,
     "noplaylist": True,
     "nocheckcertificate": True,
@@ -59,9 +59,9 @@ def convert(source, tag=False, is_stream=True):
 
 
 def lookup_file(file_name):
-    for file in os.listdir(f"{DL_DIR}"):
-        if file.startswith(file_name):
-            return os.path.join(DL_DIR, file)
+    for file in DL_DIR.iterdir():
+        if file.name.startswith(file_name):
+            return str(file)
     return None
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
     volumes:
       - nerpybot-data:/data
       - ./config/nerpybot.yaml:/app/config.yaml:ro
-    tmpfs:
-      - /app/tmp:mode=0770,uid=10001
 
   humanmusic-migrations:
     image: ghcr.io/nerdycraft/nerpybot-database-migrations:latest
@@ -36,8 +34,6 @@ services:
     volumes:
       - humanmusic-data:/data
       - ./config/humanmusic.yaml:/app/config.yaml:ro
-    tmpfs:
-      - /app/tmp:mode=0770,uid=10001
 
 volumes:
   nerpybot-data:


### PR DESCRIPTION
## Summary
- Replace hardcoded `DL_DIR = "tmp"` (relative to cwd, fragile) with `Path(tempfile.gettempdir()) / "nerpybot-dl"` for a proper OS temp directory
- Use `Path.mkdir(exist_ok=True)` instead of `os.path.exists` + `os.makedirs`
- Use `Path.iterdir()` instead of `os.listdir()` in `lookup_file()`
- Remove `import os` (no longer needed)

## Test plan
- [x] All 330 tests pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)