### PR TITLE
feat(i18n): localize admin modrole and botpermissions responses

### DIFF
--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -25,6 +25,17 @@ admin:
     get_current: "Serversprache: **{language}**"
     get_default: "Keine Sprache konfiguriert. Standard ist Englisch."
     invalid: "Nicht unterstützte Sprache: `{language}`. Verfügbar: {available}"
+  modrole:
+    get_current: "Bot-Moderator-Rolle: **{role}**"
+    get_stale: "Eine Bot-Moderator-Rolle ist konfiguriert, aber die Rolle existiert nicht mehr. Verwende `/admin modrole delete` um sie zu entfernen."
+    get_none: "Keine Bot-Moderator-Rolle konfiguriert. Es werden berechtigungsbasierte Prüfungen verwendet."
+    set_success: "Bot-Moderator-Rolle auf **{role}** gesetzt."
+    delete_success: "Bot-Moderator-Rolle entfernt."
+  botpermissions:
+    already_subscribed: "Du hast Berechtigungsbenachrichtigungen bereits abonniert."
+    subscribed: "Abonniert. Du erhältst eine DM, wenn der Bot mit fehlenden Berechtigungen auf diesem Server neu startet."
+    not_subscribed: "Du hast Berechtigungsbenachrichtigungen nicht abonniert."
+    unsubscribed: "Berechtigungsbenachrichtigungen für diesen Server abbestellt."
 
 music:
   skip:

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -25,6 +25,17 @@ admin:
     get_current: "Server language: **{language}**"
     get_default: "No language configured. Defaulting to English."
     invalid: "Unsupported language: `{language}`. Available: {available}"
+  modrole:
+    get_current: "Bot-moderator role: **{role}**"
+    get_stale: "A bot-moderator role is configured but the role no longer exists. Use `/admin modrole delete` to clear it."
+    get_none: "No bot-moderator role configured. Falling back to permission-based checks."
+    set_success: "Bot-moderator role set to **{role}**."
+    delete_success: "Bot-moderator role removed."
+  botpermissions:
+    already_subscribed: "You are already subscribed to permission notifications."
+    subscribed: "Subscribed. You will receive a DM when the bot restarts with missing permissions in this server."
+    not_subscribed: "You are not subscribed to permission notifications."
+    unsubscribed: "Unsubscribed from permission notifications for this server."
 
 music:
   skip:

--- a/tests/modules/test_admin_modrole.py
+++ b/tests/modules/test_admin_modrole.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+"""Tests for admin modrole and botpermissions — localized responses."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from models.admin import BotModeratorRole, GuildLanguageConfig, PermissionSubscriber
+from modules.admin import Admin
+from utils.strings import load_strings
+
+
+@pytest.fixture(autouse=True)
+def _load_locale_strings():
+    load_strings()
+
+
+@pytest.fixture
+def cog(mock_bot):
+    cog = Admin.__new__(Admin)
+    cog.bot = mock_bot
+    return cog
+
+
+@pytest.fixture
+def interaction(mock_interaction):
+    mock_interaction.guild.id = 987654321
+    mock_interaction.guild_id = 987654321
+    mock_interaction.user.id = 123456789
+    return mock_interaction
+
+
+def _set_german(db_session):
+    db_session.add(GuildLanguageConfig(GuildId=987654321, Language="de"))
+    db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# /admin modrole get
+# ---------------------------------------------------------------------------
+
+
+class TestModroleGet:
+    async def test_get_current(self, cog, interaction, db_session):
+        db_session.add(BotModeratorRole(GuildId=987654321, RoleId=555))
+        db_session.commit()
+        role_mock = MagicMock()
+        role_mock.name = "Mods"
+        interaction.guild.get_role = MagicMock(return_value=role_mock)
+
+        await Admin._modrole_get.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Bot-moderator role" in msg
+        assert "Mods" in msg
+
+    async def test_get_none(self, cog, interaction):
+        await Admin._modrole_get.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "No bot-moderator role" in msg
+
+    async def test_get_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+
+        await Admin._modrole_get.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Keine Bot-Moderator-Rolle" in msg
+
+
+# ---------------------------------------------------------------------------
+# /admin modrole set
+# ---------------------------------------------------------------------------
+
+
+class TestModroleSet:
+    async def test_set_success(self, cog, interaction):
+        role = MagicMock()
+        role.id = 555
+        role.name = "Mods"
+
+        await Admin._modrole_set.callback(cog, interaction, role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "set to" in msg
+        assert "Mods" in msg
+
+    async def test_set_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        role = MagicMock()
+        role.id = 555
+        role.name = "Mods"
+
+        await Admin._modrole_set.callback(cog, interaction, role)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "gesetzt" in msg
+
+
+# ---------------------------------------------------------------------------
+# /admin modrole delete
+# ---------------------------------------------------------------------------
+
+
+class TestModroleDelete:
+    async def test_delete_success(self, cog, interaction):
+        await Admin._modrole_del.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "removed" in msg
+
+    async def test_delete_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+
+        await Admin._modrole_del.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "entfernt" in msg
+
+
+# ---------------------------------------------------------------------------
+# /admin botpermissions subscribe
+# ---------------------------------------------------------------------------
+
+
+class TestBotpermissionsSubscribe:
+    async def test_subscribe_success(self, cog, interaction):
+        await Admin._botpermissions_subscribe.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Subscribed" in msg
+
+    async def test_subscribe_already(self, cog, interaction, db_session):
+        db_session.add(PermissionSubscriber(GuildId=987654321, UserId=123456789))
+        db_session.commit()
+
+        await Admin._botpermissions_subscribe.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "already subscribed" in msg
+
+    async def test_subscribe_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+
+        await Admin._botpermissions_subscribe.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Abonniert" in msg
+
+
+# ---------------------------------------------------------------------------
+# /admin botpermissions unsubscribe
+# ---------------------------------------------------------------------------
+
+
+class TestBotpermissionsUnsubscribe:
+    async def test_unsubscribe_not_subscribed(self, cog, interaction):
+        await Admin._botpermissions_unsubscribe.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "not subscribed" in msg
+
+    async def test_unsubscribe_success(self, cog, interaction, db_session):
+        db_session.add(PermissionSubscriber(GuildId=987654321, UserId=123456789))
+        db_session.commit()
+
+        await Admin._botpermissions_unsubscribe.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Unsubscribed" in msg
+
+    async def test_unsubscribe_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+
+        await Admin._botpermissions_unsubscribe.callback(cog, interaction)
+
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "nicht abonniert" in msg


### PR DESCRIPTION
## Summary
- Replace 9 hardcoded English strings in modrole (get/set/delete) and botpermissions (subscribe/unsubscribe) with `get_string()` lookups
- Add 9 YAML keys (`admin.modrole.*`, `admin.botpermissions.*`) with EN/DE translations
- Language looked up inside each command's existing `session_scope`
- Operator-only prefix commands (sync, debug, uptime, errors, disable/enable) and ping intentionally left in English
- Language commands already localized in Phase 1 (PR #235)
- Add 13 new tests covering all modrole and botpermissions paths (English + German)

## Test plan
- [x] `uv run python -m pytest` — 737 tests pass
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] German locale tests verify translated strings ("Bot-Moderator-Rolle", "gesetzt", "entfernt", "Abonniert", "nicht abonniert")

🤖 Generated with [Claude Code](https://claude.com/claude-code)