### PR TITLE
feat(application): multi-role support for manager and reviewer roles

### DIFF
--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -356,9 +356,11 @@ wow:
       success: "Berufs-Zuordnungen gespeichert."
       partial: "{count} Zuordnung(en) gespeichert. {skipped} Rolle(n) hatten keinen ausgewählten Beruf und erscheinen nicht im Dropdown."
       overflow: "⚠️ Hier werden nur die ersten {max} nicht zugeordneten Rollen angezeigt. Verwende `/wow craftingorder edit`, um die restlichen zuzuordnen."
+      next_batch: "{count} Zuordnung(en) für diesen Schritt gespeichert. Fahre mit den verbleibenden Rollen unten fort."
 
 application:
   no_permission: "Du hast keine Berechtigung, Bewerbungen zu verwalten."
+  missing_send_permission: "Ich habe keine Berechtigung, Nachrichten in {channel} zu senden. Bitte überprüfe meine Rollenberechtigungen."
   check_dms: "Sieh in deinen Direktnachrichten nach!"
   dm_forbidden: "Ich konnte dir keine DM senden. Bitte aktiviere DMs von Servermitgliedern und versuche es erneut."
   form_not_found: "Formular **{name}** nicht gefunden."
@@ -498,13 +500,19 @@ application:
     form_exists: "Ein Formular mit dem Namen **{name}** existiert bereits auf diesem Server."
     success: "Formular **{name}** erfolgreich mit {count} Frage(n) importiert."
   managerole:
-    set_success: "Bewerbungs-Manager-Rolle auf **{role}** gesetzt."
-    remove_success: "Bewerbungs-Manager-Rolle entfernt."
-    not_configured: "Keine Manager-Rolle konfiguriert."
+    add_success: "Rolle **{role}** als Bewerbungsmanager hinzugefügt."
+    remove_success: "Rolle **{role}** aus den Bewerbungsmanagern entfernt."
+    not_found: "Rolle **{role}** ist nicht als Bewerbungsmanager-Rolle konfiguriert."
+    clear_success: "Alle Bewerbungsmanager-Rollen wurden entfernt."
+    list_title: "Bewerbungsmanager-Rollen"
+    list_empty: "Es sind keine Bewerbungsmanager-Rollen konfiguriert."
   reviewerrole:
-    set_success: "Bewerbungs-Prüfer-Rolle auf **{role}** gesetzt."
-    remove_success: "Bewerbungs-Prüfer-Rolle entfernt."
-    not_configured: "Keine Prüfer-Rolle konfiguriert."
+    add_success: "Rolle **{role}** als Bewerbungsprüfer hinzugefügt."
+    remove_success: "Rolle **{role}** aus den Bewerbungsprüfern entfernt."
+    not_found: "Rolle **{role}** ist nicht als Bewerbungsprüfer-Rolle konfiguriert."
+    clear_success: "Alle Bewerbungsprüfer-Rollen wurden entfernt."
+    list_title: "Bewerbungsprüfer-Rollen"
+    list_empty: "Es sind keine Bewerbungsprüfer-Rollen konfiguriert."
   review:
     applicant: "Bewerber"
     submitted: "Eingereicht"

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -357,9 +357,11 @@ wow:
       success: "Profession mappings saved."
       partial: "Saved {count} mapping(s). {skipped} role(s) had no profession selected and won't appear in the dropdown."
       overflow: "⚠️ Only the first {max} unmapped roles are shown here. Use `/wow craftingorder edit` to map the remaining ones."
+      next_batch: "Saved {count} mapping(s) for this batch. Continue mapping the remaining roles below."
 
 application:
   no_permission: "You don't have permission to manage applications."
+  missing_send_permission: "I don't have permission to send messages in {channel}. Please check my role permissions."
   check_dms: "Check your DMs!"
   dm_forbidden: "I couldn't send you a DM. Please enable DMs from server members and try again."
   form_not_found: "Form **{name}** not found."
