### PR TITLE
fix: suppress aiohttp ws_connect timeout deprecation from discord.py

### DIFF
--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -6,6 +6,7 @@ Main Class of the NerpyBot
 from argparse import ArgumentParser, Namespace
 from asyncio import run
 from contextlib import contextmanager
+from warnings import filterwarnings
 from datetime import UTC, datetime
 from itertools import cycle
 from pathlib import Path
@@ -435,6 +436,9 @@ def parse_config(config_file=None) -> dict:
 
 def main() -> None:
     """Entry point for the NerpyBot."""
+    # discord.py passes float to aiohttp ws_connect timeout instead of ClientWSTimeout
+    filterwarnings("ignore", category=DeprecationWarning, module=r"discord\.http")
+
     args = parse_arguments()
     config = parse_config(args.config)
     intents = get_intents()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ addopts = "-v --tb=short"
 filterwarnings = [
     # discord.py uses deprecated asyncio.iscoroutinefunction (will be fixed when discord.py updates)
     "ignore::DeprecationWarning:discord.ext.commands.core",
+    # discord.py passes float to aiohttp ws_connect timeout instead of ClientWSTimeout
+    "ignore::DeprecationWarning:discord.http",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

- Suppress `DeprecationWarning` from `discord.http` caused by discord.py 2.6.4 passing a raw `float` to `aiohttp.ws_connect(timeout=...)` instead of `ClientWSTimeout`
- Added runtime filter in `bot.py` `main()` to silence it in production
- Added pytest filter in `pyproject.toml` to silence it in tests

## Test plan

- [x] All 944 existing tests pass
- [ ] Verify bot starts without the deprecation warning in Docker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)