### PR TITLE
refactor(errors): introduce semantic exception hierarchy

### DIFF
--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -423,7 +423,7 @@ def main() -> None:
         except KeyboardInterrupt:
             bot.log.info("Received KeyboardInterrupt, shutting down.")
     else:
-        raise NerpyException("Bot config not found.")
+        raise NerpyInfraException("Bot config not found.")
 
 
 if __name__ == "__main__":

--- a/NerdyPy/models/tagging.py
+++ b/NerdyPy/models/tagging.py
@@ -8,7 +8,7 @@ from discord.ext.commands import Context, Converter
 from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Index, Integer, LargeBinary, Unicode, asc
 from sqlalchemy.orm import relationship
 from utils import database as db
-from utils.errors import NerpyException
+from utils.errors import NerpyValidationError
 
 
 class TagType(Enum):
@@ -25,7 +25,7 @@ class TagTypeConverter(Converter):
         try:
             return TagType[low].value
         except KeyError:
-            raise NerpyException(f"TagType {argument} was not found.")
+            raise NerpyValidationError(f"TagType {argument} was not found.")
 
 
 class Tag(db.BASE):

--- a/NerdyPy/modules/admin.py
+++ b/NerdyPy/modules/admin.py
@@ -15,7 +15,7 @@ from models.permissions import PermissionSubscriber
 
 from utils.checks import is_admin_or_operator, require_operator
 from utils.cog import NerpyBotCog
-from utils.errors import NerpyException
+from utils.errors import NerpyInfraException, NerpyPermissionError
 from utils.permissions import build_permissions_embed, check_guild_permissions, required_permissions_for
 
 PROTECTED_MODULES = frozenset({"admin", "voicecontrol"})
@@ -71,7 +71,7 @@ class Admin(NerpyBotCog, Cog):
             return True
         if ctx.guild and ctx.author.guild_permissions.administrator:
             return True
-        raise NerpyException("This command requires administrator permissions or bot operator status.")
+        raise NerpyPermissionError("This command requires administrator permissions or bot operator status.")
 
     @modrole.command(name="get")
     async def _modrole_get(self, interaction: Interaction):
@@ -218,7 +218,7 @@ class Admin(NerpyBotCog, Cog):
                 pass
             except (CommandSyncFailure, Forbidden, MissingApplicationID, TranslationError) as ex:
                 self.bot.log.debug(ex)
-                raise NerpyException("Could not sync commands to Discord API.")
+                raise NerpyInfraException("Could not sync commands to Discord API.")
             else:
                 ret += 1
 

--- a/NerdyPy/modules/league.py
+++ b/NerdyPy/modules/league.py
@@ -7,7 +7,7 @@ from aiohttp import ClientSession
 from discord import Color, Embed, Interaction, app_commands
 from discord.ext.commands import GroupCog
 from utils.cog import NerpyBotCog
-from utils.errors import NerpyException
+from utils.errors import NerpyException, NerpyInfraException
 from utils.helpers import error_context
 
 
@@ -55,7 +55,7 @@ class League(NerpyBotCog, GroupCog):
                 data = await summoner_response.json()
                 if "status" in data:  # if query is successful there is no status key
                     self.bot.log.error(f"{error_context(interaction)}: Riot API error: {data['status']}")
-                    raise NerpyException("Could not get data from API. Please report to Bot author.")
+                    raise NerpyInfraException("Could not get data from the Riot API.")
                 else:
                     summoner_id = data.get("id")
                     name = data.get("name")

--- a/NerdyPy/modules/league.py
+++ b/NerdyPy/modules/league.py
@@ -7,7 +7,7 @@ from aiohttp import ClientSession
 from discord import Color, Embed, Interaction, app_commands
 from discord.ext.commands import GroupCog
 from utils.cog import NerpyBotCog
-from utils.errors import NerpyException, NerpyInfraException
+from utils.errors import NerpyInfraException
 from utils.helpers import error_context
 
 
@@ -97,4 +97,4 @@ async def setup(bot):
     if "league" in bot.config:
         await bot.add_cog(League(bot))
     else:
-        raise NerpyException("Config not found.")
+        raise NerpyInfraException("Config not found.")

--- a/NerdyPy/modules/leavemsg.py
+++ b/NerdyPy/modules/leavemsg.py
@@ -7,7 +7,7 @@ from discord.ext.commands import Cog, GroupCog
 from models.leavemsg import LeaveMessage
 from utils.cog import NerpyBotCog
 
