### PR TITLE
feat(i18n): localize tagging module responses

### DIFF
--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -86,6 +86,41 @@ reactionrole:
   clear:
     success: "Alle Reaktionsrollen-Zuordnungen von Nachricht `{message_id}` entfernt."
 
+tagging:
+  not_found: "Tag \"{name}\" existiert nicht!"
+  skip:
+    success: "Übersprungen."
+  queue:
+    drop_success: "Warteschlange geleert."
+  create:
+    success: "Tag \"{name}\" erstellt!"
+    already_exists: "Tag \"{name}\" existiert bereits!"
+  add:
+    success: "Eintrag zu Tag \"{name}\" hinzugefügt!"
+  volume:
+    success: "Lautstärke von \"{name}\" auf {volume} geändert."
+    out_of_range: "Lautstärke muss zwischen 0 und 200 liegen."
+  delete:
+    success: "Tag \"{name}\" gelöscht!"
+  get:
+    not_found: "Konnte keinen Tag namens \"{name}\" finden."
+    playing: "Spiele **{name}**"
+  list:
+    title: "🏷️ Tags"
+    empty: "Keine Tags gefunden."
+    entry_count_one: "{count} Eintrag"
+    entry_count_other: "{count} Einträge"
+  info:
+    author: "Autor"
+    type: "Typ"
+    created: "Erstellt"
+    hits: "Aufrufe"
+    entries: "Einträge"
+    volume: "Lautstärke"
+  raw:
+    title: "🏷️ {name} — Rohdaten"
+    binary_data: "*(Binäre Audiodaten)*"
+
 leavemsg:
   enable:
     success: "Abschiedsnachrichten in {channel} aktiviert."

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -86,6 +86,41 @@ reactionrole:
   clear:
     success: "Cleared all reaction role mappings from message `{message_id}`."
 
+tagging:
+  not_found: "Tag \"{name}\" doesn't exist!"
+  skip:
+    success: "Skipped."
+  queue:
+    drop_success: "Queue dropped."
+  create:
+    success: "Tag \"{name}\" created!"
+    already_exists: "Tag \"{name}\" already exists!"
+  add:
+    success: "Entry added to tag \"{name}\"!"
+  volume:
+    success: "Changed volume of \"{name}\" to {volume}."
+    out_of_range: "Volume must be between 0 and 200."
+  delete:
+    success: "Tag \"{name}\" deleted!"
+  get:
+    not_found: "Could not find a tag called \"{name}\"."
+    playing: "Playing **{name}**"
+  list:
+    title: "🏷️ Tags"
+    empty: "No tags found."
+    entry_count_one: "{count} entry"
+    entry_count_other: "{count} entries"
+  info:
+    author: "Author"
+    type: "Type"
+    created: "Created"
+    hits: "Hits"
+    entries: "Entries"
+    volume: "Volume"
+  raw:
+    title: "🏷️ {name} — Raw"
+    binary_data: "*(binary audio data)*"
+
 leavemsg:
   enable:
     success: "Leave messages enabled in {channel}."


### PR DESCRIPTION
## Summary
- Replace 23 hardcoded English strings across all tagging commands (get, skip, queue drop, create, add, volume, delete, list, info, raw) with `get_string()` lookups
- Add 23 YAML keys (`tagging.*`) with EN/DE translations
- Shared `tagging.not_found` key for add/volume/delete "tag doesn't exist" messages (also fixes `"doesn't exists"` typo)
- Pluralization via `entry_count_one`/`entry_count_other` keys for tag list entry counts ("1 entry" / "3 entries" → "1 Eintrag" / "3 Einträge")
- Embed field labels in `/tag info` localized (Author→Autor, Hits→Aufrufe, etc.)
- Add 12 new localization tests (English + German) for skip, queue drop, create, volume, delete, list

## Test plan
- [x] `uv run python -m pytest` — 724 tests pass
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] German locale tests verify translated strings ("Übersprungen", "Warteschlange", "existiert bereits", "zwischen 0 und 200", "existiert nicht", "Keine Tags gefunden")

🤖 Generated with [Claude Code](https://claude.com/claude-code)