### PR TITLE
feat(i18n): localize reminder module responses

### DIFF
--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -98,23 +98,23 @@ reactionrole:
     success: "Alle Reaktionsrollen-Zuordnungen von Nachricht `{message_id}` entfernt."
 
 tagging:
-  not_found: "Tag \"{name}\" existiert nicht!"
+  not_found: 'Tag "{name}" existiert nicht!'
   skip:
     success: "Übersprungen."
   queue:
     drop_success: "Warteschlange geleert."
   create:
-    success: "Tag \"{name}\" erstellt!"
-    already_exists: "Tag \"{name}\" existiert bereits!"
+    success: 'Tag "{name}" erstellt!'
+    already_exists: 'Tag "{name}" existiert bereits!'
   add:
-    success: "Eintrag zu Tag \"{name}\" hinzugefügt!"
+    success: 'Eintrag zu Tag "{name}" hinzugefügt!'
   volume:
-    success: "Lautstärke von \"{name}\" auf {volume} geändert."
+    success: 'Lautstärke von "{name}" auf {volume} geändert.'
     out_of_range: "Lautstärke muss zwischen 0 und 200 liegen."
   delete:
-    success: "Tag \"{name}\" gelöscht!"
+    success: 'Tag "{name}" gelöscht!'
   get:
-    not_found: "Konnte keinen Tag namens \"{name}\" finden."
+    not_found: 'Konnte keinen Tag namens "{name}" finden.'
     playing: "Spiele **{name}**"
   list:
     title: "🏷️ Tags"
@@ -151,11 +151,36 @@ reminder:
     success: "Erinnerung erstellt — nächste Auslösung {relative_time}."
   schedule:
     success: "Geplante Erinnerung erstellt — nächste Auslösung {relative_time}."
+    invalid_time: "Ungültiges Zeitformat. Verwende HH:MM (z.B. 09:00)."
+    unknown_timezone: "Unbekannte Zeitzone: {timezone}"
+    day_of_week_required: "day_of_week ist für wöchentliche Erinnerungen erforderlich."
+    day_of_month_required: "day_of_month ist für monatliche Erinnerungen erforderlich."
+    day_of_month_range: "day_of_month muss zwischen 1 und 28 liegen."
+  list:
+    title: "⏰ Erinnerungen"
+    next: "Nächste: {relative} ({absolute})"
+    paused: "pausiert"
+    one_time: "einmalig"
+    every: "alle {delta}"
+    daily_at: "täglich um {time} {timezone}"
+    weekly_at: "wöchentlich {day} um {time} {timezone}"
+    monthly_at: "monatlich Tag {day} um {time} {timezone}"
+    hits: "Aufrufe: {count}"
+  edit:
+    nothing_to_change: "Nichts zu ändern."
+    param_not_applicable: "`{param}` gilt nur für {allowed_types}-Erinnerungen, nicht für {schedule_type}."
+    success: "Erinnerung **#{reminder_id}** aktualisiert: {summary}. Nächste Auslösung {relative_time}."
   delete:
     success: "Nachricht gelöscht."
   pause:
     success: "Erinnerung **#{reminder_id}** pausiert."
+    already_paused: "Erinnerung ist bereits pausiert."
   resume:
     success: "Erinnerung **#{reminder_id}** fortgesetzt."
+    already_active: "Erinnerung ist bereits aktiv."
+    expired: "Erinnerung **#{reminder_id}** ist während der Pause abgelaufen und wurde gelöscht."
   not_found: "Erinnerung nicht gefunden."
   no_reminders: "Keine Erinnerungen gesetzt."
+  relative:
+    a_day: "in einem Tag"
+    days: "in {days} Tagen"

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -98,23 +98,23 @@ reactionrole:
     success: "Cleared all reaction role mappings from message `{message_id}`."
 
 tagging:
-  not_found: "Tag \"{name}\" doesn't exist!"
+  not_found: 'Tag "{name}" doesn''t exist!'
   skip:
     success: "Skipped."
   queue:
     drop_success: "Queue dropped."
   create:
-    success: "Tag \"{name}\" created!"
-    already_exists: "Tag \"{name}\" already exists!"
+    success: 'Tag "{name}" created!'
+    already_exists: 'Tag "{name}" already exists!'
   add:
-    success: "Entry added to tag \"{name}\"!"
+    success: 'Entry added to tag "{name}"!'
   volume:
-    success: "Changed volume of \"{name}\" to {volume}."
+    success: 'Changed volume of "{name}" to {volume}.'
     out_of_range: "Volume must be between 0 and 200."
   delete:
-    success: "Tag \"{name}\" deleted!"
+    success: 'Tag "{name}" deleted!'
   get:
-    not_found: "Could not find a tag called \"{name}\"."
+    not_found: 'Could not find a tag called "{name}".'
     playing: "Playing **{name}**"
   list:
     title: "🏷️ Tags"
@@ -146,17 +146,41 @@ leavemsg:
     not_enabled: "Leave messages are not enabled for this server."
     enabled: "**Leave messages:** Enabled\n**Channel:** {channel}\n**Message:** {message}"
 
-# Example module strings — pattern for Phase 2 migration PRs
 reminder:
   create:
     success: "Reminder created — next fire {relative_time}."
   schedule:
     success: "Scheduled reminder created — next fire {relative_time}."
+    invalid_time: "Invalid time format. Use HH:MM (e.g. 09:00)."
+    unknown_timezone: "Unknown timezone: {timezone}"
+    day_of_week_required: "day_of_week is required for weekly schedules."
+    day_of_month_required: "day_of_month is required for monthly schedules."
+    day_of_month_range: "day_of_month must be between 1 and 28."
+  list:
+    title: "⏰ Reminders"
+    next: "Next: {relative} ({absolute})"
+    paused: "paused"
+    one_time: "one-time"
+    every: "every {delta}"
+    daily_at: "daily at {time} {timezone}"
+    weekly_at: "weekly {day} at {time} {timezone}"
+    monthly_at: "monthly day {day} at {time} {timezone}"
+    hits: "Hits: {count}"
+  edit:
+    nothing_to_change: "Nothing to change."
+    param_not_applicable: "`{param}` only applies to {allowed_types} reminders, not {schedule_type}."
+    success: "Updated reminder **#{reminder_id}**: {summary}. Next fire {relative_time}."
   delete:
     success: "Message deleted."
   pause:
     success: "Paused reminder **#{reminder_id}**."
+    already_paused: "Reminder is already paused."
   resume:
     success: "Resumed reminder **#{reminder_id}**."
+    already_active: "Reminder is already active."
+    expired: "Reminder **#{reminder_id}** expired while paused and has been deleted."
   not_found: "Reminder not found."
   no_reminders: "No reminders set."
+  relative:
+    a_day: "a day from now"
+    days: "{days} days from now"


### PR DESCRIPTION
## Summary
- Migrate all 29 user-facing strings in the reminder module to use `get_string()` / `get_guild_language()` localized lookup
- Add 22 new YAML locale keys (EN + DE) for validation errors, schedule format labels, list display, and relative time
- Thread `lang` parameter through `_format_relative()` for calendar-day strings
- Share validation keys between `schedule` and `edit` commands (DRY: `schedule.invalid_time`, `schedule.unknown_timezone`, `schedule.day_of_month_range`)
- `humanize.naturaltime()` output for <12h durations stays English (no per-call locale support)

## Test plan
- [x] 18 new locale tests covering create, schedule, list, delete, pause, resume, edit, and `_format_relative` in both EN and DE
- [x] All 755 tests passing
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)