### PR TITLE
feat(i18n): localize league module embed fields

### DIFF
--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -39,6 +39,14 @@ music:
   search:
     no_results: "Deine Suche hat keine Ergebnisse geliefert."
 
+league:
+  summoner:
+    level: "Beschwörerstufe: {level}"
+    rank: "Rang"
+    league_points: "Ligapunkte"
+    wins: "Siege"
+    losses: "Niederlagen"
+
 leavemsg:
   enable:
     success: "Abschiedsnachrichten in {channel} aktiviert."

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -39,6 +39,14 @@ music:
   search:
     no_results: "Your search did not yield any results."
 
+league:
+  summoner:
+    level: "Summoner Level: {level}"
+    rank: "Rank"
+    league_points: "League Points"
+    wins: "Wins"
+    losses: "Losses"
+
 leavemsg:
   enable:
     success: "Leave messages enabled in {channel}."

--- a/NerdyPy/modules/league.py
+++ b/NerdyPy/modules/league.py
@@ -9,6 +9,7 @@ from discord.ext.commands import GroupCog
 from utils.cog import NerpyBotCog
 from utils.errors import NerpyInfraException
 from utils.helpers import error_context
+from utils.strings import get_guild_language, get_string
 
 
 class LeagueCommand(Enum):
@@ -27,6 +28,10 @@ class League(NerpyBotCog, GroupCog):
         super().__init__(bot)
         self.version = None
         self.config = self.bot.config["league"]
+
+    def _lang(self, guild_id: int) -> str:
+        with self.bot.session_scope() as session:
+            return get_guild_language(guild_id, session)
 
     async def _get_latest_version(self) -> str:
         if self.version is None:
@@ -47,6 +52,7 @@ class League(NerpyBotCog, GroupCog):
         """get information about the summoner"""
         rank = tier = lp = wins = losses = ""
 
+        lang = self._lang(interaction.guild_id)
         auth_header = {"X-Riot-Token": self.config["riot"]}
         summoner_url = self._get_url(region, LeagueCommand.SUMMONER_BY_NAME, summoner_name)
 
@@ -81,13 +87,13 @@ class League(NerpyBotCog, GroupCog):
                     emb.set_thumbnail(
                         url=f"https://ddragon.leagueoflegends.com/cdn/{ver}/img/profileicon/{icon_id}.png"
                     )
-                    emb.description = f"Summoner Level: {level}"
+                    emb.description = get_string(lang, "league.summoner.level", level=level)
 
                     if played_ranked:
-                        emb.add_field(name="Rank", value=f"{tier} {rank}")
-                        emb.add_field(name="League Points", value=lp)
-                        emb.add_field(name="Wins", value=wins)
-                        emb.add_field(name="Losses", value=losses)
+                        emb.add_field(name=get_string(lang, "league.summoner.rank"), value=f"{tier} {rank}")
+                        emb.add_field(name=get_string(lang, "league.summoner.league_points"), value=lp)
+                        emb.add_field(name=get_string(lang, "league.summoner.wins"), value=wins)
+                        emb.add_field(name=get_string(lang, "league.summoner.losses"), value=losses)
 
         await interaction.response.send_message(embed=emb)
 