@@ -499,13 +501,19 @@ application:
     form_exists: "A form named **{name}** already exists in this server."
     success: "Form **{name}** imported successfully with {count} question(s)."
   managerole:
-    set_success: "Application manager role set to **{role}**."
-    remove_success: "Application manager role removed."
-    not_configured: "No manager role is configured."
+    add_success: "Role **{role}** added as application manager."
+    remove_success: "Role **{role}** removed from application managers."
+    not_found: "Role **{role}** is not configured as an application manager role."
+    clear_success: "All application manager roles cleared."
+    list_title: "Application Manager Roles"
+    list_empty: "No application manager roles are configured."
   reviewerrole:
-    set_success: "Application reviewer role set to **{role}**."
-    remove_success: "Application reviewer role removed."
-    not_configured: "No reviewer role is configured."
+    add_success: "Role **{role}** added as application reviewer."
+    remove_success: "Role **{role}** removed from application reviewers."
+    not_found: "Role **{role}** is not configured as an application reviewer role."
+    clear_success: "All application reviewer roles cleared."
+    list_title: "Application Reviewer Roles"
+    list_empty: "No application reviewer roles are configured."
   review:
     applicant: "Applicant"
     submitted: "Submitted"

--- a/NerdyPy/models/application.py
+++ b/NerdyPy/models/application.py
@@ -85,9 +85,11 @@ class ApplicationGuildRole(db.BASE):
             session.add(cls(GuildId=guild_id, RoleId=role_id, RoleType=role_type))
 
     @classmethod
-    def remove(cls, guild_id: int, role_id: int, session) -> bool:
-        """Remove a role mapping; returns True if it existed, False if not found."""
-        row = session.query(cls).filter(cls.GuildId == guild_id, cls.RoleId == role_id).first()
+    def remove(cls, guild_id: int, role_id: int, role_type: str, session) -> bool:
+        """Remove a role mapping of the given type; returns True if it existed, False if not found."""
+        row = (
+            session.query(cls).filter(cls.GuildId == guild_id, cls.RoleId == role_id, cls.RoleType == role_type).first()
+        )
         if row is not None:
             session.delete(row)
             return True

--- a/NerdyPy/models/application.py
+++ b/NerdyPy/models/application.py
@@ -41,8 +41,6 @@ class ApplicationGuildConfig(db.BASE):
     __tablename__ = "ApplicationGuildConfig"
 
     GuildId = Column(BigInteger, primary_key=True)
-    ManagerRoleId = Column(BigInteger, nullable=True)
-    ReviewerRoleId = Column(BigInteger, nullable=True)
 
     @classmethod
     def get(cls, guild_id, session):
@@ -55,6 +53,50 @@ class ApplicationGuildConfig(db.BASE):
         entry = cls.get(guild_id, session)
         if entry is not None:
             session.delete(entry)
