### PR TITLE
feat(wow): improve account deduplication reliability

### DIFF
--- a/tests/modules/test_wow_mounts.py
+++ b/tests/modules/test_wow_mounts.py
@@ -12,26 +12,26 @@ class TestParseKnownMounts:
     def test_legacy_list_format(self):
         """Plain JSON list → set of IDs, count = list length."""
         raw = json.dumps([1, 2, 3])
-        ids, count = parse_known_mounts(raw)
+        ids, count, _ap = parse_known_mounts(raw)
         assert ids == {1, 2, 3}
         assert count == 3
 
     def test_new_dict_format(self):
         """New dict format → IDs from 'ids' key, count from 'last_count'."""
         raw = json.dumps({"ids": [10, 20, 30, 40], "last_count": 3})
-        ids, count = parse_known_mounts(raw)
+        ids, count, _ap = parse_known_mounts(raw)
         assert ids == {10, 20, 30, 40}
         assert count == 3
 
     def test_empty_legacy(self):
         raw = json.dumps([])
-        ids, count = parse_known_mounts(raw)
+        ids, count, _ap = parse_known_mounts(raw)
         assert ids == set()
         assert count == 0
 
     def test_empty_new_format(self):
         raw = json.dumps({"ids": [], "last_count": 0})
-        ids, count = parse_known_mounts(raw)
+        ids, count, _ap = parse_known_mounts(raw)
         assert ids == set()
         assert count == 0
 

--- a/tests/utils/test_account_resolution.py
+++ b/tests/utils/test_account_resolution.py
@@ -10,7 +10,34 @@ from utils.blizzard import (
     account_confidence,
     make_pair_key,
     build_account_groups,
+    detect_prefix_families,
+    parse_known_mounts,
 )
+
+
+class TestParseKnownMounts:
+    def test_legacy_format(self):
+        """Legacy list format returns no achievement points."""
+        ids, count, ap = parse_known_mounts(json.dumps([1, 2, 3]))
+        assert ids == {1, 2, 3}
+        assert count == 3
+        assert ap is None
+
+    def test_new_format_without_ap(self):
+        """New dict format without achievement_points returns None for ap."""
+        raw = json.dumps({"ids": [1, 2, 3], "last_count": 5})
+        ids, count, ap = parse_known_mounts(raw)
+        assert ids == {1, 2, 3}
+        assert count == 5
+        assert ap is None
+
+    def test_new_format_with_ap(self):
+        """New dict format with achievement_points returns all three values."""
+        raw = json.dumps({"ids": [1, 2], "last_count": 2, "achievement_points": 15430})
+        ids, count, ap = parse_known_mounts(raw)
+        assert ids == {1, 2}
+        assert count == 2
+        assert ap == 15430
 
 
 class TestStripDiacritics:
@@ -62,6 +89,26 @@ class TestNameSimilarityScore:
         score = name_similarity_score("alpha", "albedo")
         # 2-char prefix 'al' is below threshold
         assert score < 0.5
+
+    def test_long_prefix_substring(self):
+        """keetheon / keetheondudu -> 8-char prefix IS the shorter name -> high score."""
+        score = name_similarity_score("keetheon", "keetheondudu")
+        assert score >= 0.7
+
+    def test_long_prefix_both_long(self):
+        """keetheonmage / keetheondudu -> 8-char shared prefix, both 12 chars -> high score."""
+        score = name_similarity_score("keetheonmage", "keetheondudu")
+        assert score >= 0.7
+
+    def test_long_prefix_nine_chars(self):
+        """keetheondh / keetheondudu -> 9-char prefix -> high score."""
+        score = name_similarity_score("keetheondh", "keetheondudu")
+        assert score >= 0.7
+
+    def test_medium_prefix_six_chars_safe(self):
+        """shadow / shadowstep -> 6-char prefix, but short enough to be coincidental."""
+        score = name_similarity_score("shadow", "shadowstep")
+        assert score < 0.7
 
 
 class TestTemporalScore:
@@ -120,7 +167,11 @@ class TestAccountConfidence:
         assert score >= 0.7
 
     def test_different_everything(self):
