### PR TITLE
chore: switch IDE run configs to env files and rename configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ NerdyPy/*.db
 NerdyPy/*.dll
 NerdyPy/tmp/
 NerdyPy/config.yaml
-NerdyPy/config_humanmusic.yaml
+NerdyPy/nerdybot.yaml
+NerdyPy/humanmusic.yaml
 NerdyPy/weather_cache.sqlite
 NerpyBot.code-workspace
 config/*.yaml
@@ -177,6 +178,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+*.env
 .env
 .venv
 env/

--- a/.run/HumanMusic.run.xml
+++ b/.run/HumanMusic.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="HumanMusic" type="PythonConfigurationType" factoryName="Python">
     <module name="NerpyBot" />
-    <option name="ENV_FILES" value="" />
+    <option name="ENV_FILES" value="$PROJECT_DIR$/humanmusic.env" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
@@ -24,7 +24,7 @@
     </EXTENSION>
     <option name="RUN_TOOL" value="true" />
     <option name="SCRIPT_NAME" value="bot.py" />
-    <option name="PARAMETERS" value="-d -c config_humanmusic.yaml" />
+    <option name="PARAMETERS" value="-d -c humanmusic.yaml" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/.run/NerdyBot.run.xml
+++ b/.run/NerdyBot.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="NerdyBot" type="PythonConfigurationType" factoryName="Python">
     <module name="NerpyBot" />
-    <option name="ENV_FILES" value="" />
+    <option name="ENV_FILES" value="$PROJECT_DIR$/nerdybot.env" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
@@ -14,7 +14,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <option name="RUN_TOOL" value="true" />
     <option name="SCRIPT_NAME" value="bot.py" />
-    <option name="PARAMETERS" value="-d" />
+    <option name="PARAMETERS" value="-d -c nerdybot.yaml" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />


### PR DESCRIPTION
## Summary

- Move secrets out of IntelliJ/PyCharm XML run configs into separate `.env` files (`nerdybot.env` / `humanmusic.env`), loaded via the EnvFile plugin
- Rename `config_humanmusic.yaml` → `humanmusic.yaml` for naming consistency
- Add `*.env` glob pattern to `.gitignore` so env files are never accidentally committed

## Test plan

- [ ] Open NerdyBot run config in PyCharm — env vars load from `nerdybot.env` without inline secrets in XML
- [ ] Verify `.env` files are gitignored (`git status` shows them as untracked/ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)