### PR TITLE
fix: delete attached threads when deleting messages, fix permissions map

### DIFF
--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -200,7 +200,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
             if (
                 not perms.send_messages
                 or not perms.embed_links
-                or not perms.create_private_threads
+                or not perms.create_public_threads
                 or not perms.send_messages_in_threads
             ):
                 await interaction.response.send_message(

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -248,7 +248,12 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
 
             if interaction.guild.get_channel(channel_id) is not None:
                 validate_channel_permissions(
-                    channel, interaction.guild, "view_channel", "manage_messages", "manage_threads", "read_message_history"
+                    channel,
+                    interaction.guild,
+                    "view_channel",
+                    "manage_messages",
+                    "manage_threads",
+                    "read_message_history",
                 )
                 if delete_older_than is None:
                     delete = delete_older_than

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -136,6 +136,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
                         f"[{guild.name} ({guild.id})]: deleting message from #{message.channel.name} "
                         f"by {message.author} ({message.author.id}), created at {message.created_at}"
                     )
+                    if message.thread:
+                        await message.thread.delete()
                     await message.delete()
         except Exception as ex:
             self.bot.log.error(f"Autodeleter: {ex}")
@@ -246,7 +248,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
 
             if interaction.guild.get_channel(channel_id) is not None:
                 validate_channel_permissions(
-                    channel, interaction.guild, "view_channel", "manage_messages", "read_message_history"
+                    channel, interaction.guild, "view_channel", "manage_messages", "manage_threads", "read_message_history"
                 )
                 if delete_older_than is None:
                     delete = delete_older_than

--- a/NerdyPy/modules/wow.py
+++ b/NerdyPy/modules/wow.py
@@ -1282,6 +1282,8 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
             await interaction.followup.send(get_string(lang, "wow.craftingorder.create.no_roles"), ephemeral=True)
             return
 
+        validate_channel_permissions(channel, interaction.guild, "send_messages", "embed_links", "manage_threads")
+
         with self.bot.session_scope() as session:
             existing = CraftingBoardConfig.get_by_guild(interaction.guild_id, session)
             if existing:
@@ -1346,6 +1348,8 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
             channel = interaction.guild.get_channel(channel_id)
             if channel and message_id:
                 msg = await channel.fetch_message(message_id)
+                if msg.thread:
+                    await msg.thread.delete()
                 await msg.delete()
         except discord.HTTPException:
             self.bot.log.debug("Failed to delete crafting board message (channel=%s, msg=%s)", channel_id, message_id)

--- a/NerdyPy/utils/permissions.py
+++ b/NerdyPy/utils/permissions.py
@@ -25,10 +25,10 @@ REQUIRED_PERMISSIONS: dict[str, set[str]] = {
     },
     "admin": set(),
     "application": {"send_messages", "embed_links", "create_public_threads"},
-    "league": {"send_messages"},
+    "league": {"send_messages", "embed_links"},
     "leavemsg": {"send_messages"},
-    "moderation": {"send_messages", "kick_members", "manage_messages", "read_message_history"},
-    "music": {"send_messages", "embed_links", "connect", "speak", "add_reactions", "read_message_history"},
+    "moderation": {"send_messages", "kick_members", "manage_messages", "manage_threads", "read_message_history"},
+    "music": {"send_messages", "embed_links", "connect", "speak"},
     "reactionrole": {
         "send_messages",
         "manage_roles",
@@ -38,9 +38,9 @@ REQUIRED_PERMISSIONS: dict[str, set[str]] = {
     },
     "rolemanage": {"send_messages", "manage_roles"},
     "reminder": {"send_messages"},
-    "tagging": {"send_messages", "connect", "speak", "add_reactions", "read_message_history"},
+    "tagging": {"send_messages", "connect", "speak"},
     "voicecontrol": {"send_messages", "connect", "speak"},
-    "wow": {"send_messages", "embed_links"},
+    "wow": {"send_messages", "embed_links", "manage_threads"},
 }
 
 


### PR DESCRIPTION
## Summary

- Autodeleter and crafting board removal now delete any thread attached to a message before deleting the message itself — Discord does not cascade thread deletion from parent messages
- `validate_channel_permissions` checks now include `manage_threads` for both autodeleter create and crafting board create, so users get a clear error instead of a silent runtime failure
- `permissions.py`: add `manage_threads` to `moderation` and `wow`; add `embed_links` to `league`; remove `add_reactions` and `read_message_history` from `music` and `tagging` (both are already covered by `_core`)
- `application.py`: fix inline permission check that incorrectly tested `create_private_threads` — `message.create_thread()` creates public threads and requires `create_public_threads`

## Test Plan

- [ ] Autodeleter deletes thread when present before deleting the message
- [ ] Crafting board removal deletes thread before deleting the board message
- [ ] Setting up autodeleter/crafting board in a channel where the bot lacks `manage_threads` shows a permission error
- [ ] `uv run python -m pytest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)