### PR TITLE
fix(application): quote column names in CheckConstraint for PostgreSQL

### DIFF
--- a/NerdyPy/models/application.py
+++ b/NerdyPy/models/application.py
@@ -64,8 +64,8 @@ class ApplicationForm(db.BASE):
     __table_args__ = (
         Index("ApplicationForm_GuildId", "GuildId"),
         Index("ApplicationForm_Name_GuildId", "Name", "GuildId", unique=True),
-        CheckConstraint("RequiredApprovals >= 1", name="ck_form_required_approvals"),
-        CheckConstraint("RequiredDenials >= 1", name="ck_form_required_denials"),
+        CheckConstraint('"RequiredApprovals" >= 1', name="ck_form_required_approvals"),
+        CheckConstraint('"RequiredDenials" >= 1', name="ck_form_required_denials"),
     )
 
     Id = Column(Integer, primary_key=True)
@@ -246,7 +246,7 @@ class ApplicationTemplate(db.BASE):
     __table_args__ = (
         Index("ApplicationTemplate_GuildId", "GuildId"),
         CheckConstraint(
-            "(IsBuiltIn = 1 AND GuildId IS NULL) OR (IsBuiltIn = 0 AND GuildId IS NOT NULL)",
+            '("IsBuiltIn" = 1 AND "GuildId" IS NULL) OR ("IsBuiltIn" = 0 AND "GuildId" IS NOT NULL)',
             name="ck_template_builtin_guild",
         ),
     )


### PR DESCRIPTION
## Summary

- Quote PascalCase column names in `CheckConstraint` SQL expressions with double-quotes so PostgreSQL doesn't fold them to lowercase
- Fixes `UndefinedColumn: column "requiredapprovals" does not exist` crash on startup with PostgreSQL
- Affects three constraints: `ck_form_required_approvals`, `ck_form_required_denials`, `ck_template_builtin_guild`

## Test plan

- [x] All 632 existing tests pass
- [x] Ruff lint and format checks pass
- [x] Audited full codebase (models, migrations, queries) — no other unquoted raw SQL references to PascalCase columns
- [x] Deploy to PostgreSQL environment and verify bot starts without `CREATE TABLE` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)