### PR TITLE
fix(ci): run required checks for release badge PRs

### DIFF
--- a/.github/workflows/release-badge.yml
+++ b/.github/workflows/release-badge.yml
@@ -12,6 +12,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      pr-number: ${{ steps.create-pr.outputs.pull-request-number }}
+      pr-sha: ${{ steps.create-pr.outputs.pull-request-head-sha }}
+      pr-branch: docs/update-badge-${{ env.VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -27,6 +31,7 @@ jobs:
           sed -i "s/badge\/Version-.*-green/badge\/Version-${{ env.VERSION }}-green/" README.md
 
       - name: Create Pull Request
+        id: create-pr
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "docs: Update release badge to version ${{ env.VERSION }}"
@@ -38,3 +43,61 @@ jobs:
           branch: docs/update-badge-${{ env.VERSION }}
           delete-branch: true
           labels: documentation,automated
+
+  # PRs created by GITHUB_TOKEN don't trigger pull_request workflows, so the
+  # required status checks (lint, tests) never run. We execute them here and
+  # report check-runs against the PR's head SHA via the Checks API.
+  pr-checks:
+    name: PR Status Checks
+    needs: update-badge
+    if: needs.update-badge.outputs.pr-number
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.update-badge.outputs.pr-branch }}
+          fetch-depth: 0
+
+      - name: Run Ruff linter
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "check --output-format=github"
+
+      - name: Run Ruff formatter check
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check --diff"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --group test
+
+      - name: Run tests
+        run: uv run pytest --cov=NerdyPy --cov-report=xml
+
+      - name: Report check runs on PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = '${{ needs.update-badge.outputs.pr-sha }}';
+            const conclusion = '${{ job.status }}' === 'success' ? 'success' : 'failure';
+            for (const name of ['Ruff Lint & Format Check', 'Run Tests']) {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name,
+                head_sha: sha,
+                status: 'completed',
+                conclusion,
+              });
+            }


### PR DESCRIPTION
## Summary

- PRs created by `GITHUB_TOKEN` (like the release badge PR) don't trigger `pull_request` workflows, so required status checks never run — leaving the PR permanently blocked
- Adds a `pr-checks` job to `release-badge.yml` that runs lint and tests on the PR branch, then reports check results via the GitHub Checks API with the exact names the ruleset expects

## Context

PR #280 has been stuck since v0.6.0 was tagged — this is the same fix we applied to pandaproxy.

## Test plan

- [ ] Merge this PR
- [ ] Push an empty commit to `docs/update-badge-0.6.0` to unblock PR #280
- [ ] Verify the required checks appear on PR #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)