### PR TITLE
feat(i18n): localize moderation module responses

### DIFF
--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -184,3 +184,45 @@ reminder:
   relative:
     a_day: "in einem Tag"
     days: "in {days} Tagen"
+
+moderation:
+  invalid_timespan: "Es sind nur Zeiträume bis Wochen erlaubt. Verwende keine Monate oder Jahre."
+  autokicker:
+    configured: "AutoKicker für diesen Server konfiguriert."
+    default_reminder: "Du hast keine Rolle auf {guild} gewählt. Bitte wähle eine Rolle bis {deadline}."
+  autodeleter:
+    no_config: "Keine Auto-Lösch-Konfiguration für {channel}."
+    create:
+      success: 'AutoDeleter für Kanal "{channel}" konfiguriert.'
+      already_exists: "Dieser Kanal ist bereits für AutoDelete konfiguriert. Bitte bearbeite oder lösche die bestehende Konfiguration."
+    delete:
+      success: 'Konfiguration für Kanal "{channel}" gelöscht.'
+      not_found: 'Keine Konfiguration für Kanal "{channel}" gefunden!'
+    list:
+      title: "🗑️ AutoDeleter"
+      empty: "Keine Konfiguration gefunden!"
+      entry_details: "Alterslimit: {age} · Behalten: {keep} · Angeheftete löschen: {pinned}"
+      pinned_yes: "Ja"
+      pinned_no: "Nein"
+    pause:
+      success: "Auto-Löschung für {channel} pausiert."
+      already_paused: "Auto-Löschung für {channel} ist bereits pausiert."
+    resume:
+      success: "Auto-Löschung für {channel} fortgesetzt."
+      already_active: "Auto-Löschung für {channel} ist bereits aktiv."
+    edit:
+      success: 'Konfiguration für Kanal "{channel}" aktualisiert.'
+      not_found: 'Konfiguration für Kanal "{channel}" existiert nicht. Bitte erstelle zuerst eine.'
+  user:
+    info:
+      original_name: "Originalname: {name}"
+      created: "Erstellt"
+      joined: "Beigetreten"
+      top_role: "Höchste Rolle"
+      roles: "Rollen"
+    list:
+      title: "👥 Mitglieder"
+      empty: "Keine gefunden."
+      entry_no_roles: "**{name}** — beigetreten: {joined}"
+      entry_full: "**{name}** — erstellt: {created} · beigetreten: {joined}"
+  membercount: "Derzeit sind **{count}** Mitglieder auf diesem Server."

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -184,3 +184,45 @@ reminder:
   relative:
     a_day: "a day from now"
     days: "{days} days from now"
+
+moderation:
+  invalid_timespan: "Only timespans up until weeks are allowed. Do not use months or years."
+  autokicker:
+    configured: "AutoKicker configured for this server."
+    default_reminder: "You have not selected a role on {guild}. Please choose a role until {deadline}."
+  autodeleter:
+    no_config: "No auto-delete config for {channel}."
+    create:
+      success: 'AutoDeleter configured for channel "{channel}".'
+      already_exists: "This channel is already configured for AutoDelete. Please edit or delete the existing configuration."
+    delete:
+      success: 'Deleted configuration for channel "{channel}".'
+      not_found: 'No configuration for channel "{channel}" found!'
+    list:
+      title: "🗑️ AutoDeleter"
+      empty: "No configuration found!"
+      entry_details: "Age limit: {age} · Keep: {keep} · Delete pinned: {pinned}"
+      pinned_yes: "Yes"
+      pinned_no: "No"
+    pause:
+      success: "Paused auto-deletion for {channel}."
+      already_paused: "Auto-deletion is already paused for {channel}."
+    resume:
+      success: "Resumed auto-deletion for {channel}."
+      already_active: "Auto-deletion is already active for {channel}."
+    edit:
+      success: 'Updated configuration for channel "{channel}".'
+      not_found: 'Configuration for channel "{channel}" does not exist. Please create one first.'
+  user:
+    info:
+      original_name: "Original name: {name}"
+      created: "Created"
+      joined: "Joined"
+      top_role: "Top Role"
+      roles: "Roles"
+    list:
+      title: "👥 Members"
+      empty: "None found."
+      entry_no_roles: "**{name}** — joined: {joined}"
+      entry_full: "**{name}** — created: {created} · joined: {joined}"
+  membercount: "There are currently **{count}** members on this server."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def db_engine():
     from models.tagging import Tag, TagEntry  # noqa: F401
     from models.admin import BotModeratorRole, PermissionSubscriber, GuildLanguageConfig  # noqa: F401
     from models.leavemsg import LeaveMessage  # noqa: F401
