### PR TITLE
feat(application): open thread on review embed and ping roles inside thread

### DIFF
--- a/NerdyPy/locales/lang_de.yaml
+++ b/NerdyPy/locales/lang_de.yaml
@@ -633,6 +633,7 @@ application:
       confirm_qa_line: "**F:** {question}\n**A:** {answer}"
       error_title: "Einsende-Fehler"
       error_description: "Beim Erreichen des Überprüfungskanals ist etwas schiefgelaufen. Deine Antworten wurden nicht gespeichert — bitte versuche es in Kürze erneut."
+      review_thread_name: "Bewerbung"
       submitted_title: "Bewerbung eingereicht!"
       submitted_description: "Deine Bewerbung wurde zur Überprüfung eingereicht."
       cancelled_title: "Bewerbung abgebrochen"

--- a/NerdyPy/locales/lang_en.yaml
+++ b/NerdyPy/locales/lang_en.yaml
@@ -634,6 +634,7 @@ application:
       confirm_qa_line: "**Q:** {question}\n**A:** {answer}"
       error_title: "Submission error"
       error_description: "Something went wrong reaching the review channel. Your answers haven't been saved — please try again in a bit."
+      review_thread_name: "Application"
       submitted_title: "Application submitted!"
       submitted_description: "Your application has been submitted for review."
       cancelled_title: "Application cancelled"

--- a/NerdyPy/modules/conversations/application.py
+++ b/NerdyPy/modules/conversations/application.py
@@ -923,9 +923,7 @@ class ApplicationSubmitConversation(Conversation):
                 if mention_content:
                     await thread.send(mention_content)
             except discord.HTTPException:
-                self.bot.log.warning(
-                    "application: failed to create review thread for msg %d", msg.id
-                )
+                self.bot.log.warning("application: failed to create review thread for msg %d", msg.id)
 
             with self.bot.session_scope() as session:
                 submission = ApplicationSubmission.get_by_id(self.submission_id, session)

--- a/tests/integration/test_application_conversation.py
+++ b/tests/integration/test_application_conversation.py
@@ -1093,7 +1093,7 @@ class TestApplicationCreateConversationReview:
 
 
 class TestSubmitConversationRoleMentions:
-    """Review embed should mention admin + configured roles in message content."""
+    """Review embed should mention admin + configured roles in thread, not inline content."""
 
     @pytest.fixture
     def conv(self, mock_bot, mock_user, mock_guild, db_session):
@@ -1113,63 +1113,75 @@ class TestSubmitConversationRoleMentions:
             questions=[(q.Id, "Q1")],
         )
 
+    @pytest.fixture
+    def review_channel_with_thread(self):
+        """Mock review channel whose sent message has a thread mock attached."""
+        thread = MagicMock()
+        thread.send = AsyncMock()
+
+        sent_msg = MagicMock()
+        sent_msg.id = 777
+        sent_msg.create_thread = AsyncMock(return_value=thread)
+
+        channel = MagicMock()
+        channel.send = AsyncMock(return_value=sent_msg)
+        return channel, thread
+
     @pytest.mark.asyncio
-    async def test_mentions_admin_roles(self, conv, mock_bot, mock_guild):
+    async def test_mentions_admin_roles(self, conv, mock_bot, mock_guild, review_channel_with_thread):
+        channel, thread = review_channel_with_thread
         admin_role = MagicMock()
         admin_role.id = 888
         admin_role.permissions = MagicMock()
         admin_role.permissions.administrator = True
+        admin_role.managed = False
         mock_guild.roles = [admin_role]
 
-        channel = MagicMock()
-        sent_msg = MagicMock()
-        sent_msg.id = 777
-        channel.send = AsyncMock(return_value=sent_msg)
         mock_bot.get_channel = MagicMock(return_value=channel)
 
         conv.answers = {conv.questions[0][0]: "answer"}
         conv.currentState = SubmitState.SUBMIT
         await conv.repost_state()
 
-        content = channel.send.call_args.kwargs.get("content")
-        assert "<@&888>" in (content or "")
+        # embed posted without content
+        call_kwargs = channel.send.call_args.kwargs
+        assert "content" not in call_kwargs or call_kwargs.get("content") is None
+
+        # mention sent to thread
+        thread.send.assert_called_once()
+        assert "<@&888>" in thread.send.call_args.args[0]
 
     @pytest.mark.asyncio
-    async def test_mentions_configured_roles(self, conv, mock_bot, mock_guild, db_session):
+    async def test_mentions_configured_roles(self, conv, mock_bot, mock_guild, db_session, review_channel_with_thread):
         from models.application import ApplicationGuildRole
 
         db_session.add(ApplicationGuildRole(GuildId=mock_guild.id, RoleId=111, RoleType="manager"))
         db_session.add(ApplicationGuildRole(GuildId=mock_guild.id, RoleId=222, RoleType="reviewer"))
