### PR TITLE
feat(i18n): localize error handler and permission check messages

### DIFF
--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -2,6 +2,23 @@ common:
   error_generic: "Ein Fehler ist aufgetreten. Der Bot-Betreiber wurde benachrichtigt."
   not_found: "Nicht gefunden."
 
+bot:
+  module_disabled: "Das Modul **{module}** ist derzeit für Wartungsarbeiten deaktiviert. Bitte versuche es später erneut."
+
+checks:
+  voice:
+    not_connected: "Ich weiß nicht, wo du bist. Bitte tritt einem Sprachkanal bei."
+    no_connect_permission: "Ich darf deinem aktuellen Kanal nicht beitreten."
+    no_speak_permission: "Ich habe keine Berechtigung, in deinem Sprachkanal zu sprechen."
+    nothing_playing: "Es wird gerade nichts abgespielt."
+    user_not_in_voice: "Du musst in einem Sprachkanal sein, um diesen Befehl zu verwenden."
+    user_in_different_channel: "Du musst im selben Sprachkanal wie der Bot sein, um diesen Befehl zu verwenden."
+    leave_moderator_only: "Nur Moderatoren können den Bot den Sprachkanal verlassen lassen."
+  role:
+    integration_assign: "**{role}** ist eine Integrationsrolle und kann Mitgliedern nicht zugewiesen werden."
+    integration_remove: "**{role}** ist eine Integrationsrolle und kann Mitgliedern nicht entzogen werden."
+    above_bot_role: "Ich kann **{role}** nicht verwalten — diese Rolle ist auf oder über meiner höchsten Rolle."
+
 admin:
   language:
     set_success: "Serversprache auf **{language}** gesetzt."

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -2,6 +2,23 @@ common:
   error_generic: "An error occurred. The bot operator has been notified."
   not_found: "Not found."
 
+bot:
+  module_disabled: "The **{module}** module is currently disabled for maintenance. Please try again later."
+
+checks:
+  voice:
+    not_connected: "I don't know where you are. Please connect to a voice channel."
+    no_connect_permission: "I'm not allowed to join you in your current channel."
+    no_speak_permission: "I don't have permission to speak in your voice channel."
+    nothing_playing: "Nothing is playing right now."
+    user_not_in_voice: "You need to be in a voice channel to use this command."
+    user_in_different_channel: "You need to be in the same voice channel as the bot to use this command."
+    leave_moderator_only: "Only moderators can make the bot leave the voice channel."
+  role:
+    integration_assign: "**{role}** is an integration role and cannot be assigned to members."
+    integration_remove: "**{role}** is an integration role and cannot be removed from members."
+    above_bot_role: "I cannot manage **{role}** — it is at or above my highest role."
+
 admin:
   language:
     set_success: "Server language set to **{language}**."

--- a/tests/test_module_disable.py
+++ b/tests/test_module_disable.py
@@ -6,6 +6,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from utils.errors import SilentCheckFailure
+from utils.strings import load_strings
+
+
+@pytest.fixture(autouse=True)
+def _load_locale_strings():
+    """Load locale YAML files so localized messages resolve."""
+    load_strings()
 
 
 @pytest.fixture
@@ -32,6 +39,7 @@ def mock_interaction_for_disable(mock_bot_with_disable):
     command.binding = cog
     interaction.command = command
 
+    interaction.guild_id = 900
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
     interaction.response.is_done = MagicMock(return_value=False)


### PR DESCRIPTION
## Summary
- Localize `bot.py` error handler (`common.error_generic`) and module-disabled message (`bot.module_disabled`)
- Localize all `utils/checks.py` permission/voice check messages (7 voice + 3 role = 10 checks)
- Add 11 new YAML keys with EN/DE translations
- Operator-only commands (`!sync`, `!errors`, etc.) stay in English — no guild context
- DB lookup wrapped in try/except with English fallback for resilience

## Test plan
- [x] All 663 tests pass (9 new tests added)
- [x] German guild language returns German messages (4 localization tests)
- [x] English default when no guild config
- [x] `is_role_assignable` maps action param to correct locale key
- [x] `is_role_below_bot` uses localized message
- [x] `test_module_disable.py` updated to load locale strings

Phase 2 module #1 of 12 — localizes infrastructure error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)