-        """Different names, different mounts, no temporal -> 0.0."""
+        """Different names, different mounts, no temporal -> below threshold.
+
+        Mount count similarity fires (both have 200) but as a weak signal
+        that alone can't cross the grouping threshold.
+        """
         mounts_a = json.dumps(list(range(1, 201)))
         mounts_b = json.dumps(list(range(201, 401)))
         score = account_confidence(
@@ -130,7 +181,7 @@ class TestAccountConfidence:
             mounts_b=mounts_b,
             temporal_data=None,
         )
-        assert score == 0.0
+        assert score < 0.7
 
     def test_multiple_signals_boost(self):
         """Name match + mount identity -> boosted above either alone."""
@@ -196,6 +247,94 @@ class TestAccountConfidence:
             temporal_data={"correlated": 10, "uncorrelated": 0},
         )
         assert score >= 0.7
+
+    def test_matching_achievement_points_groups(self):
+        """Same achievement points with different names and small mount sets -> high confidence."""
+        mounts_a = json.dumps({"ids": list(range(1, 31)), "last_count": 30, "achievement_points": 15430})
+        mounts_b = json.dumps({"ids": list(range(1, 31)), "last_count": 30, "achievement_points": 15430})
+        score = account_confidence(
+            name_a="thrall",
+            name_b="jaina",
+            mounts_a=mounts_a,
+            mounts_b=mounts_b,
+            temporal_data=None,
+        )
+        assert score >= 0.7
+
+    def test_achievement_points_within_tolerance(self):
+        """AP within ±100 should still count as matching."""
+        mounts_a = json.dumps({"ids": [1], "last_count": 1, "achievement_points": 15430})
+        mounts_b = json.dumps({"ids": [1], "last_count": 1, "achievement_points": 15500})
+        score = account_confidence(
+            name_a="thrall",
+            name_b="jaina",
+            mounts_a=mounts_a,
+            mounts_b=mounts_b,
+            temporal_data=None,
+        )
+        assert score >= 0.7
+
+    def test_achievement_points_very_different_no_signal(self):
+        """AP differing by >100 should not contribute a positive signal."""
+        mounts_a = json.dumps({"ids": [1], "last_count": 1, "achievement_points": 15000})
+        mounts_b = json.dumps({"ids": [1], "last_count": 1, "achievement_points": 20000})
+        score = account_confidence(
+            name_a="thrall",
+            name_b="jaina",
+            mounts_a=mounts_a,
+            mounts_b=mounts_b,
+            temporal_data=None,
+        )
+        assert score < 0.7
+
+    def test_achievement_points_missing_one_side(self):
+        """AP missing on one character should not affect scoring."""
+        mounts_a = json.dumps({"ids": list(range(1, 201)), "last_count": 200, "achievement_points": 15430})
+        mounts_b = json.dumps({"ids": list(range(1, 201)), "last_count": 200})  # no AP
+        score = account_confidence(
+            name_a="thrall",
+            name_b="jaina",
+            mounts_a=mounts_a,
+            mounts_b=mounts_b,
+            temporal_data=None,
+        )
+        # Should still group via mount Jaccard, AP just doesn't add/subtract
+        assert score >= 0.7
+
+    def test_mount_count_similarity_supplements(self):
+        """Similar mount counts (same ratio) on small sets act as a supplementary signal."""
+        # Both have 30 mounts but different IDs (so no Jaccard match)
+        mounts_a = json.dumps({"ids": list(range(1, 31)), "last_count": 30})
+        mounts_b = json.dumps({"ids": list(range(31, 61)), "last_count": 30})
+        score_with_count = account_confidence(
+            name_a="alurush",
+            name_b="alublood",
+            mounts_a=mounts_a,
+            mounts_b=mounts_b,
+            temporal_data=None,
+        )
+        score_no_mounts = account_confidence(
+            name_a="alurush",
+            name_b="alublood",
+            mounts_a=None,
+            mounts_b=None,
+            temporal_data=None,
+        )
+        # Mount count match should provide a boost over name-only
+        assert score_with_count > score_no_mounts
+
+    def test_mount_count_very_different_no_signal(self):
+        """Very different mount counts should not add a positive signal."""
+        mounts_a = json.dumps({"ids": list(range(1, 201)), "last_count": 200})
+        mounts_b = json.dumps({"ids": list(range(201, 301)), "last_count": 100})
+        score = account_confidence(
+            name_a="thrall",
+            name_b="jaina",
+            mounts_a=mounts_a,
+            mounts_b=mounts_b,
+            temporal_data=None,
+        )
+        assert score == 0.0
 
 
 class TestMakePairKey:
