### PR TITLE
feat(ci): add comment-triggered PR Docker image builds

### DIFF
--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -1,0 +1,207 @@
+name: Build PR Docker Images (on command)
+
+# Triggered by maintainer comment "/build-pr" on a pull request
+# This provides a security gate - code is reviewed before images are published
+
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  check-trigger:
+    name: Validate Trigger
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: write
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/build-pr'
+    outputs:
+      pr_number: ${{ steps.pr.outputs.number }}
+      pr_head_sha: ${{ steps.pr.outputs.head_sha }}
+      authorized: ${{ steps.auth.outputs.authorized }}
+
+    steps:
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('number', pr.data.number);
+            core.setOutput('head_sha', pr.data.head.sha);
+            console.log(`PR #${pr.data.number} - SHA: ${pr.data.head.sha}`);
+
+      - name: Check commenter permissions
+        id: auth
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor
+            });
+            const level = permission.permission;
+            const authorized = ['admin', 'maintain', 'write'].includes(level);
+            console.log(`User ${context.actor} has permission: ${level} - Authorized: ${authorized}`);
+            core.setOutput('authorized', authorized);
+            if (!authorized) {
+              core.setFailed(`User ${context.actor} does not have write access to trigger PR builds`);
+            }
+
+      - name: Add reaction to comment
+        continue-on-error: true
+        if: steps.auth.outputs.authorized == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+  build:
+    name: Build & Push PR Images
+    runs-on: ubuntu-latest
+    needs: check-trigger
+    if: needs.check-trigger.outputs.authorized == 'true'
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.check-trigger.outputs.pr_head_sha }}
+          fetch-depth: 0
+
+      - name: Extract version from git
+        id: version
+        run: |
+          RAW=$(git describe --tags --always | sed 's/^v//')
+          if [[ "$RAW" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-g([a-f0-9]+)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}.dev${BASH_REMATCH[2]}+g${BASH_REMATCH[3]}"
+          else
+            VERSION="$RAW"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Detected version: ${VERSION}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push NerpyBot image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: bot
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ needs.check-trigger.outputs.pr_number }}
+          labels: |
+            org.opencontainers.image.title=NerpyBot
+            org.opencontainers.image.description=PR build for testing
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ needs.check-trigger.outputs.pr_head_sha }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify NerpyBot image
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAME,,}:pr-${{ needs.check-trigger.outputs.pr_number }}"
+          docker pull "${IMAGE}"
+          ACTUAL=$(docker run --rm "${IMAGE}" python bot.py -V | sed 's/NerpyBot v//')
+          echo "Expected: ${EXPECTED_VERSION}"
+          echo "Actual:   ${ACTUAL}"
+          if [[ "${ACTUAL}" != "${EXPECTED_VERSION}" ]]; then
+            echo "::error::Version mismatch in pushed NerpyBot image!"
+            exit 1
+          fi
+          echo "NerpyBot image verified (v${ACTUAL})"
+
+      - name: Build and push Migrations image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: migrations
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-database-migrations:pr-${{ needs.check-trigger.outputs.pr_number }}
+          labels: |
+            org.opencontainers.image.title=NerpyBot Database Migrations
+            org.opencontainers.image.description=PR build for testing
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ needs.check-trigger.outputs.pr_head_sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify Migrations image
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAME,,}-database-migrations:pr-${{ needs.check-trigger.outputs.pr_number }}"
+          docker pull "${IMAGE}"
+          docker run --rm "${IMAGE}" alembic heads
+          echo "Migrations image verified"
+
+      - name: Comment on PR with image info
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = ${{ needs.check-trigger.outputs.pr_number }};
+            const sha = '${{ needs.check-trigger.outputs.pr_head_sha }}'.substring(0, 7);
+            const bot = `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${pr}`;
+            const migrations = `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-database-migrations:pr-${pr}`;
+            const body = [
+              `## PR Docker Images Built`,
+              ``,
+              `| Image | Tag |`,
+              `|-------|-----|`,
+              `| Bot | \`${bot}\` |`,
+              `| Migrations | \`${migrations}\` |`,
+              ``,
+              `**Commit:** \`${sha}\``,
+              `**Platforms:** \`linux/amd64\`, \`linux/arm64\``,
+              ``,
+              `\`\`\`bash`,
+              `docker pull ${bot}`,
+              `docker pull ${migrations}`,
+              `\`\`\``,
+              ``,
+              `> This is a PR build for testing purposes. Do not use in production.`
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body: body
+            });

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -130,14 +130,14 @@ jobs:
         run: |
           IMAGE="${REGISTRY}/${IMAGE_NAME,,}:${GITHUB_SHA::7}"
           docker pull "${IMAGE}"
-          ACTUAL=$(docker run --rm "${IMAGE}" python -c "from importlib.metadata import version; print(version('NerpyBot'))")
+          ACTUAL=$(docker run --rm "${IMAGE}" python bot.py -V | sed 's/NerpyBot v//')
           echo "Expected: ${EXPECTED_VERSION}"
           echo "Actual:   ${ACTUAL}"
           if [[ "${ACTUAL}" != "${EXPECTED_VERSION}" ]]; then
             echo "::error::Version mismatch in pushed image!"
             exit 1
           fi
-          echo "✅ NerpyBot image verified (v${ACTUAL})"
+          echo "NerpyBot image verified (v${ACTUAL})"
 
   build-migrations:
     name: Build & Push Migrations Image


### PR DESCRIPTION
## Summary

- Add `docker-pr-build.yml` workflow triggered by `/build-pr` comment on PRs
- Builds and pushes both `bot` and `migrations` images to GHCR as `pr-<number>` tags
- Permission-gated: only users with write+ access can trigger builds
- Update `docker.yml` to use `python bot.py -V` for version verification (consistency)

## Security

The `issue_comment` trigger + collaborator permission check prevents abuse:
- External contributors cannot trigger image builds
- Maintainers must explicitly opt-in after reviewing the code
- No user-controlled strings are interpolated into shell commands

## How to use

Comment `/build-pr` on any PR. The workflow will:
1. Validate commenter permissions
2. Build both images (multi-arch: amd64 + arm64)
3. Push to GHCR with `pr-<number>` tags
4. Post a comment with pull commands

## Test plan

- [ ] Open a test PR and comment `/build-pr`
- [ ] Verify rocket reaction appears on the comment
- [ ] Verify both images are pushed to GHCR
- [ ] Verify PR comment with image details is posted
- [ ] Verify unauthorized user cannot trigger the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)