### PR TITLE
feat: full NERPYBOT_* env var config, typer CLI, single-stack docker compose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ uv sync --only-group migrations      # Migration tools only
 # Run the bot
 uv run python NerdyPy/bot.py                    # Start with default config
 uv run python NerdyPy/bot.py -d                 # Debug logging (no sqlalchemy noise)
-uv run python NerdyPy/bot.py -l DEBUG            # Debug mode (includes sqlalchemy)
+uv run python NerdyPy/bot.py --verbosity 3      # Max verbosity (includes sqlalchemy)
 uv run python NerdyPy/bot.py -c path             # Custom config file
 uv run python NerdyPy/bot.py -r                  # Auto-restart on failure
 
@@ -141,6 +141,7 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - **Localization strings vs user-defined templates** — `get_string()` only processes bot-authored strings from `NerdyPy/locales/lang_*.yaml`. User-defined content (leave messages, custom tags) must never pass through `get_string()` — format them at the call site instead.
 - **Adding a new language** — Create `NerdyPy/locales/lang_<code>.yaml`, restart the bot. No code changes needed. English keys are canonical — any missing key in other languages falls back to English automatically.
 - **Guild language is global** — `GuildLanguageConfig` is the single source of truth for a guild's language preference. Modules calling external APIs (Blizzard, Riot) should honor this setting when the API supports it, falling back to English otherwise.
+- **Full env var config** — All config keys can be set via `NERPYBOT_*` environment variables (see `docker-compose.yml` for the full list). Env vars take priority over `config.yaml` when both are present. Lists (`modules`, `ops`, `error_recipients`) use comma-separated values.
 
 ## Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ uv sync --only-group migrations      # Migration tools only
 # Run the bot
 uv run python NerdyPy/bot.py                    # Start with default config
 uv run python NerdyPy/bot.py -d                 # Debug logging (no sqlalchemy noise)
-uv run python NerdyPy/bot.py --verbosity 3      # Max verbosity (includes sqlalchemy)
+uv run python NerdyPy/bot.py --verbosity 1      # DEBUG (bot only)
+uv run python NerdyPy/bot.py --verbosity 2      # DEBUG + discord.py verbose
+uv run python NerdyPy/bot.py --verbosity 3      # DEBUG + discord.py + sqlalchemy
 uv run python NerdyPy/bot.py -c path             # Custom config file
 uv run python NerdyPy/bot.py -r                  # Auto-restart on failure
 

--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -6,15 +6,15 @@ Main Class of the NerpyBot
 import os
 from asyncio import CancelledError, create_task, run, sleep
 from contextlib import contextmanager
-from warnings import filterwarnings
 from datetime import UTC, datetime
 from pathlib import Path
-from random import choices as random_choices, uniform as random_uniform
+from random import choices as random_choices
+from random import uniform as random_uniform
 from traceback import format_exc, print_exc, print_tb
 from typing import Annotated, Any, Generator, Optional
+from warnings import filterwarnings
 
 import typer
