### PR TITLE
feat(i18n): localize rolemanage module responses

### DIFF
--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -47,6 +47,29 @@ league:
     wins: "Siege"
     losses: "Niederlagen"
 
+rolemanage:
+  allow:
+    success: "**{source}** darf jetzt **{target}** zuweisen."
+    already_exists: "**{source}** darf **{target}** bereits zuweisen."
+  deny:
+    success: "**{source}** darf **{target}** nicht mehr zuweisen."
+    not_found: "Keine passende Zuordnung gefunden."
+  list:
+    title: "🔗 Delegierte Rollenzuordnungen"
+    empty: "Keine Rollenzuordnungen konfiguriert."
+  assign:
+    success: "**{role}** wurde **{member}** zugewiesen."
+    no_permission: "Du hast keine Berechtigung, diese Rolle zuzuweisen."
+    already_has: "**{member}** hat **{role}** bereits."
+    forbidden: "Ich habe keine Berechtigung, **{role}** zuzuweisen. Stelle sicher, dass ich die Berechtigung `Rollen verwalten` habe und meine höchste Rolle über dieser Rolle liegt."
+    discord_error: "Discord-Fehler beim Zuweisen der Rolle (HTTP {status}). Bitte versuche es erneut."
+  remove:
+    success: "**{role}** wurde von **{member}** entfernt."
+    no_permission: "Du hast keine Berechtigung, diese Rolle zu entfernen."
+    does_not_have: "**{member}** hat **{role}** nicht."
+    forbidden: "Ich habe keine Berechtigung, **{role}** zu entfernen. Stelle sicher, dass ich die Berechtigung `Rollen verwalten` habe und meine höchste Rolle über dieser Rolle liegt."
+    discord_error: "Discord-Fehler beim Entfernen der Rolle (HTTP {status}). Bitte versuche es erneut."
+
 leavemsg:
   enable:
     success: "Abschiedsnachrichten in {channel} aktiviert."

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -47,6 +47,29 @@ league:
     wins: "Wins"
     losses: "Losses"
 
+rolemanage:
+  allow:
+    success: "**{source}** can now assign **{target}**."
+    already_exists: "**{source}** can already assign **{target}**."
+  deny:
+    success: "**{source}** can no longer assign **{target}**."
+    not_found: "No matching mapping found."
+  list:
+    title: "🔗 Delegated Role Mappings"
+    empty: "No role mappings configured."
+  assign:
+    success: "Assigned **{role}** to **{member}**."
+    no_permission: "You do not have permission to assign that role."
+    already_has: "**{member}** already has **{role}**."
+    forbidden: "I don't have permission to assign **{role}**. Make sure I have the `Manage Roles` permission and my highest role is above that role."
+    discord_error: "Discord error while assigning role (HTTP {status}). Please try again."
+  remove:
+    success: "Removed **{role}** from **{member}**."
+    no_permission: "You do not have permission to remove that role."
+    does_not_have: "**{member}** does not have **{role}**."
+    forbidden: "I don't have permission to remove **{role}**. Make sure I have the `Manage Roles` permission and my highest role is above that role."
+    discord_error: "Discord error while removing role (HTTP {status}). Please try again."
+
 leavemsg:
   enable:
     success: "Leave messages enabled in {channel}."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def db_engine():
     from models.tagging import Tag, TagEntry  # noqa: F401
     from models.admin import BotModeratorRole, PermissionSubscriber, GuildLanguageConfig  # noqa: F401
     from models.leavemsg import LeaveMessage  # noqa: F401
+    from models.rolemanage import RoleMapping  # noqa: F401
     from models.wow import WowGuildNewsConfig, WowCharacterMounts  # noqa: F401
 
     BASE.metadata.create_all(engine)

