### PR TITLE
feat: implement multilingual string templating (Phase 1)

### DIFF
--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -43,6 +43,7 @@ from utils.error_throttle import ErrorThrottle
 from utils.errors import NerpyException, NerpyInfraException, SilentCheckFailure
 from utils.helpers import error_context, notify_error, parse_id
 from utils.permissions import build_permissions_embed, check_guild_permissions, required_permissions_for
+from utils.strings import load_strings
 
 
 ACTIVITIES = [
@@ -203,6 +204,9 @@ class NerpyBot(Bot):
             except Exception as e:
                 self.log.error(f"failed to register application persistent views. {e}")
                 self.log.debug(print_exc())
+
+        # load localization strings
+        load_strings()
 
         # create database/tables and such stuff
         self.create_all()

--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -1,0 +1,24 @@
+common:
+  error_generic: "Ein Fehler ist aufgetreten. Der Bot-Betreiber wurde benachrichtigt."
+  not_found: "Nicht gefunden."
+
+admin:
+  language:
+    set_success: "Serversprache auf **{language}** gesetzt."
+    get_current: "Serversprache: **{language}**"
+    get_default: "Keine Sprache konfiguriert. Standard ist Englisch."
+    invalid: "Nicht unterstützte Sprache: `{language}`. Verfügbar: {available}"
+
+reminder:
+  create:
+    success: "Erinnerung erstellt — nächste Auslösung {relative_time}."
+  schedule:
+    success: "Geplante Erinnerung erstellt — nächste Auslösung {relative_time}."
+  delete:
+    success: "Nachricht gelöscht."
+  pause:
+    success: "Erinnerung **#{reminder_id}** pausiert."
+  resume:
+    success: "Erinnerung **#{reminder_id}** fortgesetzt."
+  not_found: "Erinnerung nicht gefunden."
+  no_reminders: "Keine Erinnerungen gesetzt."

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -1,0 +1,25 @@
+common:
+  error_generic: "An error occurred. The bot operator has been notified."
+  not_found: "Not found."
+
+admin:
+  language:
+    set_success: "Server language set to **{language}**."
+    get_current: "Server language: **{language}**"
+    get_default: "No language configured. Defaulting to English."
+    invalid: "Unsupported language: `{language}`. Available: {available}"
+
+# Example module strings — pattern for Phase 2 migration PRs
+reminder:
+  create:
+    success: "Reminder created — next fire {relative_time}."
+  schedule:
+    success: "Scheduled reminder created — next fire {relative_time}."
+  delete:
+    success: "Message deleted."
+  pause:
+    success: "Paused reminder **#{reminder_id}**."
+  resume:
+    success: "Resumed reminder **#{reminder_id}**."
+  not_found: "Reminder not found."
+  no_reminders: "No reminders set."

--- a/NerdyPy/models/admin.py
+++ b/NerdyPy/models/admin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Admin-domain database models: bot-moderator role and permission notification subscribers."""
 
-from sqlalchemy import BigInteger, Column
+from sqlalchemy import BigInteger, Column, String
 from utils import database as db
 
 
@@ -50,3 +50,17 @@ class PermissionSubscriber(db.BASE):
         entry = cls.get(guild_id, user_id, session)
         if entry is not None:
             session.delete(entry)
+
+
+class GuildLanguageConfig(db.BASE):
+    """Per-guild language preference for localized bot responses."""
+
+    __tablename__ = "GuildLanguageConfig"
+
+    GuildId = Column(BigInteger, primary_key=True)
+    Language = Column(String(5), nullable=False, default="en")
+
+    @classmethod
+    def get(cls, guild_id: int, session) -> "GuildLanguageConfig | None":
+        """Returns the language config for the given guild, or None."""
+        return session.query(cls).filter(cls.GuildId == guild_id).first()

--- a/NerdyPy/utils/strings.py
+++ b/NerdyPy/utils/strings.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Localized string lookup — loads YAML templates and resolves per-guild language."""
+
+from pathlib import Path
+
+import yaml
+from models.admin import GuildLanguageConfig
+
+# Module-level state, populated by load_strings()
+_strings: dict[str, dict] = {}
+_available_languages: list[str] = []
+
+
+def load_strings(locales_dir: Path | None = None) -> None:
+    """Scan locales directory for lang_*.yaml files and load them into memory.
+
+    Args:
+        locales_dir: Path to the locales directory. Defaults to NerdyPy/locales/.
+    """
+    if locales_dir is None:
+        locales_dir = Path(__file__).parent.parent / "locales"
+
+    _strings.clear()
+    _available_languages.clear()
+
+    for path in sorted(locales_dir.glob("lang_*.yaml")):
+        lang_code = path.stem.removeprefix("lang_")
+        with open(path, encoding="utf-8") as f:
+            _strings[lang_code] = yaml.safe_load(f) or {}
+        _available_languages.append(lang_code)
+
+
+def available_languages() -> list[str]:
+    """Return the list of discovered language codes."""
+    return list(_available_languages)
+
+
+def _traverse(data: dict, key: str) -> str | None:
+    """Traverse a nested dict by dot-separated key. Returns None if not found."""
+    parts = key.split(".")
+    current = data
+    for part in parts:
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current if isinstance(current, str) else None
+
+
+def get_string(lang: str, key: str, **kwargs) -> str:
+    """Look up a localized string by dot-notation key with English fallback.
+
+    Args:
+        lang: Language code (e.g. "de").
+        key: Dot-notation key (e.g. "admin.language.set_success").
+        **kwargs: Format arguments for the string template.
+
+    Returns:
+        The formatted string.
+
+    Raises:
+        KeyError: If the key is missing from both the target language and English.
+    """
+    # Try target language
+    if lang in _strings:
+        result = _traverse(_strings[lang], key)
+        if result is not None:
+            return result.format(**kwargs) if kwargs else result
+
+    # Fallback to English
+    if "en" in _strings:
+        result = _traverse(_strings["en"], key)
+        if result is not None:
+            return result.format(**kwargs) if kwargs else result
+
+    raise KeyError(f"Missing localization key: {key}")
+
+
+def get_guild_language(guild_id: int, session) -> str:
+    """Get the configured language for a guild, defaulting to 'en'."""
+    config = GuildLanguageConfig.get(guild_id, session)
+    return config.Language if config is not None else "en"
+
+
+def get_localized_string(guild_id: int, key: str, session, **kwargs) -> str:
+    """Convenience: resolve guild language, then look up and format a string."""
+    lang = get_guild_language(guild_id, session)
+    return get_string(lang, key, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def db_engine():
     )
     from models.reminder import ReminderMessage  # noqa: F401
     from models.tagging import Tag, TagEntry  # noqa: F401
+    from models.admin import BotModeratorRole, PermissionSubscriber, GuildLanguageConfig  # noqa: F401
     from models.wow import WowGuildNewsConfig, WowCharacterMounts  # noqa: F401
 
     BASE.metadata.create_all(engine)

--- a/tests/modules/test_admin_language.py
+++ b/tests/modules/test_admin_language.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""Tests for /language set and /language get admin commands."""
+
+import pytest
+import yaml
+
+from models.admin import GuildLanguageConfig
+from utils import strings
+
+
+@pytest.fixture(autouse=True)
+def _load_test_locales(tmp_path):
+    """Load minimal locale files for testing."""
+    en = {
+        "admin": {
+            "language": {
+                "set_success": "Server language set to **{language}**.",
+                "get_current": "Server language: **{language}**",
+                "get_default": "No language configured. Defaulting to English.",
+                "invalid": "Unsupported language: `{language}`. Available: {available}",
+            }
+        }
+    }
+    de = {
+        "admin": {
+            "language": {
+                "set_success": "Serversprache auf **{language}** gesetzt.",
+                "get_current": "Serversprache: **{language}**",
+                "get_default": "Keine Sprache konfiguriert. Standard ist Englisch.",
+                "invalid": "Nicht unterstützte Sprache: `{language}`. Verfügbar: {available}",
+            }
+        }
+    }
+    (tmp_path / "lang_en.yaml").write_text(yaml.dump(en))
+    (tmp_path / "lang_de.yaml").write_text(yaml.dump(de))
+    strings.load_strings(tmp_path)
+    yield
+    strings._strings.clear()
+    strings._available_languages.clear()
+
+
+@pytest.fixture
+def admin_cog(mock_bot):
+    """Create an Admin cog instance."""
+    from modules.admin import Admin
+
+    cog = Admin.__new__(Admin)
+    cog.bot = mock_bot
+    return cog
+
+
+class TestLanguageSet:
+    @pytest.mark.asyncio
+    async def test_set_valid_language(self, admin_cog, mock_interaction, db_session):
+        mock_interaction.guild.id = 123
+        await admin_cog._language_set.callback(admin_cog, mock_interaction, language="de")
+
+        config = GuildLanguageConfig.get(123, db_session)
+        assert config is not None
+        assert config.Language == "de"
+
+        call_args = str(mock_interaction.response.send_message.call_args)
+        assert "de" in call_args
+
+    @pytest.mark.asyncio
+    async def test_set_overwrites_existing(self, admin_cog, mock_interaction, db_session):
+        mock_interaction.guild.id = 123
+        db_session.add(GuildLanguageConfig(GuildId=123, Language="en"))
+        db_session.commit()
+
+        await admin_cog._language_set.callback(admin_cog, mock_interaction, language="de")
+
+        config = GuildLanguageConfig.get(123, db_session)
+        assert config.Language == "de"
+
+    @pytest.mark.asyncio
+    async def test_set_invalid_language(self, admin_cog, mock_interaction, db_session):
+        mock_interaction.guild.id = 123
+        await admin_cog._language_set.callback(admin_cog, mock_interaction, language="xx")
+
+        config = GuildLanguageConfig.get(123, db_session)
+        assert config is None
+
+        call_args = str(mock_interaction.response.send_message.call_args)
+        assert "xx" in call_args
+
+    @pytest.mark.asyncio
+    async def test_set_normalizes_case(self, admin_cog, mock_interaction, db_session):
+        mock_interaction.guild.id = 123
+        await admin_cog._language_set.callback(admin_cog, mock_interaction, language="DE")
+
+        config = GuildLanguageConfig.get(123, db_session)
+        assert config is not None
+        assert config.Language == "de"
+
+
+class TestLanguageGet:
+    @pytest.mark.asyncio
+    async def test_get_configured(self, admin_cog, mock_interaction, db_session):
+        mock_interaction.guild.id = 123
+        db_session.add(GuildLanguageConfig(GuildId=123, Language="de"))
+        db_session.commit()
+
+        await admin_cog._language_get.callback(admin_cog, mock_interaction)
+
+        call_args = str(mock_interaction.response.send_message.call_args)
+        assert "de" in call_args
+
+    @pytest.mark.asyncio
+    async def test_get_default(self, admin_cog, mock_interaction, db_session):
+        mock_interaction.guild.id = 123
+
+        await admin_cog._language_get.callback(admin_cog, mock_interaction)
+
+        call_args = str(mock_interaction.response.send_message.call_args)
+        assert "english" in call_args.lower() or "English" in call_args
+
+
+class TestLanguageAutocomplete:
+    @pytest.mark.asyncio
+    async def test_autocomplete_filters_by_current(self, admin_cog, mock_interaction):
+        choices = await admin_cog._language_autocomplete(mock_interaction, "d")
+        names = [c.name for c in choices]
+        assert "de" in names
+        assert "en" not in names
+
+    @pytest.mark.asyncio
+    async def test_autocomplete_returns_all_on_empty(self, admin_cog, mock_interaction):
+        choices = await admin_cog._language_autocomplete(mock_interaction, "")
+        assert len(choices) == 2  # en and de from test locales

--- a/tests/utils/test_strings.py
+++ b/tests/utils/test_strings.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""Tests for utils/strings.py — localization string lookup."""
+
+import pytest
+import yaml
+
+from models.admin import GuildLanguageConfig
+from utils import strings
+
+
+@pytest.fixture
+def locale_dir(tmp_path):
+    """Create temporary locale YAML files for testing."""
+    en = {
+        "common": {"greeting": "Hello {name}!", "farewell": "Goodbye."},
+        "admin": {"language": {"set_success": "Language set to {language}."}},
+    }
+    de = {
+        "common": {"greeting": "Hallo {name}!"},
+        "admin": {"language": {"set_success": "Sprache auf {language} gesetzt."}},
+    }
+    (tmp_path / "lang_en.yaml").write_text(yaml.dump(en))
+    (tmp_path / "lang_de.yaml").write_text(yaml.dump(de))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _reset_strings():
+    """Reset module-level state between tests."""
+    strings._strings.clear()
+    strings._available_languages.clear()
+    yield
+    strings._strings.clear()
+    strings._available_languages.clear()
+
+
+class TestLoadStrings:
+    def test_discovers_language_files(self, locale_dir):
+        strings.load_strings(locale_dir)
+        assert sorted(strings.available_languages()) == ["de", "en"]
+
+    def test_loads_nested_content(self, locale_dir):
+        strings.load_strings(locale_dir)
+        assert strings._strings["en"]["common"]["greeting"] == "Hello {name}!"
+
+    def test_ignores_non_lang_files(self, locale_dir):
+        (locale_dir / "other.yaml").write_text("foo: bar")
+        strings.load_strings(locale_dir)
+        assert sorted(strings.available_languages()) == ["de", "en"]
+
+
+class TestGetString:
+    def test_returns_english(self, locale_dir):
+        strings.load_strings(locale_dir)
+        result = strings.get_string("en", "common.greeting", name="World")
+        assert result == "Hello World!"
+
+    def test_returns_german(self, locale_dir):
+        strings.load_strings(locale_dir)
+        result = strings.get_string("de", "common.greeting", name="Welt")
+        assert result == "Hallo Welt!"
+
+    def test_fallback_to_english(self, locale_dir):
+        strings.load_strings(locale_dir)
+        # "farewell" only exists in English
+        result = strings.get_string("de", "common.farewell")
+        assert result == "Goodbye."
+
+    def test_missing_key_raises(self, locale_dir):
+        strings.load_strings(locale_dir)
+        with pytest.raises(KeyError):
+            strings.get_string("en", "nonexistent.key")
+
+    def test_format_kwargs(self, locale_dir):
+        strings.load_strings(locale_dir)
+        result = strings.get_string("en", "admin.language.set_success", language="German")
+        assert result == "Language set to German."
+
+    def test_unknown_language_falls_back_to_english(self, locale_dir):
+        strings.load_strings(locale_dir)
+        result = strings.get_string("fr", "common.greeting", name="World")
+        assert result == "Hello World!"
+
+    def test_no_kwargs_returns_raw_string(self, locale_dir):
+        strings.load_strings(locale_dir)
+        result = strings.get_string("en", "common.farewell")
+        assert result == "Goodbye."
+
+
+class TestGetGuildLanguage:
+    def test_default_when_no_config(self, db_session):
+        result = strings.get_guild_language(999, db_session)
+        assert result == "en"
+
+    def test_returns_configured_language(self, db_session):
+        db_session.add(GuildLanguageConfig(GuildId=123, Language="de"))
+        db_session.commit()
+        result = strings.get_guild_language(123, db_session)
+        assert result == "de"
+
+
+class TestGetLocalizedString:
+    def test_combines_guild_language_and_lookup(self, locale_dir, db_session):
+        strings.load_strings(locale_dir)
+        db_session.add(GuildLanguageConfig(GuildId=123, Language="de"))
+        db_session.commit()
+        result = strings.get_localized_string(123, "common.greeting", db_session, name="Welt")
+        assert result == "Hallo Welt!"
+
+    def test_defaults_to_english(self, locale_dir, db_session):
+        strings.load_strings(locale_dir)
+        result = strings.get_localized_string(999, "common.greeting", db_session, name="World")
+        assert result == "Hello World!"


### PR DESCRIPTION
## Summary

- Add `GuildLanguageConfig` database model for per-guild language preference (`/language set`, `/language get`)
- Create `NerdyPy/locales/` with English and German YAML template files, auto-discovered at startup
- Implement `utils/strings.py` with `get_string()` (dot-key lookup, English fallback), `get_guild_language()`, and `get_localized_string()` convenience wrapper
- Add admin `/language set` and `/language get` slash commands with autocomplete
- 22 new tests across `test_strings.py` and `test_admin_language.py`

## Phase 1 Scope

This PR builds the **infrastructure** for i18n. Phase 2+ PRs will migrate individual modules (reminder, moderation, wow, etc.) to use `get_localized_string()` instead of hardcoded strings — one PR per module.

## Test Plan

- [x] `uv run python -m pytest tests/ --cov` — 654 passed, `strings.py` at 98% coverage
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] `prettier --check` on YAML and markdown — clean
- [x] Manual: `/language set de` → German confirmation, `/language get` → shows "de"
- [x] Manual: `/language set xx` → error with available languages list

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)