+    from models.moderation import AutoDelete, AutoKicker  # noqa: F401
     from models.reactionrole import ReactionRoleEntry, ReactionRoleMessage  # noqa: F401
     from models.rolemanage import RoleMapping  # noqa: F401
     from models.wow import WowGuildNewsConfig, WowCharacterMounts  # noqa: F401

--- a/tests/modules/test_moderation.py
+++ b/tests/modules/test_moderation.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+"""Tests for moderation module — localized responses."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from models.admin import GuildLanguageConfig
+from models.moderation import AutoDelete
+from modules.moderation import Moderation
+from utils.strings import load_strings
+
+
+@pytest.fixture(autouse=True)
+def _load_locale_strings():
+    load_strings()
+
+
+@pytest.fixture
+def cog(mock_bot):
+    cog = Moderation.__new__(Moderation)
+    cog.bot = mock_bot
+    cog._autokicker_loop = MagicMock()
+    cog._autodeleter_loop = MagicMock()
+    cog._autokicker_loop.start = MagicMock()
+    cog._autodeleter_loop.start = MagicMock()
+    cog._autokicker_loop.cancel = MagicMock()
+    cog._autodeleter_loop.cancel = MagicMock()
+    return cog
+
+
+@pytest.fixture
+def interaction(mock_interaction):
+    mock_interaction.guild.id = 987654321
+    mock_interaction.guild_id = 987654321
+    mock_interaction.guild.get_channel = MagicMock(return_value=mock_interaction.channel)
+    mock_interaction.channel.permissions_for = MagicMock(
+        return_value=MagicMock(view_channel=True, send_messages=True, manage_messages=True, read_message_history=True)
+    )
+    return mock_interaction
+
+
+def _set_german(db_session):
+    db_session.add(GuildLanguageConfig(GuildId=987654321, Language="de"))
+    db_session.commit()
+
+
+def _make_channel_mock(channel_id=555, name="test-channel"):
+    ch = MagicMock()
+    ch.id = channel_id
+    ch.name = name
+    ch.mention = f"<#{channel_id}>"
+    ch.permissions_for = MagicMock(
+        return_value=MagicMock(view_channel=True, send_messages=True, manage_messages=True, read_message_history=True)
+    )
+    return ch
+
+
+# ---------------------------------------------------------------------------
+# /moderation autokicker
+# ---------------------------------------------------------------------------
+
+
+class TestAutokicker:
+    async def test_configured_english(self, cog, interaction, db_session):
+        await Moderation.autokicker.callback(cog, interaction, enable=True, kick_after="1 day")
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "AutoKicker configured" in msg
+
+    async def test_configured_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        await Moderation.autokicker.callback(cog, interaction, enable=True, kick_after="1 day")
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "AutoKicker für diesen Server konfiguriert" in msg
+
+    async def test_invalid_timespan_english(self, cog, interaction, db_session):
+        await Moderation.autokicker.callback(cog, interaction, enable=True, kick_after="invalid")
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Only timespans" in msg
+
+    async def test_invalid_timespan_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        await Moderation.autokicker.callback(cog, interaction, enable=True, kick_after="invalid")
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "nur Zeiträume" in msg
+
+
+# ---------------------------------------------------------------------------
+# /moderation autodeleter create
+# ---------------------------------------------------------------------------
+
+
+class TestAutodeleterCreate:
+    async def test_create_english(self, cog, interaction, db_session):
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_create.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "AutoDeleter configured" in msg
+        assert "test-channel" in msg
+
+    async def test_create_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_create.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "AutoDeleter für Kanal" in msg
+
+    async def test_create_already_exists(self, cog, interaction, db_session):
+        db_session.add(AutoDelete(GuildId=987654321, ChannelId=555, Enabled=True))
+        db_session.commit()
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_create.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "already configured" in msg
+
+    async def test_create_already_exists_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        db_session.add(AutoDelete(GuildId=987654321, ChannelId=555, Enabled=True))
+        db_session.commit()
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_create.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "bereits für AutoDelete konfiguriert" in msg
+
+
+# ---------------------------------------------------------------------------
+# /moderation autodeleter delete
+# ---------------------------------------------------------------------------
+
+
+class TestAutodeleterDelete:
+    async def test_delete_english(self, cog, interaction, db_session):
+        db_session.add(AutoDelete(GuildId=987654321, ChannelId=555, Enabled=True))
+        db_session.commit()
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_delete.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Deleted configuration" in msg
+
+    async def test_delete_not_found_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_delete.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Keine Konfiguration für Kanal" in msg
+
+
+# ---------------------------------------------------------------------------
+# /moderation autodeleter list
+# ---------------------------------------------------------------------------
+
+
+class TestAutodeleterList:
+    async def test_list_empty_english(self, cog, interaction, db_session):
+        await Moderation._autodeleter_list.callback(cog, interaction)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "No configuration found" in msg
+
+    async def test_list_empty_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        await Moderation._autodeleter_list.callback(cog, interaction)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Keine Konfiguration gefunden" in msg
+
+
+# ---------------------------------------------------------------------------
+# /moderation autodeleter pause
+# ---------------------------------------------------------------------------
+
+
+class TestAutodeleterPause:
+    async def test_pause_no_config_english(self, cog, interaction, db_session):
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_pause.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "No auto-delete config" in msg
+
+    async def test_pause_already_paused_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        db_session.add(AutoDelete(GuildId=987654321, ChannelId=555, Enabled=False))
+        db_session.commit()
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_pause.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "bereits pausiert" in msg
+
+    async def test_pause_success_english(self, cog, interaction, db_session):
+        db_session.add(AutoDelete(GuildId=987654321, ChannelId=555, Enabled=True))
+        db_session.commit()
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_pause.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Paused auto-deletion" in msg
+
+
+# ---------------------------------------------------------------------------
+# /moderation autodeleter resume
+# ---------------------------------------------------------------------------
+
+
+class TestAutodeleterResume:
+    async def test_resume_already_active_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        db_session.add(AutoDelete(GuildId=987654321, ChannelId=555, Enabled=True))
+        db_session.commit()
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_resume.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "bereits aktiv" in msg
+
+    async def test_resume_success_english(self, cog, interaction, db_session):
+        db_session.add(AutoDelete(GuildId=987654321, ChannelId=555, Enabled=False))
+        db_session.commit()
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_resume.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Resumed auto-deletion" in msg
+
+
+# ---------------------------------------------------------------------------
+# /moderation autodeleter edit
+# ---------------------------------------------------------------------------
+
+
+class TestAutodeleterEdit:
+    async def test_edit_not_found_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_modify.callback(cog, interaction, channel=channel)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "existiert nicht" in msg
+
+    async def test_edit_success_english(self, cog, interaction, db_session):
+        db_session.add(AutoDelete(GuildId=987654321, ChannelId=555, Enabled=True))
+        db_session.commit()
+        channel = _make_channel_mock()
+        await Moderation._autodeleter_modify.callback(cog, interaction, channel=channel, keep_messages=10)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Updated configuration" in msg
+
+
+# ---------------------------------------------------------------------------
+# /moderation membercount
+# ---------------------------------------------------------------------------
+
+
+class TestMembercount:
+    async def test_membercount_english(self, cog, interaction, db_session):
+        interaction.guild.member_count = 42
+        await Moderation.membercount.callback(cog, interaction)
+        emb = interaction.response.send_message.call_args[1]["embed"]
+        assert "42" in emb.description
+        assert "members" in emb.description
+
+    async def test_membercount_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        interaction.guild.member_count = 42
+        await Moderation.membercount.callback(cog, interaction)
+        emb = interaction.response.send_message.call_args[1]["embed"]
+        assert "42" in emb.description
+        assert "Mitglieder" in emb.description


### PR DESCRIPTION
## Summary
- Replace all hardcoded English strings in the moderation module with `get_string()` / `get_guild_language()` lookups (29 keys across autokicker, autodeleter, user info/list, membercount)
- Fix latent bug: autodeleter list used `is not None` instead of truthiness check — `.all()` returns `[]` not `None`, so the "empty" branch was unreachable
- Add 21 new localization tests in `tests/modules/test_moderation.py` covering both EN and DE responses

## Test plan
- [x] All 776 tests pass (`uv run python -m pytest`)
- [x] `ruff check` and `ruff format --check` clean
- [x] YAML files formatted with prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)