--- a/tests/modules/test_rolemanage.py
+++ b/tests/modules/test_rolemanage.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+"""Tests for modules.rolemanage — localized delegated role management responses."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from models.admin import GuildLanguageConfig
+from models.rolemanage import RoleMapping
+from modules.rolemanage import RoleManage
+from utils.strings import load_strings
+
+
+@pytest.fixture(autouse=True)
+def _load_locale_strings():
+    load_strings()
+
+
+@pytest.fixture(autouse=True)
+def _bypass_role_checks(monkeypatch):
+    """Bypass is_role_assignable/is_role_below_bot — tested separately in test_checks.py."""
+
+    async def _always_true(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr("modules.rolemanage.is_role_assignable", _always_true)
+    monkeypatch.setattr("modules.rolemanage.is_role_below_bot", _always_true)
+
+
+@pytest.fixture
+def cog(mock_bot):
+    cog = RoleManage.__new__(RoleManage)
+    cog.bot = mock_bot
+    return cog
+
+
+@pytest.fixture
+def interaction(mock_interaction):
+    mock_interaction.guild.id = 987654321
+    mock_interaction.guild_id = 987654321
+    return mock_interaction
+
+
+@pytest.fixture
+def source_role():
+    role = MagicMock()
+    role.id = 111
+    role.name = "Moderator"
+    return role
+
+
+@pytest.fixture
+def target_role():
+    role = MagicMock()
+    role.id = 222
+    role.name = "Verified"
+    role.managed = False
+    role.is_integration = MagicMock(return_value=False)
+    return role
+
+
+@pytest.fixture
+def member():
+    m = MagicMock()
+    m.display_name = "TestUser"
+    m.roles = []
+    m.add_roles = AsyncMock()
+    m.remove_roles = AsyncMock()
+    return m
+
+
+def _set_german(db_session):
+    db_session.add(GuildLanguageConfig(GuildId=987654321, Language="de"))
+    db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# /rolemanage allow
+# ---------------------------------------------------------------------------
+
+
+class TestAllow:
+    async def test_allow_success(self, cog, interaction, source_role, target_role):
+        await RoleManage._allow.callback(cog, interaction, source_role, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "can now assign" in msg
+        assert "Moderator" in msg
+        assert "Verified" in msg
+
+    async def test_allow_already_exists(self, cog, interaction, source_role, target_role, db_session):
+        db_session.add(RoleMapping(GuildId=987654321, SourceRoleId=111, TargetRoleId=222))
+        db_session.commit()
+
+        await RoleManage._allow.callback(cog, interaction, source_role, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "already assign" in msg
+
+    async def test_allow_german(self, cog, interaction, source_role, target_role, db_session):
+        _set_german(db_session)
+
+        await RoleManage._allow.callback(cog, interaction, source_role, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "darf jetzt" in msg
+
+
+# ---------------------------------------------------------------------------
+# /rolemanage deny
+# ---------------------------------------------------------------------------
+
+
+class TestDeny:
+    async def test_deny_success(self, cog, interaction, source_role, target_role, db_session):
+        db_session.add(RoleMapping(GuildId=987654321, SourceRoleId=111, TargetRoleId=222))
+        db_session.commit()
+
+        await RoleManage._deny.callback(cog, interaction, source_role, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "no longer assign" in msg
+
+    async def test_deny_not_found(self, cog, interaction, source_role, target_role):
+        await RoleManage._deny.callback(cog, interaction, source_role, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "No matching mapping" in msg
+
+    async def test_deny_german(self, cog, interaction, source_role, target_role, db_session):
+        _set_german(db_session)
+        db_session.add(RoleMapping(GuildId=987654321, SourceRoleId=111, TargetRoleId=222))
+        db_session.commit()
+
+        await RoleManage._deny.callback(cog, interaction, source_role, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "nicht mehr zuweisen" in msg
+
+
+# ---------------------------------------------------------------------------
+# /rolemanage list
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    async def test_list_empty(self, cog, interaction):
+        await RoleManage._list.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "No role mappings" in msg
+
+    async def test_list_empty_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+
+        await RoleManage._list.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Keine Rollenzuordnungen" in msg
+
+
+# ---------------------------------------------------------------------------
+# /rolemanage assign
+# ---------------------------------------------------------------------------
+
+
+class TestAssign:
+    async def test_assign_no_permission(self, cog, interaction, member, target_role):
+        await RoleManage._assign.callback(cog, interaction, member, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "permission to assign" in msg
+
+    async def test_assign_success(self, cog, interaction, member, target_role, db_session):
+        db_session.add(RoleMapping(GuildId=987654321, SourceRoleId=111, TargetRoleId=222))
+        db_session.commit()
+        interaction.user.roles = [MagicMock(id=111)]
+
+        await RoleManage._assign.callback(cog, interaction, member, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Assigned" in msg
+        assert "Verified" in msg
+        member.add_roles.assert_called_once()
+
+    async def test_assign_german(self, cog, interaction, member, target_role, db_session):
+        _set_german(db_session)
+        db_session.add(RoleMapping(GuildId=987654321, SourceRoleId=111, TargetRoleId=222))
+        db_session.commit()
+        interaction.user.roles = [MagicMock(id=111)]
+
+        await RoleManage._assign.callback(cog, interaction, member, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "zugewiesen" in msg
+
+
+# ---------------------------------------------------------------------------
+# /rolemanage remove
+# ---------------------------------------------------------------------------
+
+
+class TestRemove:
+    async def test_remove_no_permission(self, cog, interaction, member, target_role):
+        await RoleManage._remove.callback(cog, interaction, member, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "permission to remove" in msg
+
+    async def test_remove_success(self, cog, interaction, member, target_role, db_session):
+        db_session.add(RoleMapping(GuildId=987654321, SourceRoleId=111, TargetRoleId=222))
+        db_session.commit()
+        interaction.user.roles = [MagicMock(id=111)]
+        member.roles = [target_role]
+
+        await RoleManage._remove.callback(cog, interaction, member, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Removed" in msg
+        assert "Verified" in msg
+        member.remove_roles.assert_called_once()
+
+    async def test_remove_german(self, cog, interaction, member, target_role, db_session):
+        _set_german(db_session)
+        db_session.add(RoleMapping(GuildId=987654321, SourceRoleId=111, TargetRoleId=222))
+        db_session.commit()
+        interaction.user.roles = [MagicMock(id=111)]
+        member.roles = [target_role]
+
+        await RoleManage._remove.callback(cog, interaction, member, target_role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "entfernt" in msg


### PR DESCRIPTION
## Summary
- Replace 16 hardcoded English strings in all 5 rolemanage subcommands (allow, deny, list, assign, remove) with `get_string()` lookups
- Add 16 YAML keys (`rolemanage.*`) with EN/DE translations covering success messages, error states, and permission feedback
- Language looked up inside each command's existing `session_scope` — no extra DB connections
- Add `RoleMapping` model to test conftest `db_engine`
- Add 14 new tests (English + German) across all subcommands; role permission checks bypassed via monkeypatch (tested separately in `test_checks.py`)

## Test plan
- [x] `uv run python -m pytest` — 701 tests pass
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] German locale tests verify translated strings ("darf jetzt", "nicht mehr zuweisen", "zugewiesen", "entfernt", etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)