### PR TITLE
feat(i18n): localize leavemsg module responses

### DIFF
--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -26,6 +26,20 @@ admin:
     get_default: "Keine Sprache konfiguriert. Standard ist Englisch."
     invalid: "Nicht unterstützte Sprache: `{language}`. Verfügbar: {available}"
 
+leavemsg:
+  enable:
+    success: "Abschiedsnachrichten in {channel} aktiviert."
+  disable:
+    success: "Abschiedsnachrichten deaktiviert."
+    not_configured: "Abschiedsnachrichten sind für diesen Server nicht konfiguriert."
+  message:
+    success: "Abschiedsnachricht aktualisiert auf: {message}"
+    missing_placeholder: "Die Nachricht muss den Platzhalter {member} für den Mitgliedsnamen enthalten."
+    not_enabled: "Bitte aktiviere zuerst Abschiedsnachrichten mit `/leavemsg enable #channel`."
+  status:
+    not_enabled: "Abschiedsnachrichten sind für diesen Server nicht aktiviert."
+    enabled: "**Abschiedsnachrichten:** Aktiviert\n**Kanal:** {channel}\n**Nachricht:** {message}"
+
 reminder:
   create:
     success: "Erinnerung erstellt — nächste Auslösung {relative_time}."

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -26,6 +26,20 @@ admin:
     get_default: "No language configured. Defaulting to English."
     invalid: "Unsupported language: `{language}`. Available: {available}"
 
+leavemsg:
+  enable:
+    success: "Leave messages enabled in {channel}."
+  disable:
+    success: "Leave messages disabled."
+    not_configured: "Leave messages are not configured for this server."
+  message:
+    success: "Leave message updated to: {message}"
+    missing_placeholder: "Message must contain {member} placeholder for the member name."
+    not_enabled: "Please enable leave messages first using `/leavemsg enable #channel`."
+  status:
+    not_enabled: "Leave messages are not enabled for this server."
+    enabled: "**Leave messages:** Enabled\n**Channel:** {channel}\n**Message:** {message}"
+
 # Example module strings — pattern for Phase 2 migration PRs
 reminder:
   create:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ def db_engine():
     from models.reminder import ReminderMessage  # noqa: F401
     from models.tagging import Tag, TagEntry  # noqa: F401
     from models.admin import BotModeratorRole, PermissionSubscriber, GuildLanguageConfig  # noqa: F401
+    from models.leavemsg import LeaveMessage  # noqa: F401
     from models.wow import WowGuildNewsConfig, WowCharacterMounts  # noqa: F401
 
     BASE.metadata.create_all(engine)