-from utils.errors import NerpyException
+from utils.errors import NerpyValidationError
 from utils.permissions import validate_channel_permissions
 
 
@@ -90,7 +90,7 @@ class LeaveMsg(NerpyBotCog, GroupCog, group_name="leavemsg"):
         with self.bot.session_scope() as session:
             leave_config = LeaveMessage.get(interaction.guild.id, session)
             if leave_config is None:
-                raise NerpyException("Leave messages are not configured for this server.")
+                raise NerpyValidationError("Leave messages are not configured for this server.")
             leave_config.Enabled = False
 
         await interaction.response.send_message("Leave messages disabled.", ephemeral=True)
@@ -107,12 +107,12 @@ class LeaveMsg(NerpyBotCog, GroupCog, group_name="leavemsg"):
             The message template. Use {member} for the member's display name.
         """
         if "{member}" not in message:
-            raise NerpyException("Message must contain {member} placeholder for the member name.")
+            raise NerpyValidationError("Message must contain {member} placeholder for the member name.")
 
         with self.bot.session_scope() as session:
             leave_config = LeaveMessage.get(interaction.guild.id, session)
             if leave_config is None:
-                raise NerpyException("Please enable leave messages first using `/leavemsg enable #channel`.")
+                raise NerpyValidationError("Please enable leave messages first using `/leavemsg enable #channel`.")
             leave_config.Message = message
 
         await interaction.response.send_message(f"Leave message updated to: {message}", ephemeral=True)

--- a/NerdyPy/modules/tagging.py
+++ b/NerdyPy/modules/tagging.py
@@ -13,7 +13,7 @@ from utils.audio import QueuedSong, QueueMixin
 from utils.checks import can_stop_playback, is_connected_to_voice
 from utils.cog import NerpyBotCog
 from utils.download import download
-from utils.errors import NerpyException
+from utils.errors import NerpyNotFoundError
 from utils.helpers import error_context, send_paginated
 
 
@@ -216,7 +216,7 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
         with self.bot.session_scope() as session:
             _tag = Tag.get(tag_name, interaction.guild.id, session)
             if _tag is None:
-                raise NerpyException(f'I searched everywhere, but could not find a Tag called "{tag_name}"!')
+                raise NerpyNotFoundError(f'I searched everywhere, but could not find a Tag called "{tag_name}"!')
 
             if TagType(_tag.Type) is TagType.sound:
                 song = QueuedSong(interaction.user.voice.channel, self._fetch, tag_name, tag_name)

--- a/NerdyPy/modules/wow.py
+++ b/NerdyPy/modules/wow.py
@@ -30,7 +30,13 @@ from utils.blizzard import (
     should_update_mount_set,
 )
 from utils.cog import NerpyBotCog
-from utils.errors import NerpyInfraException, NerpyNotFoundError, NerpyPermissionError, NerpyUserException, NerpyValidationError
+from utils.errors import (
+    NerpyInfraException,
+    NerpyNotFoundError,
+    NerpyPermissionError,
+    NerpyUserException,
+    NerpyValidationError,
+)
 from utils.helpers import notify_error, register_before_loop, send_paginated
 from utils.permissions import validate_channel_permissions
 

--- a/NerdyPy/utils/checks.py
+++ b/NerdyPy/utils/checks.py
@@ -7,18 +7,18 @@ from discord.ext.commands import Context
 
 from bot import NerpyBot
 from models.botmod import BotModeratorRole
-from utils.errors import NerpyException, SilentCheckFailure
+from utils.errors import NerpyPermissionError, SilentCheckFailure
 
 
 def require_operator(ctx_or_interaction: Context | Interaction) -> None:
     """Raise if the command invoker is not a bot operator.
 
     Accepts both prefix-command Context and slash-command Interaction.