--- a/tests/modules/test_league.py
+++ b/tests/modules/test_league.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""Tests for modules.league — localized summoner embed fields."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from models.admin import GuildLanguageConfig
+from modules.league import League
+from utils.strings import load_strings
+
+
+@pytest.fixture(autouse=True)
+def _load_locale_strings():
+    load_strings()
+
+
+@pytest.fixture
+def cog(mock_bot):
+    mock_bot.config = {"league": {"riot": "fake-riot-key"}}
+    cog = League.__new__(League)
+    cog.bot = mock_bot
+    cog.config = mock_bot.config["league"]
+    cog.version = "14.1.1"
+    return cog
+
+
+@pytest.fixture
+def interaction(mock_interaction):
+    mock_interaction.guild.id = 987654321
+    mock_interaction.guild_id = 987654321
+    return mock_interaction
+
+
+def _mock_riot_api(summoner_data, rank_data):
+    """Create a nested mock that simulates aiohttp ClientSession context managers."""
+
+    def make_response(data):
+        resp = AsyncMock()
+        resp.json = AsyncMock(return_value=data)
+        return resp
+
+    summoner_resp = make_response(summoner_data)
+    rank_resp = make_response(rank_data)
+
+    call_count = 0
+
+    def session_factory(*args, **kwargs):
+        nonlocal call_count
+        session = AsyncMock()
+
+        if call_count == 0:
+            # First ClientSession — summoner lookup
+            session.get = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=summoner_resp)))
+            session.__aenter__ = AsyncMock(return_value=session)
+            session.__aexit__ = AsyncMock(return_value=False)
+        else:
+            # Second ClientSession — rank lookup
+            session.get = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=rank_resp)))
+            session.__aenter__ = AsyncMock(return_value=session)
+            session.__aexit__ = AsyncMock(return_value=False)
+
+        call_count += 1
+        return session
+
+    return session_factory
+
+
+SUMMONER_DATA = {
+    "id": "abc123",
+    "name": "TestPlayer",
+    "summonerLevel": 42,
+    "profileIconId": 1234,
+}
+
+RANK_DATA = [
+    {
+        "rank": "I",
+        "tier": "GOLD",
+        "leaguePoints": 75,
+        "wins": 100,
+        "losses": 50,
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# /league summoner — English
+# ---------------------------------------------------------------------------
+
+
+class TestSummonerEnglish:
+    async def test_summoner_embed_fields(self, cog, interaction):
+        with patch("modules.league.ClientSession", side_effect=_mock_riot_api(SUMMONER_DATA, RANK_DATA)):
+            await League.summoner.callback(cog, interaction, "EUW1", "TestPlayer")
+
+        emb = interaction.response.send_message.call_args[1]["embed"]
+        assert "Summoner Level: 42" in emb.description
+        field_names = [f.name for f in emb.fields]
+        assert "Rank" in field_names
+        assert "League Points" in field_names
+        assert "Wins" in field_names
+        assert "Losses" in field_names
+
+    async def test_summoner_no_ranked(self, cog, interaction):
+        with patch("modules.league.ClientSession", side_effect=_mock_riot_api(SUMMONER_DATA, [])):
+            await League.summoner.callback(cog, interaction, "EUW1", "TestPlayer")
+
+        emb = interaction.response.send_message.call_args[1]["embed"]
+        assert "Summoner Level: 42" in emb.description
+        assert len(emb.fields) == 0
+
+
+# ---------------------------------------------------------------------------
+# /league summoner — German
+# ---------------------------------------------------------------------------
+
+
+class TestSummonerGerman:
+    async def test_summoner_embed_fields_german(self, cog, interaction, db_session):
+        db_session.add(GuildLanguageConfig(GuildId=987654321, Language="de"))
+        db_session.commit()
+
+        with patch("modules.league.ClientSession", side_effect=_mock_riot_api(SUMMONER_DATA, RANK_DATA)):
+            await League.summoner.callback(cog, interaction, "EUW1", "TestPlayer")
+
+        emb = interaction.response.send_message.call_args[1]["embed"]
+        assert "Beschwörerstufe: 42" in emb.description
+        field_names = [f.name for f in emb.fields]
+        assert "Rang" in field_names
+        assert "Ligapunkte" in field_names
+        assert "Siege" in field_names
+        assert "Niederlagen" in field_names


### PR DESCRIPTION
## Summary
- Replace hardcoded English embed field labels in the `/league summoner` command with `get_string()` lookups
- Add 5 YAML keys (`league.summoner.*`) with EN/DE translations: level description, rank, league points, wins, losses
- Add `_lang()` helper method on the League cog (same pattern as music)
- Add 3 new tests: English embed fields, no-ranked case, German embed fields

## Test plan
- [x] `uv run python -m pytest` — 687 tests pass
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] German locale test verifies translated field names ("Rang", "Ligapunkte", "Siege", "Niederlagen")

🤖 Generated with [Claude Code](https://claude.com/claude-code)