+
+
+class ApplicationGuildRole(db.BASE):
+    """Per-guild role assignments for application management and review.
+
+    RoleType is either "manager" (can manage forms, override decisions)
+    or "reviewer" (can vote on submissions).
+    """
+
+    __tablename__ = "ApplicationGuildRole"
+    __table_args__ = (Index("ApplicationGuildRole_GuildId_Type", "GuildId", "RoleType"),)
+
+    GuildId = Column(BigInteger, primary_key=True)
+    RoleId = Column(BigInteger, primary_key=True)
+    RoleType = Column(Unicode(10), nullable=False)  # "manager" | "reviewer"
+
+    @classmethod
+    def get_role_ids(cls, guild_id: int, role_type: str, session) -> list[int]:
+        """Return all role IDs of the given type for this guild."""
+        rows = session.query(cls).filter(cls.GuildId == guild_id, cls.RoleType == role_type).all()
+        return [r.RoleId for r in rows]
+
+    @classmethod
+    def add(cls, guild_id: int, role_id: int, role_type: str, session) -> None:
+        """Add a role mapping; silently no-ops if the role is already present."""
+        existing = (
+            session.query(cls).filter(cls.GuildId == guild_id, cls.RoleId == role_id, cls.RoleType == role_type).first()
+        )
+        if existing is None:
+            session.add(cls(GuildId=guild_id, RoleId=role_id, RoleType=role_type))
+
+    @classmethod
+    def remove(cls, guild_id: int, role_id: int, session) -> bool:
+        """Remove a role mapping; returns True if it existed, False if not found."""
+        row = session.query(cls).filter(cls.GuildId == guild_id, cls.RoleId == role_id).first()
+        if row is not None:
+            session.delete(row)
+            return True
+        return False
+
+    @classmethod
+    def clear(cls, guild_id: int, role_type: str, session) -> None:
+        """Remove all role mappings of the given type for this guild."""
+        session.query(cls).filter(cls.GuildId == guild_id, cls.RoleType == role_type).delete()
 
 
 class ApplicationForm(db.BASE):

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -204,7 +204,8 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
                 or not perms.send_messages_in_threads
             ):
                 await interaction.response.send_message(
-                    get_string(lang, "application.missing_send_permission", channel=channel.mention), ephemeral=True
+                    get_string(lang, "application.missing_send_permission", channel=review_channel.mention),
+                    ephemeral=True,
                 )
                 return None
 