@@ -273,7 +412,150 @@ class TestBuildAccountGroups:
         assert groups[("morz\u00e2", "r1")] == groups[("morza", "r1")]
         assert groups[("morza", "r1")] == groups[("morzb", "r1")]
 
+    def test_long_prefix_all_grouped(self):
+        """All keetheon* characters should end up in one group via long prefix."""
+        candidates = [
+            {"name": "keetheon", "realm": "blackmoore"},
+            {"name": "keetheondh", "realm": "blackmoore"},
+            {"name": "keetheonmagê", "realm": "blackmoore"},
+            {"name": "keetheonshâm", "realm": "blackmoore"},
+            {"name": "keetheonspst", "realm": "blackmoore"},
+            {"name": "keetheônbdk", "realm": "blackmoore"},
+            {"name": "keetheônwl", "realm": "blackmoore"},
+            {"name": "keetheondudu", "realm": "blackmoore"},
+            {"name": "keetheonhunt", "realm": "blackmoore"},
+            {"name": "keetheonlock", "realm": "blackmoore"},
+            {"name": "keetheonrmix", "realm": "blackmoore"},
+        ]
+        groups = build_account_groups(candidates, stored_mounts={}, temporal_data={})
+        group_ids = {groups[k] for k in groups}
+        assert len(group_ids) == 1, f"Expected 1 group, got {len(group_ids)}: {groups}"
+
+    def test_prefix_family_extends_existing_group(self):
+        """alu-like family: 4 chars grouped by mounts, 5th extends via prefix family."""
+        mounts = json.dumps(list(range(1, 201)))
+        candidates = [
+            {"name": "aluclap", "realm": "ravencrest"},
+            {"name": "aluh", "realm": "ravencrest"},
+            {"name": "alurush", "realm": "ravencrest"},
+            {"name": "alusdreieck", "realm": "ravencrest"},
+            {"name": "alublood", "realm": "ravencrest"},
+        ]
+        # 4 of the 5 share identical mounts -> grouped in phase 1
+        stored = {
+            ("aluclap", "ravencrest"): mounts,
+            ("aluh", "ravencrest"): mounts,
+            ("alurush", "ravencrest"): mounts,
+            ("alusdreieck", "ravencrest"): mounts,
+            # alublood has NO mount data
+        }
+        groups = build_account_groups(candidates, stored_mounts=stored, temporal_data={})
+        # alublood should be pulled in by prefix family extension
+        group_ids = {groups[k] for k in groups}
+        assert len(group_ids) == 1, f"Expected 1 group, got {len(group_ids)}: {groups}"
+
+    def test_prefix_family_minority_not_extended(self):
+        """If only a minority of a prefix family is grouped, don't extend."""
+        mounts = json.dumps(list(range(1, 201)))
+        candidates = [
+            {"name": "darkblade", "realm": "r1"},
+            {"name": "darkmoon", "realm": "r1"},
+            {"name": "darkfire", "realm": "r1"},
+            {"name": "darkheart", "realm": "r1"},
+            {"name": "darksoul", "realm": "r1"},
+        ]
+        # Only 2 of 5 share mounts (not majority)
+        stored = {
+            ("darkblade", "r1"): mounts,
+            ("darkmoon", "r1"): mounts,
+        }
+        groups = build_account_groups(candidates, stored_mounts=stored, temporal_data={})
+        # darkblade and darkmoon are grouped, but the other 3 should NOT be pulled in
+        assert groups[("darkblade", "r1")] == groups[("darkmoon", "r1")]
+        grouped_with_dark = sum(1 for k, g in groups.items() if g == groups[("darkblade", "r1")])
+        assert grouped_with_dark == 2, f"Expected only 2 in group, got {grouped_with_dark}"
+
+    def test_prefix_family_no_existing_group(self):
+        """Prefix family with no mount/temporal evidence -> no grouping (for short prefixes)."""
+        candidates = [
+            {"name": "aluclap", "realm": "r1"},
+            {"name": "aluh", "realm": "r1"},
+            {"name": "alurush", "realm": "r1"},
+        ]
+        groups = build_account_groups(candidates, stored_mounts={}, temporal_data={})
+        # With no mount/temporal data and only 3-char prefix, should not group
+        group_ids = set(groups.values())
+        assert len(group_ids) == 3
+
+    def test_prefix_family_different_realms_separate(self):
+        """Same prefix on different realms should not form a cross-realm family."""
+        mounts = json.dumps(list(range(1, 201)))
+        candidates = [
+            {"name": "alualpha", "realm": "r1"},
+            {"name": "alubeta", "realm": "r1"},
+            {"name": "alugamma", "realm": "r1"},
+            {"name": "aludelta", "realm": "r2"},  # different realm
+        ]
+        stored = {
+            ("alualpha", "r1"): mounts,
+            ("alubeta", "r1"): mounts,
+            ("alugamma", "r1"): mounts,
+        }
+        groups = build_account_groups(candidates, stored_mounts=stored, temporal_data={})
+        # r1 characters grouped, but r2 character stays separate
+        assert groups[("alualpha", "r1")] == groups[("alubeta", "r1")]
+        assert groups[("aludelta", "r2")] != groups[("alualpha", "r1")]
+
     def test_empty_candidates(self):
         """No candidates -> empty groups."""
         groups = build_account_groups([], stored_mounts={}, temporal_data={})
         assert groups == {}