-    Raises NerpyException for prefix commands, CheckFailure for slash commands.
+    Raises NerpyPermissionError for prefix commands, CheckFailure for slash commands.
     """
     if isinstance(ctx_or_interaction, Context):
         if ctx_or_interaction.author.id not in ctx_or_interaction.bot.ops:
-            raise NerpyException("This command is restricted to bot operators.")
+            raise NerpyPermissionError("This command is restricted to bot operators.")
     else:
         bot = cast("NerpyBot", ctx_or_interaction.client)
         if ctx_or_interaction.user.id not in bot.ops:

--- a/NerdyPy/utils/download.py
+++ b/NerdyPy/utils/download.py
@@ -12,7 +12,7 @@ import ffmpeg
 import requests
 from cachetools import TTLCache
 from discord import FFmpegOpusAudio
-from utils.errors import NerpyException
+from utils.errors import NerpyValidationError
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
@@ -97,7 +97,7 @@ def download(url: str, tag: bool = False, video_id: str = None):
             audio_bytes = BytesIO(response.content)
 
         if audio_bytes is None:
-            raise NerpyException(f"Could not find a valid source in: {url}")
+            raise NerpyValidationError(f"Could not find a valid source in: {url}")
 
         return convert(audio_bytes, tag)
     else:

--- a/NerdyPy/utils/errors.py
+++ b/NerdyPy/utils/errors.py
@@ -7,6 +7,18 @@ class NerpyException(Exception):
     pass
 
 
+class NerpyInfraException(NerpyException):
+    """Infrastructure error (DB failure, external API failure, etc.).
+
+    Treated like NerpyException for user-facing messages, but also triggers
+    an operator DM notification so the bot owner is aware without waiting for
+    a user report.  Raise with ``from original_exc`` to include the full
+    chained traceback in the DM.
+    """
+
+    pass
+
+
 class SilentCheckFailure(CheckFailure):
     """A check already sent its own rejection message — the error handler should not send another."""
 

--- a/NerdyPy/utils/errors.py
+++ b/NerdyPy/utils/errors.py
@@ -4,16 +4,40 @@ from discord.app_commands import CheckFailure
 
 
 class NerpyException(Exception):
+    """Base for all NerpyBot exceptions. Raiseable as a fallback."""
+
+    pass
+
+
+class NerpyUserException(NerpyException):
+    """User-facing error — shown to the Discord user as-is."""
+
+    pass
+
+
+class NerpyNotFoundError(NerpyUserException):
+    """A requested entity (tag, character, guild, realm) does not exist."""
+
+    pass
+
+
+class NerpyValidationError(NerpyUserException):
+    """Input or state is invalid (bad parameter, missing placeholder, duplicate config)."""
+
+    pass
+
+
+class NerpyPermissionError(NerpyUserException):
+    """The user or guild lacks a required role, or the bot lacks channel permissions."""
+
     pass
 
 
 class NerpyInfraException(NerpyException):
-    """Infrastructure error (DB failure, external API failure, etc.).
+    """Infrastructure failure — triggers an operator DM notification.
 
-    Treated like NerpyException for user-facing messages, but also triggers
-    an operator DM notification so the bot owner is aware without waiting for
-    a user report.  Raise with ``from original_exc`` to include the full
-    chained traceback in the DM.
+    Covers: DB errors, external API failures, Discord API failures, misconfiguration.
+    Raise with ``from original_exc`` to chain the full traceback into the DM.
     """
 
     pass

--- a/NerdyPy/utils/permissions.py
+++ b/NerdyPy/utils/permissions.py
@@ -6,7 +6,7 @@ Per-module bot permission requirements and guild-level audit helpers.
 
 from discord import Embed, Guild, Permissions, TextChannel
 
-from utils.errors import NerpyException
+from utils.errors import NerpyPermissionError
 
 # Maps module name → set of Permissions flag names the bot needs at runtime.
 # User-level checks (has_permissions) are NOT included — only bot actions.