--- a/database-migrations/versions/006_application_multi_role.py
+++ b/database-migrations/versions/006_application_multi_role.py
@@ -1,0 +1,151 @@
+"""application: replace single role columns with multi-role junction table
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-02-26
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import BigInteger, Column, Unicode, text
+
+revision = "006"
+down_revision = "005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    if "ApplicationGuildConfig" not in insp.get_table_names():
+        return
+
+    # Fresh-install guard: create_all() already built the new schema without the old columns.
+    existing_cols = {c["name"] for c in insp.get_columns("ApplicationGuildConfig")}
+    if "ManagerRoleId" not in existing_cols and "ReviewerRoleId" not in existing_cols:
+        return
+
+    # Create junction table (may already exist on fresh install — guard with check)
+    if "ApplicationGuildRole" not in insp.get_table_names():
+        op.create_table(
+            "ApplicationGuildRole",
+            Column("GuildId", BigInteger, nullable=False),
+            Column("RoleId", BigInteger, nullable=False),
+            Column("RoleType", Unicode(10), nullable=False),
+            sa.PrimaryKeyConstraint("GuildId", "RoleId"),
+        )
+        op.create_index(
+            "ApplicationGuildRole_GuildId_Type",
+            "ApplicationGuildRole",
+            ["GuildId", "RoleType"],
+        )
+
+    # Migrate existing single-role data into the junction table
+    dialect = conn.dialect.name
+    if dialect == "sqlite":
+        conn.execute(
+            text(
+                "INSERT OR IGNORE INTO ApplicationGuildRole (GuildId, RoleId, RoleType) "
+                "SELECT GuildId, ManagerRoleId, 'manager' FROM ApplicationGuildConfig "
+                "WHERE ManagerRoleId IS NOT NULL"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT OR IGNORE INTO ApplicationGuildRole (GuildId, RoleId, RoleType) "
+                "SELECT GuildId, ReviewerRoleId, 'reviewer' FROM ApplicationGuildConfig "
+                "WHERE ReviewerRoleId IS NOT NULL"
+            )
+        )
+    elif dialect == "postgresql":
+        conn.execute(
+            text(
+                'INSERT INTO "ApplicationGuildRole" ("GuildId", "RoleId", "RoleType") '
+                'SELECT "GuildId", "ManagerRoleId", \'manager\' FROM "ApplicationGuildConfig" '
+                'WHERE "ManagerRoleId" IS NOT NULL '
+                "ON CONFLICT DO NOTHING"
+            )
+        )
+        conn.execute(
+            text(
+                'INSERT INTO "ApplicationGuildRole" ("GuildId", "RoleId", "RoleType") '
+                'SELECT "GuildId", "ReviewerRoleId", \'reviewer\' FROM "ApplicationGuildConfig" '
+                'WHERE "ReviewerRoleId" IS NOT NULL '
+                "ON CONFLICT DO NOTHING"
+            )
+        )
+    else:
+        raise NotImplementedError(f"Unsupported dialect: {dialect}")
+
+    # Drop old columns (batch_alter_table required for SQLite)
+    with op.batch_alter_table("ApplicationGuildConfig") as batch_op:
+        if "ManagerRoleId" in existing_cols:
+            batch_op.drop_column("ManagerRoleId")
+        if "ReviewerRoleId" in existing_cols:
+            batch_op.drop_column("ReviewerRoleId")
+
+
+def downgrade():
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    if "ApplicationGuildConfig" not in insp.get_table_names():
+        return
+
+    existing_cols = {c["name"] for c in insp.get_columns("ApplicationGuildConfig")}
+    if "ManagerRoleId" in existing_cols:
+        return  # Already at old schema
+
+    # Re-add single-role columns
+    with op.batch_alter_table("ApplicationGuildConfig") as batch_op:
+        batch_op.add_column(Column("ManagerRoleId", BigInteger, nullable=True))
+        batch_op.add_column(Column("ReviewerRoleId", BigInteger, nullable=True))
+
+    # Best-effort: copy first manager/reviewer role per guild back to config columns
+    dialect = conn.dialect.name
+    if dialect == "sqlite":
+        conn.execute(
+            text(
+                "UPDATE ApplicationGuildConfig SET ManagerRoleId = ("
+                "  SELECT RoleId FROM ApplicationGuildRole"
+                "  WHERE GuildId = ApplicationGuildConfig.GuildId AND RoleType = 'manager'"
+                "  LIMIT 1"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "UPDATE ApplicationGuildConfig SET ReviewerRoleId = ("
+                "  SELECT RoleId FROM ApplicationGuildRole"
+                "  WHERE GuildId = ApplicationGuildConfig.GuildId AND RoleType = 'reviewer'"
+                "  LIMIT 1"
+                ")"
+            )
+        )
+    elif dialect == "postgresql":
+        conn.execute(
+            text(
+                'UPDATE "ApplicationGuildConfig" SET "ManagerRoleId" = ('
+                '  SELECT "RoleId" FROM "ApplicationGuildRole"'
+                '  WHERE "GuildId" = "ApplicationGuildConfig"."GuildId" AND "RoleType" = \'manager\''
+                "  LIMIT 1"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                'UPDATE "ApplicationGuildConfig" SET "ReviewerRoleId" = ('
+                '  SELECT "RoleId" FROM "ApplicationGuildRole"'
+                '  WHERE "GuildId" = "ApplicationGuildConfig"."GuildId" AND "RoleType" = \'reviewer\''
+                "  LIMIT 1"
+                ")"
+            )
+        )
+    else:
+        raise NotImplementedError(f"Unsupported dialect: {dialect}")
+
+    if "ApplicationGuildRole" in insp.get_table_names():
+        op.drop_index("ApplicationGuildRole_GuildId_Type", table_name="ApplicationGuildRole")
+        op.drop_table("ApplicationGuildRole")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def db_engine():
         ApplicationAnswer,
         ApplicationVote,
         ApplicationGuildConfig,
+        ApplicationGuildRole,
         ApplicationTemplate,
         ApplicationTemplateQuestion,
     )

--- a/tests/integration/test_application_conversation.py
+++ b/tests/integration/test_application_conversation.py
@@ -1136,9 +1136,10 @@ class TestSubmitConversationRoleMentions:
 
     @pytest.mark.asyncio
     async def test_mentions_configured_roles(self, conv, mock_bot, mock_guild, db_session):
-        from models.application import ApplicationGuildConfig
+        from models.application import ApplicationGuildRole
 
-        db_session.add(ApplicationGuildConfig(GuildId=mock_guild.id, ManagerRoleId=111, ReviewerRoleId=222))
+        db_session.add(ApplicationGuildRole(GuildId=mock_guild.id, RoleId=111, RoleType="manager"))
+        db_session.add(ApplicationGuildRole(GuildId=mock_guild.id, RoleId=222, RoleType="reviewer"))
         db_session.flush()
         mock_guild.roles = []
 

--- a/tests/models/test_application.py
+++ b/tests/models/test_application.py
@@ -29,28 +29,19 @@ class TestApplicationGuildConfig:
 
     def test_create_and_get(self, db_session):
         """Should store and retrieve a guild config."""
-        cfg = ApplicationGuildConfig(GuildId=111, ManagerRoleId=999)
-        db_session.add(cfg)
-        db_session.commit()
-
-        result = ApplicationGuildConfig.get(111, db_session)
-        assert result is not None
-        assert result.ManagerRoleId == 999
-
-    def test_get_nonexistent_returns_none(self, db_session):
-        assert ApplicationGuildConfig.get(999, db_session) is None
-
-    def test_nullable_manager_role(self, db_session):
-        """ManagerRoleId can be None."""
         cfg = ApplicationGuildConfig(GuildId=111)
         db_session.add(cfg)
         db_session.commit()
 
         result = ApplicationGuildConfig.get(111, db_session)
-        assert result.ManagerRoleId is None
+        assert result is not None
+        assert result.GuildId == 111
+
+    def test_get_nonexistent_returns_none(self, db_session):
+        assert ApplicationGuildConfig.get(999, db_session) is None
 
     def test_delete(self, db_session):
-        cfg = ApplicationGuildConfig(GuildId=111, ManagerRoleId=999)
+        cfg = ApplicationGuildConfig(GuildId=111)
         db_session.add(cfg)
         db_session.commit()
 
@@ -887,12 +878,12 @@ class TestGuildIsolation:
         assert len(ApplicationSubmission.get_by_guild(222, db_session)) == 1
 
     def test_guild_config_is_guild_isolated(self, db_session):
-        db_session.add(ApplicationGuildConfig(GuildId=111, ManagerRoleId=10))
-        db_session.add(ApplicationGuildConfig(GuildId=222, ManagerRoleId=20))
+        db_session.add(ApplicationGuildConfig(GuildId=111))
+        db_session.add(ApplicationGuildConfig(GuildId=222))
         db_session.commit()
 
-        assert ApplicationGuildConfig.get(111, db_session).ManagerRoleId == 10
-        assert ApplicationGuildConfig.get(222, db_session).ManagerRoleId == 20
+        assert ApplicationGuildConfig.get(111, db_session).GuildId == 111
+        assert ApplicationGuildConfig.get(222, db_session).GuildId == 222
 
 
 # ---------------------------------------------------------------------------

--- a/tests/modules/test_application.py
+++ b/tests/modules/test_application.py
@@ -15,6 +15,7 @@ from models.application import (
     BUILT_IN_TEMPLATES,
     ApplicationForm,
     ApplicationGuildConfig,
+    ApplicationGuildRole,
     ApplicationQuestion,
     ApplicationTemplate,
     seed_built_in_templates,
@@ -230,9 +231,8 @@ class TestHasManagePermission:
         assert app_cog._has_manage_permission(non_admin_interaction) is False
 
     def test_non_admin_with_manager_role_allowed(self, app_cog, non_admin_interaction, db_session):
-        # Set up manager role config
-        config = ApplicationGuildConfig(GuildId=non_admin_interaction.guild.id, ManagerRoleId=42)
-        db_session.add(config)
+        # Set up manager role via ApplicationGuildRole
+        db_session.add(ApplicationGuildRole(GuildId=non_admin_interaction.guild.id, RoleId=42, RoleType="manager"))
         db_session.commit()
 
         role = MagicMock()
@@ -242,8 +242,7 @@ class TestHasManagePermission:
         assert app_cog._has_manage_permission(non_admin_interaction) is True
 
     def test_non_admin_with_wrong_role_denied(self, app_cog, non_admin_interaction, db_session):
-        config = ApplicationGuildConfig(GuildId=non_admin_interaction.guild.id, ManagerRoleId=42)
-        db_session.add(config)
+        db_session.add(ApplicationGuildRole(GuildId=non_admin_interaction.guild.id, RoleId=42, RoleType="manager"))
         db_session.commit()
 
         role = MagicMock()
@@ -254,8 +253,7 @@ class TestHasManagePermission:
 
     def test_reviewer_role_cannot_manage(self, app_cog, non_admin_interaction, db_session):
         """Reviewer-role holders must not be able to manage forms."""
-        config = ApplicationGuildConfig(GuildId=non_admin_interaction.guild.id, ReviewerRoleId=888)
-        db_session.add(config)
+        db_session.add(ApplicationGuildRole(GuildId=non_admin_interaction.guild.id, RoleId=888, RoleType="reviewer"))
         db_session.commit()
 
         role = MagicMock()

--- a/tests/modules/test_application_locale.py
+++ b/tests/modules/test_application_locale.py
@@ -417,73 +417,87 @@ class TestTemplateEditMessagesLocale:
 
 
 # ---------------------------------------------------------------------------
-# /application managerole set / remove
+# /application managerole add / remove / clear / list
 # ---------------------------------------------------------------------------
 
 
 class TestManagerRoleLocale:
-    async def test_set_english(self, cog, interaction, db_session):
+    async def test_add_english(self, cog, interaction, db_session):
         role = MagicMock()
         role.id = 42
         role.name = "Manager"
-        await Application._managerole_set.callback(cog, interaction, role=role)
+        await Application._managerole_add.callback(cog, interaction, role)
         msg = interaction.response.send_message.call_args[0][0]
-        assert "manager role set" in msg.lower()
+        assert "Manager" in msg
+        assert "application manager" in msg.lower()
 
-    async def test_set_german(self, cog, interaction, db_session):
+    async def test_add_german(self, cog, interaction, db_session):
         _set_german(db_session)
         role = MagicMock()
         role.id = 42
         role.name = "Manager"
-        await Application._managerole_set.callback(cog, interaction, role=role)
+        await Application._managerole_add.callback(cog, interaction, role)
         msg = interaction.response.send_message.call_args[0][0]
-        assert "Manager-Rolle" in msg
+        assert "Bewerbungsmanager" in msg
 
-    async def test_remove_not_configured_english(self, cog, interaction, db_session):
-        await Application._managerole_remove.callback(cog, interaction)
+    async def test_remove_not_found_english(self, cog, interaction, db_session):
+        role = MagicMock()
+        role.id = 9999
+        role.name = "Ghost"
+        await Application._managerole_remove.callback(cog, interaction, role)
         msg = interaction.response.send_message.call_args[0][0]
-        assert "No manager role" in msg
+        assert "not configured" in msg.lower()
 
-    async def test_remove_not_configured_german(self, cog, interaction, db_session):
+    async def test_remove_not_found_german(self, cog, interaction, db_session):
         _set_german(db_session)
-        await Application._managerole_remove.callback(cog, interaction)
+        role = MagicMock()
+        role.id = 9999
+        role.name = "Ghost"
+        await Application._managerole_remove.callback(cog, interaction, role)
         msg = interaction.response.send_message.call_args[0][0]
-        assert "Keine Manager-Rolle" in msg
+        assert "nicht als" in msg.lower()
 
 
 # ---------------------------------------------------------------------------
-# /application reviewerrole set / remove
+# /application reviewerrole add / remove / clear / list
 # ---------------------------------------------------------------------------
 
 
 class TestReviewerRoleLocale:
-    async def test_set_english(self, cog, interaction, db_session):
+    async def test_add_english(self, cog, interaction, db_session):
         role = MagicMock()
         role.id = 55
         role.name = "Reviewer"
-        await Application._reviewerrole_set.callback(cog, interaction, role=role)
+        await Application._reviewerrole_add.callback(cog, interaction, role)
         msg = interaction.response.send_message.call_args[0][0]
-        assert "reviewer role set" in msg.lower()
+        assert "Reviewer" in msg
+        assert "application reviewer" in msg.lower()
 
-    async def test_set_german(self, cog, interaction, db_session):
+    async def test_add_german(self, cog, interaction, db_session):
         _set_german(db_session)
         role = MagicMock()
         role.id = 55
         role.name = "Reviewer"
-        await Application._reviewerrole_set.callback(cog, interaction, role=role)
+        await Application._reviewerrole_add.callback(cog, interaction, role)
         msg = interaction.response.send_message.call_args[0][0]
-        assert "Prüfer-Rolle" in msg
+        assert "Bewerbungsprüfer" in msg
 
-    async def test_remove_not_configured_english(self, cog, interaction, db_session):
-        await Application._reviewerrole_remove.callback(cog, interaction)
+    async def test_remove_not_found_english(self, cog, interaction, db_session):
+        role = MagicMock()
+        role.id = 9999
+        role.name = "Ghost"
+        await Application._reviewerrole_remove.callback(cog, interaction, role)
         msg = interaction.response.send_message.call_args[0][0]
-        assert "No reviewer role" in msg
+        assert "not configured" in msg.lower()
 
-    async def test_remove_not_configured_german(self, cog, interaction, db_session):
+    async def test_remove_not_found_german(self, cog, interaction, db_session):
         _set_german(db_session)
-        await Application._reviewerrole_remove.callback(cog, interaction)
+        role = MagicMock()
+        role.id = 9999
+        role.name = "Ghost"
+        await Application._reviewerrole_remove.callback(cog, interaction, role)
         msg = interaction.response.send_message.call_args[0][0]
-        assert "Keine Prüfer-Rolle" in msg
+        assert "nicht als" in msg.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **New junction table** `ApplicationGuildRole(GuildId, RoleId, RoleType)` replaces the single `ManagerRoleId`/`ReviewerRoleId` columns on `ApplicationGuildConfig`, allowing guilds to assign multiple Discord roles to each type
- **Alembic migration 006** migrates existing single-role data and drops the old columns; dialect-aware (SQLite + PostgreSQL) with fresh-install guard
- **Permission checks** (`check_application_permission`, `check_override_permission`) rewritten to query all configured roles and use `any()` intersection
- **Review channel mentions** now ping all configured manager and reviewer roles instead of just one each
- **Command groups rewritten**: `managerole` and `reviewerrole` now have `add <role>`, `remove <role>`, `clear`, and `list` subcommands (replacing the old single `set`/`remove` pair)
- **Locale strings** updated in EN and DE for all four subcommands
- **Bug fix**: review channel permission error message now correctly references the review channel (not the apply channel)

## Test plan

- [ ] `/application managerole add @Role` — adds role, idempotent on repeat
- [ ] `/application managerole remove @Role` — removes specific role; shows error if not configured
- [ ] `/application managerole clear` — removes all manager roles
- [ ] `/application managerole list` — shows embed with all configured roles
- [ ] Same for `reviewerrole`
- [ ] Users holding any one of multiple manager/reviewer roles can vote and override as expected
- [ ] Review channel mention on new application pings all configured roles
- [ ] `alembic upgrade head` on an existing DB migrates single-role data correctly
- [ ] Fresh install (`create_all`) produces correct schema without migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)