### PR TITLE
fix: route alembic logs through bot logging infrastructure

### DIFF
--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -84,6 +84,7 @@ def run_migrations() -> None:
     both in the repo (alembic.ini at root) and in Docker. Raises on failure —
     callers must not catch it.
     """
+    log = logging.get_logger("nerpybot")
     for parent in Path(__file__).resolve().parents:
         candidate = parent / "alembic.ini"
         if candidate.exists():
@@ -91,8 +92,14 @@ def run_migrations() -> None:
             break
     else:
         raise FileNotFoundError("alembic.ini not found in any parent directory of bot.py")
-    alembic_cfg = Config(str(alembic_ini))
-    alembic_command.upgrade(alembic_cfg, "head")
+    log.info("Running database migrations...")
+    try:
+        alembic_cfg = Config(str(alembic_ini))
+        alembic_command.upgrade(alembic_cfg, "head")
+    except Exception as e:
+        log.error(f"Database migration failed: {e}")
+        raise
+    log.info("Database migrations complete.")
 
 
 class NerpyBot(Bot):
@@ -547,6 +554,11 @@ def main(
         loggers.append("sqlalchemy.engine")
 
     if "bot" in resolved_config:
+        # Configure alembic at INFO before run_migrations().
+        # The guard in database-migrations/env.py checks logging.getLogger("alembic").handlers
+        # to decide whether to skip fileConfig. Moving run_migrations() above this line
+        # will silently revert embedded runs to alembic.ini formatting.
+        logging.create_logger("INFO", "alembic")
         resolved_loglevel = "DEBUG" if (debug or verbosity > 0) else effective_loglevel
         for logger_name in loggers:
             logging.create_logger(resolved_loglevel, logger_name)

--- a/database-migrations/env.py
+++ b/database-migrations/env.py
@@ -1,5 +1,5 @@
+import logging as _logging
 import os
-from logging.config import fileConfig
 from pathlib import Path
 
 import yaml
@@ -12,10 +12,12 @@ from sqlalchemy import engine_from_config, pool
 # access to the values within the .ini file in use.
 config = context.config
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+# Only configure logging from alembic.ini when running standalone (no handlers yet).
+# When embedded in the bot, bot.py has already set up the alembic logger.
+if config.config_file_name is not None and not _logging.getLogger("alembic").handlers:
+    from logging.config import fileConfig
+
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 
 def _build_url_from_bot_config(bot_config: dict) -> str | None:

--- a/tests/test_bot_functions.py
+++ b/tests/test_bot_functions.py
@@ -587,3 +587,71 @@ class TestGlobalInteractionCheck:
                 await NerpyBot._global_interaction_check(mock_self, mock_interaction)
 
             mock_interaction.response.send_message.assert_called_once()
+
+
+class TestRunMigrations:
+    """Test run_migrations() logging and error handling."""
+
+    def test_run_migrations_logs_start_and_complete(self, tmp_path):
+        """run_migrations() should log start and complete messages on success."""
+        from NerdyPy.bot import run_migrations
+
+        (tmp_path / "alembic.ini").touch()
+
+        with (
+            patch("NerdyPy.bot.Path") as mock_path_cls,
+            patch("NerdyPy.bot.alembic_command.upgrade"),
+            patch("NerdyPy.bot.Config"),
+            patch("NerdyPy.bot.logging.get_logger") as mock_get_logger,
+        ):
+            mock_log = MagicMock()
+            mock_get_logger.return_value = mock_log
+
+            mock_resolve = MagicMock()
+            mock_resolve.parents = [tmp_path]
+            mock_path_cls.return_value.resolve.return_value = mock_resolve
+
+            run_migrations()
+
+        calls = [str(c[0][0]) for c in mock_log.info.call_args_list]
+        assert any("Running database migrations" in msg for msg in calls)
+        assert any("complete" in msg.lower() for msg in calls)
+
+    def test_run_migrations_logs_error_and_reraises(self, tmp_path):
+        """run_migrations() should log the error and re-raise on failure."""
+        from NerdyPy.bot import run_migrations
+
+        (tmp_path / "alembic.ini").touch()
+
+        with (
+            patch("NerdyPy.bot.Path") as mock_path_cls,
+            patch("NerdyPy.bot.alembic_command.upgrade", side_effect=RuntimeError("migration failed")),
+            patch("NerdyPy.bot.Config"),
+            patch("NerdyPy.bot.logging.get_logger") as mock_get_logger,
+        ):
+            mock_log = MagicMock()
+            mock_get_logger.return_value = mock_log
+
+            mock_resolve = MagicMock()
+            mock_resolve.parents = [tmp_path]
+            mock_path_cls.return_value.resolve.return_value = mock_resolve
+
+            with pytest.raises(RuntimeError, match="migration failed"):
+                run_migrations()
+
+        mock_log.error.assert_called_once()
+        error_msg = str(mock_log.error.call_args[0][0])
+        assert "migration failed" in error_msg
+
+    def test_run_migrations_raises_when_ini_not_found(self, tmp_path):
+        """run_migrations() should raise FileNotFoundError when alembic.ini is missing."""
+        from NerdyPy.bot import run_migrations
+
+        with patch("NerdyPy.bot.Path") as mock_path_cls:
+            mock_resolve = MagicMock()
+            # Empty parents list → for/else immediately hits the else branch
+            mock_resolve.parents = []
+            mock_path_cls.return_value.resolve.return_value = mock_resolve
+
+            with pytest.raises(FileNotFoundError, match="alembic.ini not found"):
+                run_migrations()


### PR DESCRIPTION
## Summary

- Guard `fileConfig` in `database-migrations/env.py` so it only fires in standalone CLI mode (when the `alembic` logger has no handlers yet). When embedded in the bot, the existing handler prevents `fileConfig` from reconfiguring logging and silencing the `nerpybot` logger.
- Configure the `alembic` logger at a fixed `INFO` level in `main()` before `run_migrations()` is called, routing Alembic output through the bot's logging infrastructure (same format and stream routing).
- Wrap `run_migrations()` with bookend `log.info` messages and structured error handling — logs the failure then re-raises so the bot exits cleanly on a broken schema.

## Test Plan

- [ ] 3 new tests in `TestRunMigrations` cover: start/complete logging on success, error logging + re-raise on failure, `FileNotFoundError` when `alembic.ini` is missing
- [ ] Full test suite passes: 907 tests, 0 failures
- [ ] Ruff lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration process with structured logging and enhanced error handling during application startup for better reliability and easier diagnostics.

* **Tests**
  * Added comprehensive test coverage validating migration success, failure scenarios, and missing configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->