-
 import yaml
 from discord import (
     ClientException,
@@ -47,7 +47,6 @@ from utils.errors import NerpyException, NerpyInfraException, SilentCheckFailure
 from utils.helpers import error_context, notify_error, parse_id
 from utils.permissions import build_permissions_embed, check_guild_permissions, required_permissions_for
 from utils.strings import get_localized_string, get_string, load_strings
-
 
 ACTIVITIES = [
     "💡 Use / for commands",
@@ -508,7 +507,7 @@ def main(
     loggers = ["nerpybot"]
     if verbosity >= 2:
         loggers.append("discord")
-    if verbosity >= 3 or str(loglevel).upper() == "DEBUG":
+    if verbosity >= 3:
         loggers.append("sqlalchemy.engine")
 
     if "bot" in resolved_config:

--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -494,7 +494,9 @@ def main(
     debug: Annotated[bool, typer.Option("--debug", "-d", help="Enable debug logging")] = False,
     auto_restart: Annotated[bool, typer.Option("--auto-restart", "-r", help="Auto-restart on failure")] = False,
     loglevel: Annotated[str, typer.Option("--loglevel", "-l", help="Log level (DEBUG, INFO, WARNING, ERROR)")] = "INFO",
-    verbosity: Annotated[int, typer.Option("--verbosity", "-v", help="Verbosity level 0-3")] = 0,
+    verbosity: Annotated[
+        int, typer.Option("--verbosity", "-v", help="Verbosity: 1=DEBUG, 2=+discord, 3=+sqlalchemy")
+    ] = 0,
 ) -> None:
     """NerpyBot — the nerdiest Discord bot."""
     filterwarnings("ignore", category=DeprecationWarning, module=r"discord\.http")
@@ -504,13 +506,15 @@ def main(
 
     is_debug = debug or str(loglevel).upper() == "DEBUG" or verbosity > 0
     loggers = ["nerpybot"]
+    if verbosity >= 2:
+        loggers.append("discord")
     if verbosity >= 3 or str(loglevel).upper() == "DEBUG":
         loggers.append("sqlalchemy.engine")
 
     if "bot" in resolved_config:
-        resolved_loglevel = "DEBUG" if debug else loglevel
+        resolved_loglevel = "DEBUG" if (debug or verbosity > 0) else loglevel
         for logger_name in loggers:
-            logging.create_logger(verbosity, resolved_loglevel, logger_name)
+            logging.create_logger(resolved_loglevel, logger_name)
         bot = NerpyBot(resolved_config, intents, is_debug)
 
         try:

--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -457,7 +457,7 @@ def parse_env_config() -> dict:
     ]
     for var_name, keys, converter in mappings:
         value = os.environ.get(var_name)
-        if value is not None:
+        if value:
             _set_nested(env, keys, converter(value))
     return env
 

--- a/NerdyPy/config.yaml.template
+++ b/NerdyPy/config.yaml.template
@@ -1,3 +1,13 @@
+# All keys in this file can also be set via NERPYBOT_* environment variables.
+# Environment variables take priority over this file when both are present.
+# See docker-compose.yml for the full variable reference.
+#
+# Examples:
+#   NERPYBOT_TOKEN=your_token
+#   NERPYBOT_MODULES=wow,league,tagging
+#   NERPYBOT_DB_TYPE=sqlite
+#   NERPYBOT_DB_NAME=/data/db.db
+
 bot:
   client_id: "your_client_id_here"  # quoted to prevent formatter corruption
   token: your_bot_token_here

--- a/NerdyPy/utils/logging.py
+++ b/NerdyPy/utils/logging.py
@@ -14,24 +14,15 @@ class LessThanFilter(logging.Filter):
         return 1 if record.levelno < self.max_level else 0
 
 
-def create_logger(verbosity: int = 0, level: str = "WARNING", name: str = None):
+def create_logger(level: str = "WARNING", name: str = None):
     """
     Set logging level at runtime
 
-    :param verbosity: int
     :param level: str
     :param name: str
 
     :return: logging.Logger
     """
-    switcher = {
-        1: "WARNING",
-        2: "INFO",
-        3: "DEBUG",
-    }
-    if verbosity > 0:
-        level = switcher.get(verbosity)
-
     fmt = logging.Formatter(
         "%(asctime)s - %(levelname)s - %(module)s %(lineno)d: %(message)s",
         datefmt="[%d/%m/%Y %H:%M]",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,8 +8,3 @@ services:
     build:
       context: .
       target: bot
-
-  humanmusic:
-    build:
-      context: .
-      target: bot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,18 @@ services:
   nerpybot-migrations:
     image: ghcr.io/nerdycraft/nerpybot-database-migrations:latest
     restart: "no"
+    environment:
+      NERPYBOT_DB_TYPE: sqlite
+      NERPYBOT_DB_NAME: /data/db.db
+      # ── PostgreSQL alternative ──
+      # NERPYBOT_DB_TYPE: postgresql
+      # NERPYBOT_DB_NAME: nerpybot
+      # NERPYBOT_DB_USERNAME: nerpybot
+      # NERPYBOT_DB_PASSWORD: changeme
+      # NERPYBOT_DB_HOST: postgres
+      # NERPYBOT_DB_PORT: "5432"
     volumes:
       - nerpybot-data:/data
-      - ./config/nerpybot.yaml:/app/config.yaml:ro
     # depends_on:
     #   postgres:
     #     condition: service_healthy
@@ -17,16 +26,35 @@ services:
         condition: service_completed_successfully
       # postgres:
       #   condition: service_healthy
+    environment:
+      # ── Required ──
+      NERPYBOT_TOKEN: "your_bot_token_here"
+      NERPYBOT_CLIENT_ID: "your_client_id_here"
+      NERPYBOT_OPS: "your_discord_id_here"
+      NERPYBOT_MODULES: "application,league,leavemsg,moderation,reactionrole,rolemanage,reminder,tagging,wow"
+      # ── Database (SQLite default) ──
+      NERPYBOT_DB_TYPE: sqlite
+      NERPYBOT_DB_NAME: /data/db.db
+      # ── Database (PostgreSQL alternative) ──
+      # NERPYBOT_DB_TYPE: postgresql
+      # NERPYBOT_DB_NAME: nerpybot
+      # NERPYBOT_DB_USERNAME: nerpybot
+      # NERPYBOT_DB_PASSWORD: changeme
+      # NERPYBOT_DB_HOST: postgres
+      # NERPYBOT_DB_PORT: "5432"
+      # ── Music (requires tagging in NERPYBOT_MODULES) ──
+      # NERPYBOT_YOUTUBE_KEY: "your_youtube_key_here"
+      # ── League of Legends ──
+      # NERPYBOT_RIOT_KEY: "your_riot_api_key_here"
+      # ── World of Warcraft ──
+      # NERPYBOT_WOW_CLIENT_ID: "your_wow_client_id_here"
+      # NERPYBOT_WOW_CLIENT_SECRET: "your_wow_client_secret_here"
+      # ── Error notifications (comma-separated Discord user IDs) ──
+      # NERPYBOT_ERROR_RECIPIENTS: "your_discord_id_here"
+      # ── Audio tuning ──
+      # NERPYBOT_AUDIO_BUFFER_LIMIT: "5"
     volumes:
       - nerpybot-data:/data
-      - ./config/nerpybot.yaml:/app/config.yaml:ro
-
-  humanmusic:
-    image: ghcr.io/nerdycraft/nerpybot:latest
-    restart: unless-stopped
-    volumes:
-      - humanmusic-data:/data
-      - ./config/humanmusic.yaml:/app/config.yaml:ro
 
   # ── Uncomment to use PostgreSQL instead of SQLite ──
   # postgres:
@@ -46,5 +74,4 @@ services:
 
 volumes:
   nerpybot-data:
-  humanmusic-data:
   # postgres-data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ bot = [
     "requests-cache",
     "cachetools",
     "yt-dlp",
+    "typer",
 ]
 test = [
     "pytest",

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -153,6 +153,11 @@ class TestParseEnvConfig:
         result = parse_env_config()
         assert result["notifications"]["error_recipients"] == ["111", "222"]
 
+    def test_empty_string_int_var_is_skipped(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_AUDIO_BUFFER_LIMIT", "")
+        result = parse_env_config()
+        assert "audio" not in result
+
     def test_only_set_vars_appear_in_result(self, monkeypatch):
         monkeypatch.setenv("NERPYBOT_TOKEN", "tok")
         monkeypatch.delenv("NERPYBOT_CLIENT_ID", raising=False)

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+"""Tests for parse_env_config(), deep_merge(), and parse_config() in bot.py."""
+
+from NerdyPy.bot import parse_env_config, deep_merge, parse_config
+
+
+class TestDeepMerge:
+    def test_simple_override(self):
+        base = {"a": 1, "b": 2}
+        override = {"b": 3, "c": 4}
+        assert deep_merge(base, override) == {"a": 1, "b": 3, "c": 4}
+
+    def test_nested_merge(self):
+        base = {"wow": {"wow_id": "old_id", "guild_news": {"track_mounts": True}}}
+        override = {"wow": {"guild_news": {"track_mounts": False}}}
+        result = deep_merge(base, override)
+        assert result == {"wow": {"wow_id": "old_id", "guild_news": {"track_mounts": False}}}
+
+    def test_base_is_not_mutated(self):
+        base = {"a": {"b": 1}}
+        override = {"a": {"c": 2}}
+        deep_merge(base, override)
+        assert base == {"a": {"b": 1}}
+
+    def test_override_replaces_non_dict_with_dict(self):
+        base = {"key": "string"}
+        override = {"key": {"nested": True}}
+        assert deep_merge(base, override) == {"key": {"nested": True}}
+
+    def test_empty_override(self):
+        base = {"a": 1}
+        assert deep_merge(base, {}) == {"a": 1}
+
+    def test_empty_base(self):
+        override = {"a": 1}
+        assert deep_merge({}, override) == {"a": 1}
+
+
+class TestParseEnvConfig:
+    def test_empty_when_no_vars_set(self, monkeypatch):
+        for key in [
+            "NERPYBOT_TOKEN",
+            "NERPYBOT_CLIENT_ID",
+            "NERPYBOT_OPS",
+            "NERPYBOT_MODULES",
+            "NERPYBOT_DB_TYPE",
+            "NERPYBOT_DB_NAME",
+            "NERPYBOT_DB_USERNAME",
+            "NERPYBOT_DB_PASSWORD",
+            "NERPYBOT_DB_HOST",
+            "NERPYBOT_DB_PORT",
+            "NERPYBOT_AUDIO_BUFFER_LIMIT",
+            "NERPYBOT_YOUTUBE_KEY",
+            "NERPYBOT_RIOT_KEY",
+            "NERPYBOT_WOW_CLIENT_ID",
+            "NERPYBOT_WOW_CLIENT_SECRET",
+            "NERPYBOT_WOW_POLL_INTERVAL_MINUTES",
+            "NERPYBOT_WOW_MOUNT_BATCH_SIZE",
+            "NERPYBOT_WOW_TRACK_MOUNTS",
+            "NERPYBOT_WOW_ACTIVE_DAYS",
+            "NERPYBOT_ERROR_RECIPIENTS",
+        ]:
+            monkeypatch.delenv(key, raising=False)
+        assert parse_env_config() == {}
+
+    def test_token(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_TOKEN", "my_token")
+        result = parse_env_config()
+        assert result["bot"]["token"] == "my_token"
+
+    def test_client_id(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_CLIENT_ID", "111222333")
+        result = parse_env_config()
+        assert result["bot"]["client_id"] == "111222333"
+
+    def test_ops_comma_separated(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_OPS", "111, 222, 333")
+        result = parse_env_config()
+        assert result["bot"]["ops"] == ["111", "222", "333"]
+
+    def test_modules_comma_separated(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_MODULES", "wow,league,music")
+        result = parse_env_config()
+        assert result["bot"]["modules"] == ["wow", "league", "music"]
+
+    def test_db_type(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_DB_TYPE", "sqlite")
+        result = parse_env_config()
+        assert result["database"]["db_type"] == "sqlite"
+
+    def test_db_name(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_DB_NAME", "/data/db.db")
+        result = parse_env_config()
+        assert result["database"]["db_name"] == "/data/db.db"
+
+    def test_db_credentials(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_DB_USERNAME", "admin")
+        monkeypatch.setenv("NERPYBOT_DB_PASSWORD", "s3cr3t")
+        monkeypatch.setenv("NERPYBOT_DB_HOST", "db.host")
+        monkeypatch.setenv("NERPYBOT_DB_PORT", "5432")
+        result = parse_env_config()
+        assert result["database"]["db_username"] == "admin"
+        assert result["database"]["db_password"] == "s3cr3t"
+        assert result["database"]["db_host"] == "db.host"
+        assert result["database"]["db_port"] == "5432"
+
+    def test_audio_buffer_limit_as_int(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_AUDIO_BUFFER_LIMIT", "10")
+        result = parse_env_config()
+        assert result["audio"]["buffer_limit"] == 10
+
+    def test_youtube_key(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_YOUTUBE_KEY", "yt_key_abc")
+        result = parse_env_config()
+        assert result["music"]["ytkey"] == "yt_key_abc"
+
+    def test_riot_key(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_RIOT_KEY", "riot_key_abc")
+        result = parse_env_config()
+        assert result["league"]["riot"] == "riot_key_abc"
+
+    def test_wow_credentials(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_WOW_CLIENT_ID", "wow_id")
+        monkeypatch.setenv("NERPYBOT_WOW_CLIENT_SECRET", "wow_secret")
+        result = parse_env_config()
+        assert result["wow"]["wow_id"] == "wow_id"
+        assert result["wow"]["wow_secret"] == "wow_secret"
+
+    def test_wow_guild_news_nested(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_WOW_POLL_INTERVAL_MINUTES", "30")
+        monkeypatch.setenv("NERPYBOT_WOW_MOUNT_BATCH_SIZE", "50")
+        monkeypatch.setenv("NERPYBOT_WOW_ACTIVE_DAYS", "14")
+        result = parse_env_config()
+        gn = result["wow"]["guild_news"]
+        assert gn["poll_interval_minutes"] == 30
+        assert gn["mount_batch_size"] == 50
+        assert gn["active_days"] == 14
+
+    def test_wow_track_mounts_true(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_WOW_TRACK_MOUNTS", "true")
+        assert parse_env_config()["wow"]["guild_news"]["track_mounts"] is True
+
+    def test_wow_track_mounts_false(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_WOW_TRACK_MOUNTS", "false")
+        assert parse_env_config()["wow"]["guild_news"]["track_mounts"] is False
+
+    def test_wow_track_mounts_yes(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_WOW_TRACK_MOUNTS", "yes")
+        assert parse_env_config()["wow"]["guild_news"]["track_mounts"] is True
+
+    def test_error_recipients_comma_separated(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_ERROR_RECIPIENTS", "111,222")
+        result = parse_env_config()
+        assert result["notifications"]["error_recipients"] == ["111", "222"]
+
+    def test_only_set_vars_appear_in_result(self, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_TOKEN", "tok")
+        monkeypatch.delenv("NERPYBOT_CLIENT_ID", raising=False)
+        result = parse_env_config()
+        assert "token" in result["bot"]
+        assert "client_id" not in result["bot"]
+
+
+class TestParseConfig:
+    def test_env_overrides_yaml(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("bot:\n  token: yaml_token\n  client_id: '123'\n")
+        monkeypatch.setenv("NERPYBOT_TOKEN", "env_token")
+        result = parse_config(config_file)
+        assert result["bot"]["token"] == "env_token"
+        assert result["bot"]["client_id"] == "123"
+
+    def test_yaml_preserved_when_no_env(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("bot:\n  token: yaml_token\n")
+        monkeypatch.delenv("NERPYBOT_TOKEN", raising=False)
+        result = parse_config(config_file)
+        assert result["bot"]["token"] == "yaml_token"
+
+    def test_missing_yaml_returns_env_only(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NERPYBOT_TOKEN", "env_only_token")
+        result = parse_config(tmp_path / "nonexistent.yaml")
+        assert result["bot"]["token"] == "env_only_token"
+
+    def test_no_yaml_no_env_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NERPYBOT_TOKEN", raising=False)
+        result = parse_config(tmp_path / "nonexistent.yaml")
+        assert result == {}

--- a/uv.lock
+++ b/uv.lock
@@ -106,6 +106,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -306,6 +315,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -765,6 +786,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -814,6 +847,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -918,6 +960,7 @@ bot = [
     { name = "pyyaml" },
     { name = "requests-cache" },
     { name = "sqlalchemy" },
+    { name = "typer" },
     { name = "yt-dlp" },
 ]
 migrations = [
@@ -952,6 +995,7 @@ bot = [
     { name = "pyyaml" },
     { name = "requests-cache" },
     { name = "sqlalchemy" },
+    { name = "typer" },
     { name = "yt-dlp" },
 ]
 migrations = [
@@ -1385,6 +1429,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
 name = "rsa"
 version = "4.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1419,6 +1476,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
     { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
     { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -1458,6 +1524,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/db/cafdeca5ecdaa3bb0811ba5449501da677ce0d83be8d05c5822da72d2e86/sqlalchemy-2.0.47-cp314-cp314t-win32.whl", hash = "sha256:c200db1128d72a71dc3c31c24b42eb9fd85b2b3e5a3c9ba1e751c11ac31250ff", size = 2147164, upload-time = "2026-02-24T17:14:40.783Z" },
     { url = "https://files.pythonhosted.org/packages/fc/5e/ff41a010e9e0f76418b02ad352060a4341bb15f0af66cedc924ab376c7c6/sqlalchemy-2.0.47-cp314-cp314t-win_amd64.whl", hash = "sha256:669837759b84e575407355dcff912835892058aea9b80bd1cb76d6a151cf37f7", size = 2182154, upload-time = "2026-02-24T17:14:43.205Z" },
     { url = "https://files.pythonhosted.org/packages/15/9f/7c378406b592fcf1fc157248607b495a40e3202ba4a6f1372a2ba6447717/sqlalchemy-2.0.47-py3-none-any.whl", hash = "sha256:e2647043599297a1ef10e720cf310846b7f31b6c841fee093d2b09d81215eb93", size = 1940159, upload-time = "2026-02-24T17:15:07.158Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Env var config** — All config keys can now be set via `NERPYBOT_*` environment variables (e.g. `NERPYBOT_TOKEN`, `NERPYBOT_MODULES`, `NERPYBOT_DB_TYPE`). Env vars are layered on top of `config.yaml` — env vars win. Lists (modules, ops, error\_recipients) use comma-separated values.
- **Typer CLI** — Replaces `argparse` in `bot.py` with `typer`. Same flags: `--config/-c`, `--debug/-d`, `--auto-restart/-r`, `--loglevel/-l`, `--verbosity/-v` (replaces count with int).
- **Docker compose** — `docker-compose.yml` is now a single env-var-driven example stack (migrations + bot). `humanmusic` service removed. No more YAML file mounts.
- **Migrations** — `database-migrations/env.py` gains `NERPYBOT_DB_*` as a resolution step between `DATABASE_URL` and `config.yaml`, so both containers share the same env vars.

## Test Plan

- [x] 973 tests passing (`uv run python -m pytest`)
- [x] `uv run python NerdyPy/bot.py --help` shows all flags
- [x] `NERPYBOT_TOKEN=x NERPYBOT_DB_TYPE=sqlite uv run python NerdyPy/bot.py` resolves config from env (no config.yaml needed)
- [x] Blank env vars (e.g. `NERPYBOT_AUDIO_BUFFER_LIMIT=""`) are safely skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)