### PR TITLE
ci: add pre-commit ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- Adds `pre-commit` ecosystem to `.github/dependabot.yml` so Dependabot automatically opens PRs when pre-commit hook versions (ruff, prettier) are updated

## Test plan

- [ ] Verify Dependabot picks up the new ecosystem on the next weekly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)