+
+
+class TestDetectPrefixFamilies:
+    def test_basic_family(self):
+        """3+ characters sharing a prefix on same realm -> detected as family."""
+        candidates = [
+            {"name": "aluclap", "realm": "r1"},
+            {"name": "aluh", "realm": "r1"},
+            {"name": "alurush", "realm": "r1"},
+        ]
+        families = detect_prefix_families(candidates)
+        # All 3 should be in the same family
+        assert ("aluclap", "r1") in families
+        family = families[("aluclap", "r1")]
+        assert ("aluh", "r1") in family
+        assert ("alurush", "r1") in family
+        assert len(family) == 3
+
+    def test_too_few_members(self):
+        """2 characters sharing a prefix -> no family detected."""
+        candidates = [
+            {"name": "alurush", "realm": "r1"},
+            {"name": "alublood", "realm": "r1"},
+        ]
+        families = detect_prefix_families(candidates)
+        assert len(families) == 0
+
+    def test_different_realms(self):
+        """Same prefix on different realms -> separate families (or none if < 3)."""
+        candidates = [
+            {"name": "alualpha", "realm": "r1"},
+            {"name": "alubeta", "realm": "r1"},
+            {"name": "alugamma", "realm": "r2"},
+        ]
+        families = detect_prefix_families(candidates)
+        # Only 2 on r1, 1 on r2 -> no family meets the threshold
+        assert len(families) == 0
+
+    def test_diacritics_normalized(self):
+        """Characters with diacritics should be grouped by normalized prefix."""
+        candidates = [
+            {"name": "keetheon", "realm": "r1"},
+            {"name": "keetheonmage", "realm": "r1"},
+            {"name": "keetheônwl", "realm": "r1"},
+        ]
+        families = detect_prefix_families(candidates)
+        assert ("keetheon", "r1") in families
+        family = families[("keetheon", "r1")]
+        assert len(family) == 3


### PR DESCRIPTION
## Summary

- **Long-prefix bonus**: `name_similarity_score` now scales with absolute prefix length (≥5 chars), so 7+ char shared prefixes like "keetheon" cross the 0.7 confidence threshold on their own — fixes characters like `keetheon*` being split across multiple groups
- **Prefix family extension**: after pairwise grouping, detects 3+ same-realm characters sharing a name prefix; if a majority is already grouped by mount/temporal evidence, extends the group to remaining members — fixes `alu*` characters not being fully grouped
- **Achievement points signal**: extracts account-wide AP from the already-fetched profile response, stores in `KnownMountIds` JSON, and uses as a 0.9 confidence signal when characters match within ±100 points — deterministic same-account evidence at zero extra API cost
- **Mount count similarity**: uses existing `last_count` as a supplementary signal when both characters have 20+ mounts with counts within 10%

## Test plan

- [x] All 879 tests pass (55 account resolution tests, including 22 new)
- [x] Ruff lint and format clean
- [ ] Deploy to staging and verify keetheon-family groups into a single account group
- [ ] Verify alu-family extends to include alublood after mount data accumulates
- [ ] Monitor for false positives in guilds with common-word name prefixes (e.g. "dark*")

🤖 Generated with [Claude Code](https://claude.com/claude-code)