### PR TITLE
feat(i18n): localize wow module responses

### DIFF
--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -226,3 +226,47 @@ moderation:
       entry_no_roles: "**{name}** — beigetreten: {joined}"
       entry_full: "**{name}** — erstellt: {created} · beigetreten: {joined}"
   membercount: "Derzeit sind **{count}** Mitglieder auf diesem Server."
+
+wow:
+  realm_not_found: "Unbekanntes Realm '{realm}' in {region}. Verwende die Autovervollständigung oder überprüfe deine Schreibweise."
+  armory:
+    not_found: "Kein Charakter mit diesem Namen gefunden."
+    level: "Stufe"
+    faction: "Fraktion"
+    guild: "Gilde"
+    best_keys: "Beste M+ Schlüssel"
+    mplus_score: "M+ Wertung"
+    external_sites: "Externe Seiten"
+  guildnews:
+    config_not_found: "Konfiguration #{config} nicht gefunden."
+    setup:
+      guild_not_found: "Gilde '{guild}' auf {realm_region} nicht gefunden."
+      already_tracked: "Gilde '{guild}' auf {realm_region} wird bereits verfolgt (Konfiguration #{id} in {channel})."
+      success: "Verfolge jetzt **{guild}** ({realm_region}) in {channel}. Der erste Scan erstellt eine Baseline ohne Benachrichtigungen."
+    remove:
+      success: "Tracking-Konfiguration #{config} entfernt."
+    list:
+      title: "⚔️ Gilden-News"
+      empty: "Keine Gilden-News-Konfigurationen für diesen Server."
+      status_active: "Aktiv"
+      status_paused: "Pausiert"
+      entry_details: "{status} · Aktive Tage: {active_days}"
+      entry_channel: "Kanal: {channel}"
+      channel_deleted: "#{channel_id} (gelöscht)"
+    pause:
+      success: "Tracking für Konfiguration #{config} pausiert."
+    resume:
+      success: "Tracking für Konfiguration #{config} fortgesetzt."
+    edit:
+      nothing_to_change: "Nichts zu ändern. Gib mindestens einen der folgenden Parameter an: channel, active_days."
+      success: "Konfiguration #{config} für {guild} aktualisiert: {changes}."
+      change_channel: "Kanal → {channel}"
+      change_active_days: "Aktive Tage → {active_days}"
+  notification:
+    achievement_title: "Erfolg errungen!"
+    achievement_desc: "**{name}** ({realm}) hat den Erfolg **{achievement}** errungen"
+    mount_title: "Neues Reittier erhalten!"
+    mount_desc: "**{name}** ({realm}) hat **{mount}** erhalten"
+    boss_title: "Boss besiegt!"
+    boss_desc: "**{name}** ({realm}) hat **{boss}** besiegt"
+    boss_desc_mode: "**{name}** ({realm}) hat **{boss}** besiegt ({mode})"

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -226,3 +226,47 @@ moderation:
       entry_no_roles: "**{name}** — joined: {joined}"
       entry_full: "**{name}** — created: {created} · joined: {joined}"
   membercount: "There are currently **{count}** members on this server."
+
+wow:
+  realm_not_found: "Unknown realm '{realm}' in {region}. Use the autocomplete suggestions or check your spelling."
+  armory:
+    not_found: "No character with this name found."
+    level: "Level"
+    faction: "Faction"
+    guild: "Guild"
+    best_keys: "Best M+ Keys"
+    mplus_score: "M+ Score"
+    external_sites: "External Sites"
+  guildnews:
+    config_not_found: "Config #{config} not found."
+    setup:
+      guild_not_found: "Guild '{guild}' not found on {realm_region}."
+      already_tracked: "Guild '{guild}' on {realm_region} is already tracked (config #{id} in {channel})."
+      success: "Now tracking **{guild}** ({realm_region}) in {channel}. First scan will establish a baseline silently."
+    remove:
+      success: "Removed tracking config #{config}."
+    list:
+      title: "⚔️ Guild News"
+      empty: "No guild news configs for this server."
+      status_active: "Active"
+      status_paused: "Paused"
+      entry_details: "{status} · Active Days: {active_days}"
+      entry_channel: "Channel: {channel}"
+      channel_deleted: "#{channel_id} (deleted)"
+    pause:
+      success: "Paused tracking for config #{config}."
+    resume:
+      success: "Resumed tracking for config #{config}."
+    edit:
+      nothing_to_change: "Nothing to change. Specify at least one of: channel, active_days."
+      success: "Updated config #{config} for {guild}: {changes}."
+      change_channel: "channel → {channel}"
+      change_active_days: "active_days → {active_days}"
+  notification:
+    achievement_title: "Achievement Earned!"
+    achievement_desc: "**{name}** ({realm}) has earned the achievement **{achievement}**"
+    mount_title: "New Mount Collected!"
+    mount_desc: "**{name}** ({realm}) obtained **{mount}**"
+    boss_title: "Boss Defeated!"
+    boss_desc: "**{name}** ({realm}) defeated **{boss}**"
+    boss_desc_mode: "**{name}** ({realm}) defeated **{boss}** ({mode})"

