### PR TITLE
docs: improve CLAUDE.md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: no-commit-to-branch
+        args: [--branch, main]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.5
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,9 @@ uv run alembic revision --autogenerate -m "description"  # Create a new migratio
 # Only create migrations when altering existing tables (add/remove columns, change constraints).
 # When adding columns to existing tables, use server_default (not just ORM default) so existing rows get a value.
 
+# Worktrees: always pass path explicitly — never cd && uv run
+uv run --directory .worktrees/<branch> python -m pytest
+
 # Docker builds
 docker buildx build --target bot --build-arg VERSION=0.6.0 -t nerpybot .
 
@@ -94,6 +97,10 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - `NerdyPy/utils/database.py` - Session management with context managers
 - `database-migrations/` - Alembic migrations
 - Supports SQLite (default) and PostgreSQL
+
+### Web Component
+
+`web/` contains a FastAPI application (`web/app.py`) with JWT auth (`web/auth/`), API routes (`web/routes/`), schemas (`web/schemas.py`), and a Vue frontend (`web/frontend/`). Configuration is separate from the bot — see `webapp.env`.
 
 ### Utilities
 
@@ -147,6 +154,9 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - **Adding a new language** — Create `NerdyPy/locales/lang_<code>.yaml`, restart the bot. No code changes needed. English keys are canonical — any missing key in other languages falls back to English automatically.
 - **Guild language is global** — `GuildLanguageConfig` is the single source of truth for a guild's language preference. Modules calling external APIs (Blizzard, Riot) should honor this setting when the API supports it, falling back to English otherwise.
 - **Full env var config** — All config keys can be set via `NERPYBOT_*` environment variables (see `docker-compose.yml` for the full list). Env vars take priority over `config.yaml` when both are present. Lists (`modules`, `ops`, `error_recipients`) use comma-separated values.
+
+#### Web Component (FastAPI / Vue)
+
 - **`session.commit()` before `background_tasks.add_task()`** — FastAPI background tasks run after the response is sent but before yield-dependency cleanup, so `session.commit()` in `_get_db_session` fires too late. Always call `session.commit()` explicitly before scheduling any background task that re-reads data written by the same request.
 - **`selectinload` for multiple one-to-many collections** — Two `joinedload` on different one-to-many relationships on the same parent produce a Cartesian product (rows × rows). Use `selectinload` for the second (and any further) collection — it fires a separate `IN` query instead.
 - **`Guild.get_channel()` is cache-only** — Returns `None` on cache miss (e.g. after reconnect). Fall back to `await guild.fetch_channel(channel_id)` and catch `(discord.NotFound, discord.Forbidden)` before treating a channel as missing or deleting related DB rows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,12 +154,12 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - **Adding a new language** — Create `NerdyPy/locales/lang_<code>.yaml`, restart the bot. No code changes needed. English keys are canonical — any missing key in other languages falls back to English automatically.
 - **Guild language is global** — `GuildLanguageConfig` is the single source of truth for a guild's language preference. Modules calling external APIs (Blizzard, Riot) should honor this setting when the API supports it, falling back to English otherwise.
 - **Full env var config** — All config keys can be set via `NERPYBOT_*` environment variables (see `docker-compose.yml` for the full list). Env vars take priority over `config.yaml` when both are present. Lists (`modules`, `ops`, `error_recipients`) use comma-separated values.
+- **`Guild.get_channel()` is cache-only** — Returns `None` on cache miss (e.g. after reconnect). Fall back to `await guild.fetch_channel(channel_id)` and catch `(discord.NotFound, discord.Forbidden)` before treating a channel as missing or deleting related DB rows. Canonical pattern: `NerdyPy/utils/helpers.py`; inline shorthand: `NerdyPy/modules/views/crafting_order.py`.
 
 #### Web Component (FastAPI / Vue)
 
 - **`session.commit()` before `background_tasks.add_task()`** — FastAPI background tasks run after the response is sent but before yield-dependency cleanup, so `session.commit()` in `_get_db_session` fires too late. Always call `session.commit()` explicitly before scheduling any background task that re-reads data written by the same request.
 - **`selectinload` for multiple one-to-many collections** — Two `joinedload` on different one-to-many relationships on the same parent produce a Cartesian product (rows × rows). Use `selectinload` for the second (and any further) collection — it fires a separate `IN` query instead.
-- **`Guild.get_channel()` is cache-only** — Returns `None` on cache miss (e.g. after reconnect). Fall back to `await guild.fetch_channel(channel_id)` and catch `(discord.NotFound, discord.Forbidden)` before treating a channel as missing or deleting related DB rows.
 - **No `return` inside `finally`** — Biome flags this as `noUnsafeFinally`; it suppresses any exception that escapes the `catch` block. Move stale-sequence guards and cleanup logic to _after_ the `try/catch` block instead.
 - **`route.query` TypeScript types** — Vue Router types query values as `LocationQueryValue | LocationQueryValue[]` where `LocationQueryValue = string | null`. Any helper that normalises a query param must accept `(string | null)[]`, not `string[]`.
 


### PR DESCRIPTION
## Summary

- Add Web Component architecture section describing the FastAPI/Vue app under `web/`
- Add worktree usage note to development commands
- Add `#### Web Component (FastAPI / Vue)` subheader in Gotchas to visually separate Discord bot entries from FastAPI/Vue Router/Biome entries
- Add `no-commit-to-branch` pre-commit hook to prevent accidental direct commits to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-commit hook to prevent commits to the protected main branch.

* **Documentation**
  * Expanded Web Component guidance with best practices: commit before scheduling background tasks, safe loading patterns to avoid Cartesian products, cache-first channel lookup with fallback/error handling, avoid returns in finally, and TypeScript route-query typing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->