### PR TITLE
refactor(docker): split builder stages and add per-target CI path filtering

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,9 +4,19 @@ LICENSE
 CHANGELOG
 .github
 .gitignore
+.git
 config/
 docker-compose*.yml
 NerdyPy/config.yaml.template
 NerdyPy/config*.yaml
 NerdyPy/db.db
 NerdyPy/weather_cache.sqlite
+
+# Non-build files
+docs/
+tests/
+*.md
+.pre-commit-config.yaml
+.ruff.toml
+.pytest_cache/
+.venv/

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -14,9 +14,44 @@ on:
       - ".github/workflows/docker-pr.yml"
 
 jobs:
+  changes:
+    name: Detect Changed Paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      bot: ${{ steps.filter.outputs.bot }}
+      migrations: ${{ steps.filter.outputs.migrations }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Detect changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            bot:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'NerdyPy/**'
+              - '.github/workflows/docker-pr.yml'
+            migrations:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'database-migrations/**'
+              - 'alembic.ini'
+              - '.github/workflows/docker-pr.yml'
+
   validate-bot:
     name: Validate NerpyBot Image
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.bot == 'true'
     permissions:
       contents: read
 
@@ -46,6 +81,8 @@ jobs:
   validate-migrations:
     name: Validate Migrations Image
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.migrations == 'true'
     permissions:
       contents: read
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,9 +19,45 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  changes:
+    name: Detect Changed Paths
+    runs-on: ubuntu-latest
+    if: github.ref_type != 'tag'
+    permissions:
+      contents: read
+    outputs:
+      bot: ${{ steps.filter.outputs.bot }}
+      migrations: ${{ steps.filter.outputs.migrations }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Detect changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            bot:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'NerdyPy/**'
+              - '.github/workflows/docker.yml'
+            migrations:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'database-migrations/**'
+              - 'alembic.ini'
+              - '.github/workflows/docker.yml'
+
   build-bot:
     name: Build & Push NerpyBot Image
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.bot == 'true')
     permissions:
       contents: read
       packages: write
@@ -80,6 +116,8 @@ jobs:
   build-migrations:
     name: Build & Push Migrations Image
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.migrations == 'true')
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

- **Dockerfile**: Split single `builder` into `builder-base` → `builder-bot` / `builder-migrations` so BuildKit's DAG pruning skips the irrelevant dependency install when building a single target. Eliminates the `cp -a .venv` workaround.
- **CI workflows**: Added `dorny/paths-filter@v3` to both `docker.yml` and `docker-pr.yml`. Bot and migrations jobs now only run when their respective files change. Tag pushes still build both images unconditionally.
- **.dockerignore**: Expanded to exclude `docs/`, `tests/`, `*.md`, `.git/`, `.pre-commit-config.yaml`, `.ruff.toml`, `.pytest_cache/`, `.venv/` from the build context.

## Test plan

- [x] `docker buildx build --target bot` — builds successfully, no migration deps installed
- [x] `docker buildx build --target migrations` — builds successfully, no bot deps installed
- [x] Bot smoke test: `docker run --rm nerpybot:test python -c "from bot import NerpyBot; print('OK')"` → OK
- [x] Migrations smoke test: `docker run --rm nerpybot-migrations:test alembic heads` → `006 (head)`
- [x] `actionlint` passes on both workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)