### PR TITLE
fix(application): use IS TRUE/FALSE in CheckConstraint for PostgreSQL

### DIFF
--- a/NerdyPy/models/application.py
+++ b/NerdyPy/models/application.py
@@ -246,7 +246,7 @@ class ApplicationTemplate(db.BASE):
     __table_args__ = (
         Index("ApplicationTemplate_GuildId", "GuildId"),
         CheckConstraint(
-            '("IsBuiltIn" = 1 AND "GuildId" IS NULL) OR ("IsBuiltIn" = 0 AND "GuildId" IS NOT NULL)',
+            '("IsBuiltIn" IS TRUE AND "GuildId" IS NULL) OR ("IsBuiltIn" IS FALSE AND "GuildId" IS NOT NULL)',
             name="ck_template_builtin_guild",
         ),
     )


### PR DESCRIPTION
## Summary
- PostgreSQL rejects `"IsBuiltIn" = 1` because there is no implicit `boolean = integer` operator
- Replaced `= 1` / `= 0` with SQL-standard `IS TRUE` / `IS FALSE` in the `ck_template_builtin_guild` check constraint
- Works across all supported dialects (PostgreSQL, SQLite, MySQL)

## Test plan
- [x] All 632 existing tests pass
- [ ] Deploy to PostgreSQL environment and verify `ApplicationTemplate` table creation succeeds
- [ ] Verify built-in template insertion still respects the constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)