--- a/tests/modules/test_leavemsg.py
+++ b/tests/modules/test_leavemsg.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+"""Tests for modules.leavemsg — leave message commands."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from models.admin import GuildLanguageConfig
+from models.leavemsg import LeaveMessage
+from modules.leavemsg import LeaveMsg
+from utils.errors import NerpyValidationError
+from utils.strings import load_strings
+
+
+@pytest.fixture(autouse=True)
+def _load_locale_strings():
+    """Load locale YAML files before each test."""
+    load_strings()
+
+
+@pytest.fixture
+def cog(mock_bot):
+    return LeaveMsg(mock_bot)
+
+
+@pytest.fixture
+def interaction(mock_interaction):
+    mock_interaction.guild.id = 987654321
+    mock_interaction.guild_id = 987654321
+    return mock_interaction
+
+
+# ---------------------------------------------------------------------------
+# /leavemsg enable
+# ---------------------------------------------------------------------------
+
+
+class TestLeavemsgEnable:
+    async def test_enable_creates_config(self, cog, interaction, db_session):
+        channel = MagicMock()
+        channel.id = 111
+        channel.mention = "<#111>"
+        channel.permissions_for.return_value = MagicMock(view_channel=True, send_messages=True)
+
+        await LeaveMsg._leavemsg_enable.callback(cog, interaction, channel)
+
+        interaction.response.send_message.assert_awaited_once()
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "<#111>" in msg
+        assert "enabled" in msg.lower() or "aktiviert" in msg.lower()
+
+        config = db_session.query(LeaveMessage).filter_by(GuildId=987654321).first()
+        assert config is not None
+        assert config.Enabled is True
+        assert config.ChannelId == 111
+
+    async def test_enable_updates_existing(self, cog, interaction, db_session):
+        db_session.add(LeaveMessage(GuildId=987654321, ChannelId=222, Enabled=False))
+        db_session.commit()
+
+        channel = MagicMock()
+        channel.id = 333
+        channel.mention = "<#333>"
+        channel.permissions_for.return_value = MagicMock(view_channel=True, send_messages=True)
+
+        await LeaveMsg._leavemsg_enable.callback(cog, interaction, channel)
+
+        config = db_session.query(LeaveMessage).filter_by(GuildId=987654321).first()
+        assert config.ChannelId == 333
+        assert config.Enabled is True
+
+
+# ---------------------------------------------------------------------------
+# /leavemsg disable
+# ---------------------------------------------------------------------------
+
+
+class TestLeavemsgDisable:
+    async def test_disable_success(self, cog, interaction, db_session):
+        db_session.add(LeaveMessage(GuildId=987654321, ChannelId=111, Enabled=True))
+        db_session.commit()
+
+        await LeaveMsg._leavemsg_disable.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "disabled" in msg.lower() or "deaktiviert" in msg.lower()
+
+    async def test_disable_not_configured(self, cog, interaction):
+        with pytest.raises(NerpyValidationError, match="not configured|nicht konfiguriert"):
+            await LeaveMsg._leavemsg_disable.callback(cog, interaction)
+
+
+# ---------------------------------------------------------------------------
+# /leavemsg message
+# ---------------------------------------------------------------------------
+
+
+class TestLeavemsgMessage:
+    async def test_set_message_success(self, cog, interaction, db_session):
+        db_session.add(LeaveMessage(GuildId=987654321, ChannelId=111, Enabled=True))
+        db_session.commit()
+
+        await LeaveMsg._leavemsg_message.callback(cog, interaction, "Goodbye {member}!")
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Goodbye {member}!" in msg
+
+        config = db_session.query(LeaveMessage).filter_by(GuildId=987654321).first()
+        assert config.Message == "Goodbye {member}!"
+
+    async def test_set_message_missing_placeholder(self, cog, interaction, db_session):
+        db_session.add(LeaveMessage(GuildId=987654321, ChannelId=111, Enabled=True))
+        db_session.commit()
+
+        with pytest.raises(NerpyValidationError, match="\\{member\\}"):
+            await LeaveMsg._leavemsg_message.callback(cog, interaction, "No placeholder here")
+
+    async def test_set_message_not_enabled(self, cog, interaction):
+        with pytest.raises(NerpyValidationError, match="enable|aktiviere"):
+            await LeaveMsg._leavemsg_message.callback(cog, interaction, "Bye {member}")
+
+
+# ---------------------------------------------------------------------------
+# /leavemsg status
+# ---------------------------------------------------------------------------
+
+
+class TestLeavemsgStatus:
+    async def test_status_not_enabled(self, cog, interaction):
+        await LeaveMsg._leavemsg_status.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "not enabled" in msg.lower() or "nicht aktiviert" in msg.lower()
+
+    async def test_status_enabled(self, cog, interaction, db_session):
+        db_session.add(LeaveMessage(GuildId=987654321, ChannelId=111, Message="Bye {member}", Enabled=True))
+        db_session.commit()
+
+        channel = MagicMock()
+        channel.mention = "<#111>"
+        interaction.guild.get_channel = MagicMock(return_value=channel)
+
+        await LeaveMsg._leavemsg_status.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "<#111>" in msg
+        assert "Bye {member}" in msg
+
+
+# ---------------------------------------------------------------------------
+# Localization: German guild language
+# ---------------------------------------------------------------------------
+
+
+class TestLeavemsgLocalization:
+    @pytest.fixture(autouse=True)
+    def _set_german(self, db_session):
+        db_session.add(GuildLanguageConfig(GuildId=987654321, Language="de"))
+        db_session.commit()
+
+    async def test_enable_returns_german(self, cog, interaction, db_session):
+        channel = MagicMock()
+        channel.id = 111
+        channel.mention = "<#111>"
+        channel.permissions_for.return_value = MagicMock(view_channel=True, send_messages=True)
+
+        await LeaveMsg._leavemsg_enable.callback(cog, interaction, channel)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "aktiviert" in msg
+
+    async def test_disable_not_configured_returns_german(self, cog, interaction):
+        with pytest.raises(NerpyValidationError, match="nicht konfiguriert"):
+            await LeaveMsg._leavemsg_disable.callback(cog, interaction)
+
+    async def test_status_not_enabled_returns_german(self, cog, interaction):
+        await LeaveMsg._leavemsg_status.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "nicht aktiviert" in msg
+
+    async def test_message_missing_placeholder_returns_german(self, cog, interaction, db_session):
+        db_session.add(LeaveMessage(GuildId=987654321, ChannelId=111, Enabled=True))
+        db_session.commit()
+
+        with pytest.raises(NerpyValidationError, match="Platzhalter"):
+            await LeaveMsg._leavemsg_message.callback(cog, interaction, "No placeholder")


### PR DESCRIPTION
## Summary
- Localize all 8 user-facing strings in the `leavemsg` module (enable/disable/message/status commands)
- Add `leavemsg.*` YAML keys with EN/DE translations
- Pattern: look up guild language once per command with `get_guild_language()`, then use `get_string()` for all messages
- User-defined leave message templates (`{member}` placeholder) pass through untouched — no double-substitution risk
- Add `LeaveMessage` model import to test conftest `db_engine`

## Test plan
- [x] 676 tests pass (13 new leavemsg tests)
- [x] Enable/disable/message/status commands return correct English responses
- [x] German guild returns German responses (4 localization tests)
- [x] Validation errors (missing placeholder, not configured, not enabled) are localized
- [x] Status display correctly includes user-defined `{member}` template literally

Phase 2 module #2 of 12 — localizes leavemsg command responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)