### PR TITLE
feat: derive version from git tags via hatch-vcs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,7 @@ NerdyPy/weather_cache.sqlite
 docs/
 tests/
 *.md
+!README.md
 .pre-commit-config.yaml
 .ruff.toml
 .pytest_cache/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,6 +68,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Extract version from git
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            RAW=$(git describe --tags --always | sed 's/^v//')
+            if [[ "$RAW" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-g([a-f0-9]+)$ ]]; then
+              VERSION="${BASH_REMATCH[1]}.dev${BASH_REMATCH[2]}+g${BASH_REMATCH[3]}"
+            else
+              VERSION="$RAW"
+            fi
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Detected version: ${VERSION}"
+
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -103,15 +119,25 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Verify pushed image
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
           IMAGE="${REGISTRY}/${IMAGE_NAME,,}:${GITHUB_SHA::7}"
           docker pull "${IMAGE}"
-          docker run --rm "${IMAGE}" python -c "from bot import NerpyBot; print('OK')"
-          echo "✅ NerpyBot image verified"
+          ACTUAL=$(docker run --rm "${IMAGE}" python -c "from importlib.metadata import version; print(version('NerpyBot'))")
+          echo "Expected: ${EXPECTED_VERSION}"
+          echo "Actual:   ${ACTUAL}"
+          if [[ "${ACTUAL}" != "${EXPECTED_VERSION}" ]]; then
+            echo "::error::Version mismatch in pushed image!"
+            exit 1
+          fi
+          echo "✅ NerpyBot image verified (v${ACTUAL})"
 
   build-migrations:
     name: Build & Push Migrations Image

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ### Custom
+_version.py
 NerdyPy/audio
 NerdyPy/*.db
 NerdyPy/*.dll

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ uv run python NerdyPy/bot.py --verbosity 1      # DEBUG (bot only)
 uv run python NerdyPy/bot.py --verbosity 2      # DEBUG + discord.py verbose
 uv run python NerdyPy/bot.py --verbosity 3      # DEBUG + discord.py + sqlalchemy
 uv run python NerdyPy/bot.py -c path             # Custom config file
-uv run python NerdyPy/bot.py -r                  # Auto-restart on failure
+uv run python NerdyPy/bot.py -V                  # Show version and exit
 
 # Git hooks (run once after cloning)
 uv sync --group test                 # Installs pre-commit
@@ -48,7 +48,7 @@ uv run alembic revision --autogenerate -m "description"  # Create migration
 # When adding columns to existing tables, use server_default (not just ORM default) so existing rows get a value.
 
 # Docker builds (two targets)
-docker buildx build --target bot -t nerpybot .
+docker buildx build --target bot --build-arg VERSION=0.6.0 -t nerpybot .
 docker buildx build --target migrations -t nerpybot-migrations .
 
 # Validate GitHub Actions workflows
@@ -137,7 +137,8 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - **Alembic migrations must be dialect-aware** — SQLite uses `datetime()`, PostgreSQL uses `make_interval()`. Use `op.get_bind().dialect.name` to branch. Always use `batch_alter_table` for SQLite column operations. Note: `op.alter_column()` **without** a `batch_alter_table` context crashes on SQLite — and type-only encoding migrations (e.g. `Text` → `UnicodeText`) can skip SQLite entirely since it stores all text as Unicode internally.
 - **All Alembic migrations must guard column/index existence, not just table existence** — `create_all()` on a fresh install already builds the latest schema; a subsequent `alembic upgrade head` must be a no-op. Before `add_column`, check `{c["name"] for c in inspect(conn).get_columns(table)}`; before `create_index`, check `{i["name"] for i in inspect(conn).get_indexes(table)}`. The return-early guard must cover both the "table absent" and "schema already current" cases.
 - **`interaction.response.is_done()` returns `False` after a failed `send_message()`** — If `send_message()` raises (e.g. 10062 Unknown interaction), `is_done()` is still `False`. In `_on_app_command_error`, wrap the user-facing response in `try/except` _before_ `notify_error`, or `notify_error` will never be reached.
-- **`pyproject.toml` requires `packages = []`** — Without `[tool.setuptools] packages = []`, setuptools auto-discovers `config/` and `NerdyPy/` as a flat-layout conflict, breaking all `uv` commands.
+- **Version is derived from git tags** — `hatch-vcs` reads the version from git tags (e.g. `v0.6.0` → `0.6.0`). No static version in `pyproject.toml`. In Docker, `SETUPTOOLS_SCM_PRETEND_VERSION` build arg supplies the version since there's no `.git` dir. `hatch.build.targets.wheel.packages = []` prevents hatchling from trying to include `config/` or `NerdyPy/` as installable packages.
+- **`uv sync --only-group` skips the project package** — Only `--group` (without `only-`) installs the project metadata alongside dependencies. The bot Docker image needs `--group bot` so `importlib.metadata.version("NerpyBot")` works at runtime.
 - **`cog_load` runs before `create_all()`** — `setup_hook` calls `load_extension()` (triggering `cog_load`) before `create_all()`. If a cog accesses new tables in `cog_load`, call `self.bot.create_all()` at the top of `cog_load` to ensure tables exist on existing databases.
 - **SQLite enforces unique constraints row-by-row, not deferred** — Swapping two values under a unique column in a single flush raises `IntegrityError`. Use a two-phase update: write temporary/offset values and flush, then write final values and flush.
 - **Module-specific permission helpers stay with the module** — Only move a permission check to `utils/checks.py` if it is purely based on Discord roles/permissions. If it queries a module-specific table (e.g. `ApplicationGuildConfig`), keep it in the module's own file.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,21 +5,25 @@ FROM ghcr.io/astral-sh/uv:latest AS uv
 
 # ── Builder base: shared build tools and lockfile ──
 FROM python:3.14-alpine AS builder-base
-ENV UV_LINK_MODE=copy
+
+# Version from git tag (passed via --build-arg in CI, defaults to dev)
+ARG VERSION=0.0.0.dev0
+ENV UV_LINK_MODE=copy \
+    SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
 WORKDIR /app
 COPY --from=uv /uv /usr/local/bin/uv
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock README.md ./
 
 RUN apk add --no-cache git libffi-dev \
     gcc g++ musl-dev python3-dev pkgconf \
     freetype-dev libpng-dev
 
-# ── Builder: bot dependencies only ──
+# ── Builder: bot dependencies + project metadata ──
 FROM builder-base AS builder-bot
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-managed-python --only-group bot
+    uv sync --frozen --no-managed-python --group bot
 
 # ── Builder: migration dependencies only ──
 FROM builder-base AS builder-migrations

--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -15,6 +15,7 @@ from typing import Annotated, Any, Generator, Optional
 from warnings import filterwarnings
 
 import typer
+from importlib.metadata import version as pkg_version
 import yaml
 from discord import (
     ClientException,
@@ -484,6 +485,12 @@ def parse_config(config_path: Optional[Path] = None) -> dict:
     return deep_merge(config, parse_env_config())
 
 
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"NerpyBot v{pkg_version('NerpyBot')}")
+        raise typer.Exit()
+
+
 app = typer.Typer(add_completion=False)
 
 
@@ -495,8 +502,12 @@ def main(
     verbosity: Annotated[
         int, typer.Option("--verbosity", "-v", help="Verbosity: 1=DEBUG, 2=+discord, 3=+sqlalchemy")
     ] = 0,
+    version: Annotated[
+        bool, typer.Option("--version", "-V", callback=_version_callback, is_eager=True, help="Show version and exit")
+    ] = False,
 ) -> None:
     """NerpyBot — the nerdiest Discord bot."""
+    print(BANNER)
     filterwarnings("ignore", category=DeprecationWarning, module=r"discord\.http")
 
     resolved_config = parse_config(config)
@@ -534,9 +545,7 @@ def main(
         raise NerpyInfraException("Bot config not found.")
 
 
-if __name__ == "__main__":
-    print(
-        """
+BANNER = """
 '##::: ##:'########:'########::'########::'##:::'##::::'########:::'#######::'########:
  ###:: ##: ##.....:: ##.... ##: ##.... ##:. ##:'##::::: ##.... ##:'##.... ##:... ##..::
  ####: ##: ##::::::: ##:::: ##: ##:::: ##::. ####:::::: ##:::: ##: ##:::: ##:::: ##::::
@@ -546,5 +555,6 @@ if __name__ == "__main__":
  ##::. ##: ########: ##:::. ##: ##::::::::::: ##::::::: ########::. #######::::: ##::::
 ..::::..::........::..:::::..::..::::::::::::..::::::::........::::.......::::::..:::::
 """
-    )
+
+if __name__ == "__main__":
     app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "NerpyBot"
 description = "The nerdiest Bot on Discord!"
-version = "0.5.0"
+dynamic = ["version"]
 authors = [
     { name = "Rico Wesenberg", email = "r.wesenberg@gmail.com" },
     { name = "Dennis Bernardy", email = "bernardyd@gmail.com" }
@@ -47,7 +47,13 @@ migrations = [
     "pyyaml",
 ]
 
-[tool.setuptools]
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "_version.py"
+
+[tool.hatch.build.targets.wheel]
 packages = []
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -960,7 +960,6 @@ wheels = [
 
 [[package]]
 name = "nerpybot"
-version = "0.5.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Replace static `version = "0.5.0"` in pyproject.toml with dynamic versioning via **hatch-vcs** (setuptools-scm under the hood)
- Git tags are now the single source of truth for the version — no more manual bumps
- Add `--version` / `-V` CLI flag so users and operators can check the running version
- Docker images get the correct version via `SETUPTOOLS_SCM_PRETEND_VERSION` build arg
- CI workflow extracts version from git tag (for releases) or `git describe` (for branch builds) and verifies it in the built image

## Changes

| File | What changed |
|------|-------------|
| `pyproject.toml` | setuptools → hatchling + hatch-vcs, `dynamic = ["version"]` |
| `Dockerfile` | `VERSION` build arg, `SETUPTOOLS_SCM_PRETEND_VERSION` env, `--group bot` instead of `--only-group bot` |
| `.dockerignore` | Allowlist `README.md` (hatchling validates it exists) |
| `.gitignore` | Ignore generated `_version.py` |
| `docker.yml` | Version extraction step, build arg passing, version verification |
| `bot.py` | `--version` / `-V` flag, banner moved into `main()` |
| `CLAUDE.md` | Updated gotcha for new versioning approach |

## Verified locally

- `uv run python bot.py --version` → `NerpyBot v0.5.1.dev...`
- `docker run --rm nerpybot:test python bot.py --version` → `NerpyBot v0.6.0` (with `--build-arg VERSION=0.6.0`)
- `docker run --rm nerpybot:test python -c "from bot import NerpyBot; print('OK')"` → OK
- `docker run --rm nerpybot-migrations:test alembic heads` → OK
- 808 tests pass, ruff clean, actionlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)