### PR TITLE
fix(wow): normalize naive LastChecked datetime and fix TextInput label deprecation

### DIFF
--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -146,7 +146,10 @@ class WowCharacterMounts(db.BASE):
         deleted = 0
         for entry in all_entries:
             if (entry.CharacterName, entry.RealmSlug) not in active_keys:
-                if entry.LastChecked and entry.LastChecked < stale_cutoff:
+                last_checked = entry.LastChecked
+                if last_checked and last_checked.tzinfo is None:
+                    last_checked = last_checked.replace(tzinfo=UTC)
+                if last_checked and last_checked < stale_cutoff:
                     session.delete(entry)
                     deleted += 1
         return deleted

--- a/NerdyPy/modules/views/crafting_order.py
+++ b/NerdyPy/modules/views/crafting_order.py
@@ -168,11 +168,6 @@ class ProfessionSelectView(ui.View):
 class CraftingOrderModal(ui.Modal):
     """Order creation modal (Step 2)."""
 
-    item_name_input = ui.TextInput(label="Item Name", max_length=200)
-    notes_input = ui.TextInput(
-        label="Additional Notes (optional)", style=discord.TextStyle.paragraph, required=False, max_length=1000
-    )
-
     def __init__(
         self,
         bot,
@@ -186,8 +181,15 @@ class CraftingOrderModal(ui.Modal):
         self.role_id = role_id
         self.role = role
         self.guild_id = guild_id
-        self.item_name_input.label = get_string(lang, "wow.craftingorder.modal_item_name")
-        self.notes_input.label = get_string(lang, "wow.craftingorder.modal_notes")
+        self.item_name_input = ui.TextInput(label=get_string(lang, "wow.craftingorder.modal_item_name"), max_length=200)
+        self.notes_input = ui.TextInput(
+            label=get_string(lang, "wow.craftingorder.modal_notes"),
+            style=discord.TextStyle.paragraph,
+            required=False,
+            max_length=1000,
+        )
+        self.add_item(self.item_name_input)
+        self.add_item(self.notes_input)
 
     async def on_submit(self, interaction: Interaction):
         await interaction.response.defer(ephemeral=True)
@@ -447,12 +449,15 @@ class AskQuestionButton(ui.DynamicItem[ui.Button], template=r"crafting:ask:(?P<o
 
 
 class AskQuestionModal(ui.Modal):
-    message_input = ui.TextInput(label="Your question", style=discord.TextStyle.paragraph, max_length=1000)
-
     def __init__(self, order_id: int, lang: str = "en"):
         super().__init__(title=get_string(lang, "wow.craftingorder.ask.modal_title"))
         self.order_id = order_id
-        self.message_input.label = get_string(lang, "wow.craftingorder.ask.modal_message")
+        self.message_input = ui.TextInput(
+            label=get_string(lang, "wow.craftingorder.ask.modal_message"),
+            style=discord.TextStyle.paragraph,
+            max_length=1000,
+        )
+        self.add_item(self.message_input)
 
     async def on_submit(self, interaction: Interaction):
         await interaction.response.defer(ephemeral=True)


### PR DESCRIPTION
## Summary

- **`models/wow.py`**: `WowCharacterMounts.delete_stale()` compared `entry.LastChecked` (naive datetime, SQLite strips tzinfo) against `stale_cutoff = datetime.now(UTC)` (timezone-aware), causing a recurring `can't compare offset-naive and offset-aware datetimes` error in the guild news poll every 15 minutes. Fixed by normalizing with `.replace(tzinfo=UTC)` when `tzinfo is None`.
- **`crafting_order.py`**: `CraftingOrderModal` and `AskQuestionModal` were setting `TextInput.label` as a property after construction, which is deprecated in the installed discord.py version. Moved `TextInput` definitions into `__init__()` with translated labels passed directly to the constructor, using `add_item()` for explicit registration.

## Test plan

- [ ] Deploy and confirm guild news poll no longer logs `can't compare offset-naive and offset-aware datetimes`
- [ ] Open a crafting order and verify the item name / notes modal renders correctly with translated labels
- [ ] Use the "ask question" button on an order and verify the modal renders correctly
- [ ] Confirm no `DeprecationWarning: label is deprecated` lines appear in stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)