-        db_session.flush()
-        mock_guild.roles = []
+        db_session.commit()
 
-        channel = MagicMock()
-        sent_msg = MagicMock()
-        sent_msg.id = 777
-        channel.send = AsyncMock(return_value=sent_msg)
+        mock_guild.roles = []
+        channel, thread = review_channel_with_thread
         mock_bot.get_channel = MagicMock(return_value=channel)
 
         conv.answers = {conv.questions[0][0]: "answer"}
         conv.currentState = SubmitState.SUBMIT
         await conv.repost_state()
 
-        content = channel.send.call_args.kwargs.get("content")
-        assert "<@&111>" in (content or "")
-        assert "<@&222>" in (content or "")
+        thread.send.assert_called_once()
+        mentions = thread.send.call_args.args[0]
+        assert "<@&111>" in mentions
+        assert "<@&222>" in mentions
 
     @pytest.mark.asyncio
-    async def test_no_content_when_no_roles(self, conv, mock_bot, mock_guild):
-        mock_guild.roles = []  # no admin roles, no config
+    async def test_no_thread_send_when_no_roles(self, conv, mock_bot, mock_guild, review_channel_with_thread):
+        mock_guild.roles = []
 
-        channel = MagicMock()
-        sent_msg = MagicMock()
-        sent_msg.id = 777
-        channel.send = AsyncMock(return_value=sent_msg)
+        channel, thread = review_channel_with_thread
         mock_bot.get_channel = MagicMock(return_value=channel)
 
         conv.answers = {conv.questions[0][0]: "answer"}
         conv.currentState = SubmitState.SUBMIT
         await conv.repost_state()
 
-        content = channel.send.call_args.kwargs.get("content")
-        assert not content
+        # No mentions → thread still created but thread.send not called
+        thread.send.assert_not_called()

--- a/tests/integration/test_application_conversation.py
+++ b/tests/integration/test_application_conversation.py
@@ -1189,14 +1189,12 @@ class TestSubmitConversationRoleMentions:
         await conv.repost_state()
 
         # No mentions → thread still created but thread.send not called
+        channel.send.return_value.create_thread.assert_called_once()
         thread.send.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_managed_admin_role_not_mentioned(self, conv, mock_bot, mock_guild, review_channel_with_thread):
-        """Managed (bot/integration) admin roles must not be pinged.
-        Currently passes trivially (no thread creation yet); after Task 5 implementation
-        this correctly fails if role.managed filtering is absent from the admin sweep.
-        """
+        """Managed (bot/integration) admin roles must not be pinged."""
         managed_role = MagicMock()
         managed_role.id = 999
         managed_role.permissions = MagicMock()
@@ -1215,10 +1213,7 @@ class TestSubmitConversationRoleMentions:
 
     @pytest.mark.asyncio
     async def test_thread_creation_failure_is_handled(self, conv, mock_bot, mock_guild, db_session):
-        """If create_thread raises HTTPException, ReviewMessageId must still be saved and
-        no exception must propagate. Currently passes trivially (no create_thread call yet);
-        after Task 5 implementation this exercises the real exception-handling path.
-        """
+        """If create_thread raises HTTPException, ReviewMessageId must still be saved and no exception must propagate."""
         from models.application import ApplicationSubmission
 
         admin_role = MagicMock()

--- a/tests/integration/test_application_conversation.py
+++ b/tests/integration/test_application_conversation.py
@@ -435,10 +435,15 @@ class TestApplicationSubmitConversation:
 
     @pytest.fixture
     def mock_review_channel(self):
-        """Mock channel for review embed posting."""
-        channel = MagicMock()
+        """Mock channel for review embed posting, with thread creation support."""
+        thread = MagicMock()
+        thread.send = AsyncMock()
+
         review_msg = MagicMock()
         review_msg.id = 888777666
+        review_msg.create_thread = AsyncMock(return_value=thread)
+
+        channel = MagicMock()
         channel.send = AsyncMock(return_value=review_msg)
         return channel
 


### PR DESCRIPTION
## Summary

- Review embed is now posted to the review channel without inline role pings
- A public thread is immediately opened on the embed (named after the applicant)
- Role mentions (manager, reviewer, and non-managed admin roles) are sent inside the thread instead
- Managed (bot/integration) roles with administrator permissions are filtered out of the ping to avoid mentioning bot accounts

## Test Plan

- [ ] Submit an application and verify the review embed has no inline mentions
- [ ] Verify a thread is created immediately on the embed, named after the applicant
- [ ] Verify role pings appear as a message inside the thread
- [ ] Verify bot/integration roles with admin perms are not mentioned
- [ ] Verify thread creation failure is handled gracefully (ReviewMessageId still saved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)