--- a/tests/modules/test_wow_locale.py
+++ b/tests/modules/test_wow_locale.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""Tests for wow module — localized responses."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from models.admin import GuildLanguageConfig
+from models.wow import WowGuildNewsConfig
+from modules.wow import WorldofWarcraft
+from utils.strings import load_strings
+
+
+@pytest.fixture(autouse=True)
+def _load_locale_strings():
+    load_strings()
+
+
+@pytest.fixture
+def cog(mock_bot):
+    cog = WorldofWarcraft.__new__(WorldofWarcraft)
+    cog.bot = mock_bot
+    cog.config = {"wow": {"wow_id": "test", "wow_secret": "test", "guild_news": {}}}
+    cog.client_id = "test"
+    cog.client_secret = "test"
+    cog.regions = ["eu", "us"]
+    cog._realm_cache = {}
+    cog._realm_cache_lock = MagicMock()
+    cog._guild_news_loop = MagicMock()
+    cog._guild_news_loop.start = MagicMock()
+    cog._guild_news_loop.cancel = MagicMock()
+    cog._guild_news_loop.change_interval = MagicMock()
+    cog._poll_interval = 15
+    cog._mount_batch_size = 20
+    cog._track_mounts = True
+    cog._default_active_days = 7
+    return cog
+
+
+@pytest.fixture
+def interaction(mock_interaction):
+    mock_interaction.guild.id = 987654321
+    mock_interaction.guild_id = 987654321
+    mock_interaction.guild.get_channel = MagicMock(return_value=None)
+    return mock_interaction
+
+
+def _set_german(db_session):
+    db_session.add(GuildLanguageConfig(GuildId=987654321, Language="de"))
+    db_session.commit()
+
+
+def _add_config(db_session, config_id=1, enabled=True):
+    cfg = WowGuildNewsConfig(
+        GuildId=987654321,
+        ChannelId=555,
+        WowGuildName="test-guild",
+        WowRealmSlug="blackrock",
+        Region="eu",
+        Language="en",
+        Enabled=enabled,
+    )
+    db_session.add(cfg)
+    db_session.commit()
+    # SQLite auto-increments; return the actual ID
+    return cfg.Id
+
+
+# ---------------------------------------------------------------------------
+# /wow guildnews remove
+# ---------------------------------------------------------------------------
+
+
+class TestGuildnewsRemove:
+    async def test_not_found_english(self, cog, interaction, db_session):
+        await WorldofWarcraft._guildnews_remove.callback(cog, interaction, config=999)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "not found" in msg
+        assert "999" in msg
+
+    async def test_not_found_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        await WorldofWarcraft._guildnews_remove.callback(cog, interaction, config=999)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "nicht gefunden" in msg
+
+    async def test_success_english(self, cog, interaction, db_session):
+        cfg_id = _add_config(db_session)
+        await WorldofWarcraft._guildnews_remove.callback(cog, interaction, config=cfg_id)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Removed tracking config" in msg
+
+    async def test_success_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        cfg_id = _add_config(db_session)
+        await WorldofWarcraft._guildnews_remove.callback(cog, interaction, config=cfg_id)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Tracking-Konfiguration" in msg
+        assert "entfernt" in msg
+
+
+# ---------------------------------------------------------------------------
+# /wow guildnews list
+# ---------------------------------------------------------------------------
+
+
+class TestGuildnewsList:
+    async def test_empty_english(self, cog, interaction, db_session):
+        await WorldofWarcraft._guildnews_list.callback(cog, interaction)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "No guild news configs" in msg
+
+    async def test_empty_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        await WorldofWarcraft._guildnews_list.callback(cog, interaction)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Keine Gilden-News-Konfigurationen" in msg
+
+
+# ---------------------------------------------------------------------------
+# /wow guildnews pause
+# ---------------------------------------------------------------------------
+
+
+class TestGuildnewsPause:
+    async def test_not_found_english(self, cog, interaction, db_session):
+        await WorldofWarcraft._guildnews_pause.callback(cog, interaction, config=999)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "not found" in msg
+
+    async def test_success_english(self, cog, interaction, db_session):
+        cfg_id = _add_config(db_session)
+        await WorldofWarcraft._guildnews_pause.callback(cog, interaction, config=cfg_id)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Paused tracking" in msg
+
+    async def test_success_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        cfg_id = _add_config(db_session)
+        await WorldofWarcraft._guildnews_pause.callback(cog, interaction, config=cfg_id)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "pausiert" in msg
+
+
+# ---------------------------------------------------------------------------
+# /wow guildnews resume
+# ---------------------------------------------------------------------------
+
+
+class TestGuildnewsResume:
+    async def test_not_found_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        await WorldofWarcraft._guildnews_resume.callback(cog, interaction, config=999)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "nicht gefunden" in msg
+
+    async def test_success_english(self, cog, interaction, db_session):
+        cfg_id = _add_config(db_session, enabled=False)
+        await WorldofWarcraft._guildnews_resume.callback(cog, interaction, config=cfg_id)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Resumed tracking" in msg
+
+    async def test_success_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        cfg_id = _add_config(db_session, enabled=False)
+        await WorldofWarcraft._guildnews_resume.callback(cog, interaction, config=cfg_id)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "fortgesetzt" in msg
+
+
+# ---------------------------------------------------------------------------
+# /wow guildnews edit
+# ---------------------------------------------------------------------------
+
+
+class TestGuildnewsEdit:
+    async def test_nothing_to_change_english(self, cog, interaction, db_session):
+        await WorldofWarcraft._guildnews_edit.callback(cog, interaction, config=1)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Nothing to change" in msg
+
+    async def test_nothing_to_change_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        await WorldofWarcraft._guildnews_edit.callback(cog, interaction, config=1)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Nichts zu ändern" in msg
+
+    async def test_not_found_english(self, cog, interaction, db_session):
+        await WorldofWarcraft._guildnews_edit.callback(cog, interaction, config=999, active_days=14)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "not found" in msg
+
+    async def test_success_english(self, cog, interaction, db_session):
+        cfg_id = _add_config(db_session)
+        await WorldofWarcraft._guildnews_edit.callback(cog, interaction, config=cfg_id, active_days=14)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "Updated config" in msg
+        assert "active_days" in msg
+
+    async def test_success_german(self, cog, interaction, db_session):
+        _set_german(db_session)
+        cfg_id = _add_config(db_session)
+        await WorldofWarcraft._guildnews_edit.callback(cog, interaction, config=cfg_id, active_days=14)
+        msg = interaction.response.send_message.call_args[0][0]
+        assert "aktualisiert" in msg
+        assert "Aktive Tage" in msg


### PR DESCRIPTION
## Summary
- Replace all hardcoded English strings in the wow module with `get_string()` / `get_guild_language()` lookups (29 keys)
- Migrate in-code `_NOTIFICATION_STRINGS` dict to YAML locale files for consistency with the rest of the i18n system
- **Remove per-command `language` parameters** from `/wow armory`, `/wow guildnews setup`, and `/wow guildnews edit` — the guild language from `GuildLanguageConfig` is now the single source of truth for both API locale and UI strings
- Background polls dynamically look up the guild language instead of using the stored per-config `Language` field
- Operator-only command (`check`) stays in English per convention
- Add 17 new localization tests in `tests/modules/test_wow_locale.py`

## Test plan
- [x] All 793 tests pass (`uv run python -m pytest`)
- [x] `ruff check` and `ruff format --check` clean
- [x] YAML files formatted with prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)