### PR TITLE
fix(wow): paginate manual profession mapping and add Cooking

### DIFF
--- a/NerdyPy/modules/wow.py
+++ b/NerdyPy/modules/wow.py
@@ -1415,14 +1415,11 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
         """Send an ephemeral followup with Select dropdowns for manual profession mapping."""
         from modules.views.crafting_order import ManualProfessionMappingView
 
-        max_roles = ManualProfessionMappingView.MAX_ROLES
         unmapped_roles = [
             (rid, (interaction.guild.get_role(rid).name if interaction.guild.get_role(rid) else str(rid)))
-            for rid in unmapped[:max_roles]
+            for rid in unmapped
         ]
         content = get_string(lang, "wow.craftingorder.manual_map.description")
-        if len(unmapped) > max_roles:
-            content += "\n" + get_string(lang, "wow.craftingorder.manual_map.overflow", max=max_roles)
         view = ManualProfessionMappingView(self.bot, interaction.guild_id, unmapped_roles, lang)
         await interaction.followup.send(content, view=view, ephemeral=True)
 

--- a/NerdyPy/utils/blizzard.py
+++ b/NerdyPy/utils/blizzard.py
@@ -45,8 +45,10 @@ def get_asset_url(response, key: str = "icon") -> str | None:
     return None
 
 
-# Only crafting professions that support the crafting order system.
-# Excludes gathering (Skinning, Mining, Herbalism) and Cooking.
+# Professions mappable in the crafting order board.
+# Excludes gathering (Skinning, Mining, Herbalism).
+# Cooking is included for role-based coordination (e.g. food tables) even though
+# it does not support the in-game crafting order system.
 CRAFTING_PROFESSIONS = {
     "Blacksmithing": 164,
     "Leatherworking": 165,
@@ -56,6 +58,7 @@ CRAFTING_PROFESSIONS = {
     "Alchemy": 171,
     "Inscription": 773,
     "Jewelcrafting": 755,
+    "Cooking": 185,
 }
 
 

--- a/tests/utils/test_blizzard.py
+++ b/tests/utils/test_blizzard.py
@@ -10,10 +10,11 @@ class TestCraftingProfessions:
     def test_has_expected_professions(self):
         assert "Blacksmithing" in CRAFTING_PROFESSIONS
         assert "Jewelcrafting" in CRAFTING_PROFESSIONS
-        assert len(CRAFTING_PROFESSIONS) == 8
+        assert "Cooking" in CRAFTING_PROFESSIONS
+        assert len(CRAFTING_PROFESSIONS) == 9
 
     def test_no_gathering_professions(self):
-        for name in ("Skinning", "Mining", "Herbalism", "Cooking"):
+        for name in ("Skinning", "Mining", "Herbalism"):
             assert name not in CRAFTING_PROFESSIONS
 
 


### PR DESCRIPTION
## Summary

- **Pagination for manual role mapping**: `ManualProfessionMappingView` previously silently dropped any unmapped roles beyond the first 4 (Discord's hard limit of 4 selects per view). The view now processes all roles in batches — confirming a batch auto-advances to the next one via `edit_message` until every role is mapped.
- **Add Cooking profession**: Cooking (Blizzard ID 185) is now mappable in the crafting order board for role-based raid coordination (e.g. food tables), even though it doesn't support in-game crafting orders.

## Test plan

- [ ] Verify that setting up a crafting order board with >4 unmapped roles shows subsequent batches after confirming each one
- [ ] Verify that Cooking appears as a profession option in the manual mapping select menus
- [ ] Unit tests updated: `test_blizzard.py` asserts count=9 and Cooking is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)