### PR TITLE
refactor(application): migrate TextInput.label to discord.ui.Label wrapper

### DIFF
--- a/NerdyPy/modules/views/application.py
+++ b/NerdyPy/modules/views/application.py
@@ -332,10 +332,6 @@ async def _validate_review_interaction(bot, interaction, session):
 class DenyVoteModal(discord.ui.Modal):
     """Modal that collects a required message when denying an application."""
 
-    message = discord.ui.TextInput(
-        label="Review note", style=discord.TextStyle.paragraph, required=True, max_length=1000
-    )
-
     def __init__(
         self,
         submission_id: int,
@@ -349,15 +345,18 @@ class DenyVoteModal(discord.ui.Modal):
         self.submission_id = submission_id
         self.bot = bot
         self.lang = lang
-        self.message.label = get_string(lang, "application.modal.review_note_label")
         self.review_channel_id = review_channel_id
         self.review_message_id = review_message_id
+        self._message = discord.ui.TextInput(style=discord.TextStyle.paragraph, required=True, max_length=1000)
         if prefill:
-            self.message.default = prefill
+            self._message.default = prefill
+        self.add_item(
+            discord.ui.Label(text=get_string(lang, "application.modal.review_note_label"), component=self._message)
+        )
 
     async def on_submit(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
-        message_text = self.message.value
+        message_text = self._message.value
 
         with self.bot.session_scope() as session:
             if not await _record_first_vote(
@@ -399,10 +398,6 @@ class DenyVoteModal(discord.ui.Modal):
 class ApproveVoteModal(discord.ui.Modal):
     """Modal that collects a required message when approving an application."""
 
-    message = discord.ui.TextInput(
-        label="Review note", style=discord.TextStyle.paragraph, required=True, max_length=1000
-    )
-
     def __init__(
         self,
         submission_id: int,
@@ -416,15 +411,18 @@ class ApproveVoteModal(discord.ui.Modal):
         self.submission_id = submission_id
         self.bot = bot
         self.lang = lang
-        self.message.label = get_string(lang, "application.modal.review_note_label")
         self.review_channel_id = review_channel_id
         self.review_message_id = review_message_id
+        self._message = discord.ui.TextInput(style=discord.TextStyle.paragraph, required=True, max_length=1000)
         if prefill:
-            self.message.default = prefill
+            self._message.default = prefill
+        self.add_item(
+            discord.ui.Label(text=get_string(lang, "application.modal.review_note_label"), component=self._message)
+        )
 
     async def on_submit(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
-        message_text = self.message.value
+        message_text = self._message.value
 
         with self.bot.session_scope() as session:
             if not await _record_first_vote(
@@ -466,10 +464,6 @@ class ApproveVoteModal(discord.ui.Modal):
 class MessageModal(discord.ui.Modal):
     """Modal that sends a free-form message to the applicant."""
 
-    message = discord.ui.TextInput(
-        label="Message to send", style=discord.TextStyle.paragraph, required=False, max_length=1000
-    )
-
     def __init__(
         self,
         user_id: int,
@@ -484,15 +478,18 @@ class MessageModal(discord.ui.Modal):
         self.target_user_id = user_id
         self.bot = bot
         self.lang = lang
-        self.message.label = get_string(lang, "application.modal.message_label")
         self.submission_id = submission_id
         self.review_channel_id = review_channel_id
         self.review_message_id = review_message_id
+        self._message = discord.ui.TextInput(style=discord.TextStyle.paragraph, required=False, max_length=1000)
         if prefill:
-            self.message.default = prefill
+            self._message.default = prefill
+        self.add_item(
+            discord.ui.Label(text=get_string(lang, "application.modal.message_label"), component=self._message)
+        )
 
     async def on_submit(self, interaction: discord.Interaction):
-        if not self.message.value:
+        if not self._message.value:
             await interaction.response.send_message(
                 get_string(self.lang, "application.message_modal.no_content"), ephemeral=True
             )
@@ -502,7 +499,7 @@ class MessageModal(discord.ui.Modal):
             user = await self.bot.fetch_user(self.target_user_id)
             embed = discord.Embed(
                 title=get_string(self.lang, "application.message_modal.reviewer_title"),
-                description=f"**From:** {interaction.user.mention}\n\n{self.message.value}",
+                description=f"**From:** {interaction.user.mention}\n\n{self._message.value}",
                 colour=discord.Colour.blurple(),
             )
             await user.send(embed=embed)
@@ -683,10 +680,6 @@ class EditVoteSelectView(discord.ui.View):
 class EditApproveModal(discord.ui.Modal):
     """Modal for changing an existing vote to Approve."""
 
-    message = discord.ui.TextInput(
-        label="Review note", style=discord.TextStyle.paragraph, required=True, max_length=1000
-    )
-
     def __init__(
         self,
         submission_id: int,
@@ -700,14 +693,17 @@ class EditApproveModal(discord.ui.Modal):
         self.submission_id = submission_id
         self.bot = bot
         self.lang = lang
-        self.message.label = get_string(lang, "application.modal.review_note_label")
         self.previous_vote = previous_vote
         self.review_channel_id = review_channel_id
         self.review_message_id = review_message_id
+        self._message = discord.ui.TextInput(style=discord.TextStyle.paragraph, required=True, max_length=1000)
+        self.add_item(
+            discord.ui.Label(text=get_string(lang, "application.modal.review_note_label"), component=self._message)
+        )
 
     async def on_submit(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
-        message_text = self.message.value
+        message_text = self._message.value
 
         with self.bot.session_scope() as session:
             if not await _record_edit_vote(
@@ -739,10 +735,6 @@ class EditApproveModal(discord.ui.Modal):
 class EditDenyModal(discord.ui.Modal):
     """Modal for changing an existing vote to Deny."""
 
-    message = discord.ui.TextInput(
-        label="Review note", style=discord.TextStyle.paragraph, required=True, max_length=1000
-    )
-
     def __init__(
         self,
         submission_id: int,
@@ -756,14 +748,17 @@ class EditDenyModal(discord.ui.Modal):
         self.submission_id = submission_id
         self.bot = bot
         self.lang = lang
-        self.message.label = get_string(lang, "application.modal.review_note_label")
         self.previous_vote = previous_vote
         self.review_channel_id = review_channel_id
         self.review_message_id = review_message_id
+        self._message = discord.ui.TextInput(style=discord.TextStyle.paragraph, required=True, max_length=1000)
+        self.add_item(
+            discord.ui.Label(text=get_string(lang, "application.modal.review_note_label"), component=self._message)
+        )
 
     async def on_submit(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
-        message_text = self.message.value
+        message_text = self._message.value
 
         with self.bot.session_scope() as session:
             if not await _record_edit_vote(
@@ -793,10 +788,6 @@ class EditDenyModal(discord.ui.Modal):
 class OverrideModal(discord.ui.Modal):
     """Admin/manager modal to flip a decided application APPROVED↔DENIED."""
 
-    reason = discord.ui.TextInput(
-        label="Reason for override", style=discord.TextStyle.paragraph, required=True, max_length=1000
-    )
-
     def __init__(
         self,
         current_status: SubmissionStatus,
@@ -817,13 +808,16 @@ class OverrideModal(discord.ui.Modal):
         self.submission_id = submission_id
         self.bot = bot
         self.lang = lang
-        self.reason.label = get_string(lang, "application.modal.override_reason_label")
         self.review_channel_id = review_channel_id
         self.review_message_id = review_message_id
+        self._reason = discord.ui.TextInput(style=discord.TextStyle.paragraph, required=True, max_length=1000)
+        self.add_item(
+            discord.ui.Label(text=get_string(lang, "application.modal.override_reason_label"), component=self._reason)
+        )
 
     async def on_submit(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
-        reason_text = self.reason.value
+        reason_text = self._reason.value
 
         with self.bot.session_scope() as session:
             submission = ApplicationSubmission.get_by_id(self.submission_id, session)

--- a/NerdyPy/modules/wow.py
+++ b/NerdyPy/modules/wow.py
@@ -1232,9 +1232,10 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
             return
 
         await interaction.response.defer(ephemeral=True)
-        await self._finish_board_create(interaction, channel, roles, description, lang)
+        await self.finish_board_create(interaction, channel, roles, description, lang)
 
-    def _parse_role_ids(self, roles_str: str, guild: discord.Guild) -> list[int]:
+    @staticmethod
+    def _parse_role_ids(roles_str: str, guild: discord.Guild) -> list[int]:
         """Parse role mentions/IDs from a space/comma-separated string."""
         role_ids = []
         for part in roles_str.replace(",", " ").split():
@@ -1245,7 +1246,8 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
                     role_ids.append(role.id)
         return role_ids
 
-    def _auto_match_roles(self, guild: discord.Guild, role_ids: list[int], session) -> tuple[list[int], list[int]]:
+    @staticmethod
+    def _auto_match_roles(guild: discord.Guild, role_ids: list[int], session) -> tuple[list[int], list[int]]:
         """Auto-match Discord roles to Blizzard profession IDs.
 
         Returns (mapped_role_ids, unmapped_role_ids).
@@ -1272,7 +1274,7 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
 
         return mapped, unmapped
 
-    async def _finish_board_create(
+    async def finish_board_create(
         self, interaction: Interaction, channel: TextChannel, roles: str, description: str, lang: str
     ):
         """Shared board creation logic used by both the command and the description modal."""
@@ -1386,7 +1388,7 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
         modal._unmapped = unmapped
         await interaction.response.send_modal(modal)
 
-    async def _finish_board_edit(
+    async def finish_board_edit(
         self, interaction: Interaction, new_description: str, lang: str, unmapped: list[int] | None = None
     ):
         """Update the board description and edit the embed in-place."""
@@ -1432,7 +1434,7 @@ class _BoardDescriptionModal(discord.ui.Modal):
     """Modal for collecting/editing board description.
 
     Supports two modes:
-    - "create": calls _finish_board_create after submission
+    - "create": calls finish_board_create after submission
     - "edit": updates existing board config and edits the embed in-place
     """
 
@@ -1468,14 +1470,12 @@ class _BoardDescriptionModal(discord.ui.Modal):
         cog = self.bot.get_cog("WorldofWarcraft")
 
         if self.mode == "create":
-            await cog._finish_board_create(
+            await cog.finish_board_create(
                 interaction, self.channel, self.roles, self.description_input.value.strip(), self.lang
             )
         else:
             unmapped = getattr(self, "_unmapped", [])
-            await cog._finish_board_edit(
-                interaction, self.description_input.value.strip(), self.lang, unmapped=unmapped
-            )
+            await cog.finish_board_edit(interaction, self.description_input.value.strip(), self.lang, unmapped=unmapped)
 
 
 async def setup(bot):

--- a/tests/modules/test_application_view.py
+++ b/tests/modules/test_application_view.py
@@ -335,7 +335,7 @@ class TestApproveVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Looking forward to having you!"
+        modal._message._value = "Looking forward to having you!"
 
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.message = None
@@ -360,7 +360,7 @@ class TestApproveVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Approved!"
+        modal._message._value = "Approved!"
 
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.message = None
@@ -381,7 +381,7 @@ class TestApproveVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Great application!"
+        modal._message._value = "Great application!"
 
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.message = None
@@ -404,7 +404,7 @@ class TestApproveVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Welcome!"
+        modal._message._value = "Welcome!"
 
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.message = None
@@ -425,7 +425,7 @@ class TestApproveVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Nice!"
+        modal._message._value = "Nice!"
 
         call_order = []
         interaction = _make_reviewer_interaction(mock_bot)
@@ -450,7 +450,7 @@ class TestApproveVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Vote again!"
+        modal._message._value = "Vote again!"
 
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.message = None
@@ -471,7 +471,7 @@ class TestApproveVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Congrats!"
+        modal._message._value = "Congrats!"
 
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.message = None
@@ -561,7 +561,7 @@ class TestDenyVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Not a good fit"
+        modal._message._value = "Not a good fit"
 
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.message = None
@@ -587,7 +587,7 @@ class TestDenyVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Does not meet requirements."
+        modal._message._value = "Does not meet requirements."
 
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.message = None
@@ -610,7 +610,7 @@ class TestDenyVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Not this time."
+        modal._message._value = "Not this time."
 
         call_order = []
         interaction = _make_reviewer_interaction(mock_bot)
@@ -633,7 +633,7 @@ class TestDenyVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Not yet."
+        modal._message._value = "Not yet."
 
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.message = None
@@ -654,7 +654,7 @@ class TestDenyVoteModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Too late"
+        modal._message._value = "Too late"
 
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.message = None
@@ -712,7 +712,7 @@ class TestMessageButton:
         await review_view.message_applicant.callback(interaction)
 
         modal = interaction.response.send_modal.call_args[0][0]
-        assert modal.message.default == "Welcome to the team!"
+        assert modal._message.default == "Welcome to the team!"
 
     @pytest.mark.asyncio
     async def test_message_button_no_prefill_when_pending(self, review_view, mock_bot, db_session):
@@ -723,7 +723,7 @@ class TestMessageButton:
         await review_view.message_applicant.callback(interaction)
 
         modal = interaction.response.send_modal.call_args[0][0]
-        assert modal.message.default is None
+        assert modal._message.default is None
 
     @pytest.mark.asyncio
     async def test_message_button_uses_default_approval_message_when_none_configured(
@@ -738,8 +738,8 @@ class TestMessageButton:
         await review_view.message_applicant.callback(interaction)
 
         modal = interaction.response.send_modal.call_args[0][0]
-        assert modal.message.default is not None
-        assert "approved" in modal.message.default.lower()
+        assert modal._message.default is not None
+        assert "approved" in modal._message.default.lower()
 
     @pytest.mark.asyncio
     async def test_message_button_uses_default_denial_message_when_none_configured(
@@ -754,8 +754,8 @@ class TestMessageButton:
         await review_view.message_applicant.callback(interaction)
 
         modal = interaction.response.send_modal.call_args[0][0]
-        assert modal.message.default is not None
-        assert "denied" in modal.message.default.lower()
+        assert modal._message.default is not None
+        assert "denied" in modal._message.default.lower()
 
     @pytest.mark.asyncio
     async def test_message_button_prefills_denial_message(self, review_view, mock_bot, db_session):
@@ -769,7 +769,7 @@ class TestMessageButton:
         await review_view.message_applicant.callback(interaction)
 
         modal = interaction.response.send_modal.call_args[0][0]
-        assert modal.message.default == "Unfortunately you do not meet our requirements."
+        assert modal._message.default == "Unfortunately you do not meet our requirements."
 
 
 # ---------------------------------------------------------------------------
@@ -785,7 +785,7 @@ class TestMessageModal:
         mock_bot.fetch_user = AsyncMock(return_value=mock_user)
 
         modal = MessageModal(user_id=APPLICANT_USER_ID, bot=mock_bot)
-        modal.message._value = "Please provide more details about your experience."
+        modal._message._value = "Please provide more details about your experience."
 
         interaction = _make_reviewer_interaction(mock_bot)
         await modal.on_submit(interaction)
@@ -799,7 +799,7 @@ class TestMessageModal:
         mock_bot.fetch_user = AsyncMock(side_effect=discord.Forbidden(MagicMock(), "Cannot send messages"))
 
         modal = MessageModal(user_id=APPLICANT_USER_ID, bot=mock_bot)
-        modal.message._value = "Hello"
+        modal._message._value = "Hello"
 
         interaction = _make_reviewer_interaction(mock_bot)
         await modal.on_submit(interaction)
@@ -813,7 +813,7 @@ class TestMessageModal:
         mock_bot.fetch_user = AsyncMock(side_effect=discord.NotFound(MagicMock(status=404), "Unknown User"))
 
         modal = MessageModal(user_id=APPLICANT_USER_ID, bot=mock_bot)
-        modal.message._value = "Hello"
+        modal._message._value = "Hello"
 
         interaction = _make_reviewer_interaction(mock_bot)
         await modal.on_submit(interaction)
@@ -827,7 +827,7 @@ class TestMessageModal:
         mock_bot.fetch_user = AsyncMock()
 
         modal = MessageModal(user_id=APPLICANT_USER_ID, bot=mock_bot)
-        modal.message._value = ""
+        modal._message._value = ""
 
         interaction = _make_reviewer_interaction(mock_bot)
         await modal.on_submit(interaction)
@@ -840,7 +840,7 @@ class TestMessageModal:
     async def test_message_modal_prefill_stored(self, mock_bot):
         """Prefill string should be set as the TextInput default."""
         modal = MessageModal(user_id=APPLICANT_USER_ID, bot=mock_bot, prefill="Welcome aboard!")
-        assert modal.message.default == "Welcome aboard!"
+        assert modal._message.default == "Welcome aboard!"
 
     @pytest.mark.asyncio
     async def test_message_modal_sets_notified_on_decided_submission(self, mock_bot, db_session):
@@ -866,7 +866,7 @@ class TestMessageModal:
             review_channel_id=REVIEW_CHANNEL_ID,
             review_message_id=REVIEW_MSG_ID,
         )
-        modal.message._value = "Congratulations!"
+        modal._message._value = "Congratulations!"
 
         interaction = _make_reviewer_interaction(mock_bot)
         await modal.on_submit(interaction)
@@ -888,7 +888,7 @@ class TestMessageModal:
             bot=mock_bot,
             submission_id=submission.Id,
         )
-        modal.message._value = "Could you clarify your experience?"
+        modal._message._value = "Could you clarify your experience?"
 
         interaction = _make_reviewer_interaction(mock_bot)
         await modal.on_submit(interaction)
@@ -910,7 +910,7 @@ class TestMessageModal:
             bot=mock_bot,
             submission_id=submission.Id,
         )
-        modal.message._value = "Welcome!"
+        modal._message._value = "Welcome!"
 
         interaction = _make_reviewer_interaction(mock_bot)
         await modal.on_submit(interaction)
@@ -1183,7 +1183,7 @@ class TestEditApproveModal:
             review_channel_id=111,
             review_message_id=222,
         )
-        modal.message._value = "Looks good after all"
+        modal._message._value = "Looks good after all"
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.followup = AsyncMock()
         await modal.on_submit(interaction)
@@ -1207,7 +1207,7 @@ class TestEditApproveModal:
             review_channel_id=111,
             review_message_id=222,
         )
-        modal.message._value = "changed mind"
+        modal._message._value = "changed mind"
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.followup = AsyncMock()
         await modal.on_submit(interaction)
@@ -1232,7 +1232,7 @@ class TestEditApproveModal:
             review_channel_id=111,
             review_message_id=222,
         )
-        modal.message._value = "on second thought, yes"
+        modal._message._value = "on second thought, yes"
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.followup = AsyncMock()
         await modal.on_submit(interaction)
@@ -1254,7 +1254,7 @@ class TestEditApproveModal:
             review_channel_id=111,
             review_message_id=222,
         )
-        modal.message._value = "some note"
+        modal._message._value = "some note"
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.followup = AsyncMock()
         await modal.on_submit(interaction)
@@ -1291,7 +1291,7 @@ class TestEditDenyModal:
             review_channel_id=111,
             review_message_id=222,
         )
-        modal.message._value = "actually not good"
+        modal._message._value = "actually not good"
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.followup = AsyncMock()
         await modal.on_submit(interaction)
@@ -1315,7 +1315,7 @@ class TestEditDenyModal:
             review_channel_id=111,
             review_message_id=222,
         )
-        modal.message._value = "nope"
+        modal._message._value = "nope"
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.followup = AsyncMock()
         await modal.on_submit(interaction)
@@ -1431,7 +1431,7 @@ class TestOverrideModal:
             review_channel_id=111,
             review_message_id=222,
         )
-        modal.reason._value = "Changed due to new info"
+        modal._reason._value = "Changed due to new info"
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.followup = AsyncMock()
         await modal.on_submit(interaction)
@@ -1454,7 +1454,7 @@ class TestOverrideModal:
             review_channel_id=111,
             review_message_id=222,
         )
-        modal.reason._value = "Actually looks fine"
+        modal._reason._value = "Actually looks fine"
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.followup = AsyncMock()
         await modal.on_submit(interaction)
@@ -1477,7 +1477,7 @@ class TestOverrideModal:
             review_channel_id=111,
             review_message_id=222,
         )
-        modal.reason._value = "Override reason here"
+        modal._reason._value = "Override reason here"
         interaction = _make_reviewer_interaction(mock_bot)
         interaction.followup = AsyncMock()
         await modal.on_submit(interaction)


### PR DESCRIPTION
## Summary
- Migrate all 10 modal classes in `views/application.py` and `application.py` from deprecated `TextInput.label` property setter to discord.py 2.6 `discord.ui.Label(text=..., component=...)` wrapper (closes #261)
- Update `_localize_field` helper to accept modal and use Label wrapper instead of setting `.label` directly
- Add `@staticmethod` to `_parse_role_ids` and `_auto_match_roles` in `wow.py` (PyCharm inspection fix)
- Rename `_finish_board_create`/`_finish_board_edit` to public methods since they're called cross-class from `_BoardDescriptionModal`
- Update 30 test references in `test_application_view.py` to match renamed instance attributes

## Test plan
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — 98 files already formatted
- [x] `uv run python -m pytest tests/modules/test_application_view.py -v` — 93/93 passed
- [x] `uv run python -m pytest` — 944/944 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)