@@ -83,7 +83,7 @@ def build_permissions_embed(guild: Guild, missing: list[str], client_id: int, re
 
 
 def validate_channel_permissions(channel: TextChannel, guild: Guild, *perms: str) -> None:
-    """Raise NerpyException if the bot lacks any of *perms* in *channel*.
+    """Raise NerpyPermissionError if the bot lacks any of *perms* in *channel*.
 
     Uses channel.permissions_for(guild.me) which resolves guild-level
     permissions plus channel-specific overrides into effective permissions.
@@ -92,4 +92,4 @@ def validate_channel_permissions(channel: TextChannel, guild: Guild, *perms: str
     missing = [p for p in perms if not getattr(resolved, p, False)]
     if missing:
         formatted = ", ".join(f"`{p}`" for p in missing)
-        raise NerpyException(f"I need the following permissions in {channel.mention}: {formatted}")
+        raise NerpyPermissionError(f"I need the following permissions in {channel.mention}: {formatted}")

--- a/tests/modules/test_tagging.py
+++ b/tests/modules/test_tagging.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from models.tagging import Tag, TagType, TagTypeConverter
-from utils.errors import NerpyException
+from utils.errors import NerpyValidationError
 
 
 class TestTagTypeConverter:
@@ -54,14 +54,14 @@ class TestTagTypeConverter:
 
     @pytest.mark.asyncio
     async def test_convert_invalid_type_raises(self, converter, mock_ctx):
-        """Invalid type should raise NerpyException."""
-        with pytest.raises(NerpyException, match="TagType invalid was not found"):
+        """Invalid type should raise NerpyValidationError."""
+        with pytest.raises(NerpyValidationError, match="TagType invalid was not found"):
             await converter.convert(mock_ctx, "invalid")
 
     @pytest.mark.asyncio
     async def test_convert_empty_string_raises(self, converter, mock_ctx):
-        """Empty string should raise NerpyException."""
-        with pytest.raises(NerpyException):
+        """Empty string should raise NerpyValidationError."""
+        with pytest.raises(NerpyValidationError):
             await converter.convert(mock_ctx, "")
 
 

--- a/tests/utils/test_errors.py
+++ b/tests/utils/test_errors.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Tests for the NerpyBot exception hierarchy."""
+
+from discord.app_commands import CheckFailure
+from utils.errors import (
+    NerpyException,
+    NerpyInfraException,
+    NerpyNotFoundError,
+    NerpyPermissionError,
+    NerpyUserException,
+    NerpyValidationError,
+    SilentCheckFailure,
+)
+
+
+def test_user_exception_is_nerpy_exception():
+    assert issubclass(NerpyUserException, NerpyException)
+
+
+def test_not_found_is_user_exception():
+    assert issubclass(NerpyNotFoundError, NerpyUserException)
+
+
+def test_validation_is_user_exception():
+    assert issubclass(NerpyValidationError, NerpyUserException)
+
+
+def test_permission_is_user_exception():
+    assert issubclass(NerpyPermissionError, NerpyUserException)
+
+
+def test_infra_is_nerpy_exception():
+    assert issubclass(NerpyInfraException, NerpyException)
+
+
+def test_infra_is_not_user_exception():
+    assert not issubclass(NerpyInfraException, NerpyUserException)
+
+
+def test_silent_check_failure_unchanged():
+    assert issubclass(SilentCheckFailure, CheckFailure)

--- a/tests/utils/test_permissions.py
+++ b/tests/utils/test_permissions.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from utils.errors import NerpyException
+from utils.errors import NerpyPermissionError
 from utils.permissions import validate_channel_permissions
 
 
@@ -38,14 +38,14 @@ def test_validate_passes_when_all_permissions_present():
 def test_validate_raises_when_permission_missing():
     channel = _make_channel(send_messages=False)
     guild = _make_guild()
-    with pytest.raises(NerpyException, match="send_messages"):
+    with pytest.raises(NerpyPermissionError, match="send_messages"):
         validate_channel_permissions(channel, guild, "view_channel", "send_messages")
 
 
 def test_validate_raises_lists_all_missing():
     channel = _make_channel(view_channel=False, send_messages=False)
     guild = _make_guild()
-    with pytest.raises(NerpyException, match="view_channel") as exc_info:
+    with pytest.raises(NerpyPermissionError, match="view_channel") as exc_info:
         validate_channel_permissions(channel, guild, "view_channel", "send_messages")
     assert "send_messages" in str(exc_info.value)
 


### PR DESCRIPTION
## Summary

- Adds `NerpyUserException`, `NerpyNotFoundError`, `NerpyValidationError`, and `NerpyPermissionError` sub-types under `NerpyException` so raise sites communicate intent at a glance
- Migrates all 18 `NerpyException` raise sites across 8 source files to the most specific sub-type
- Tightens two inline `except NerpyException` catches in `wow.py` to `except NerpyUserException`, so infrastructure errors correctly bubble up to the global handler and trigger operator DMs

## Test Plan

- [x] `uv run python -m pytest` — 337 passed, 0 failed
- [x] `uv run ruff check NerdyPy/` — clean
- [x] `grep -rn "raise NerpyException" NerdyPy/` — zero results (all raise sites migrated)
- [x] Exception hierarchy verified by `tests/utils/test_errors.py` (7 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)