### PR TITLE
docs: add release process documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ docker run --rm nerpybot python -c "from bot import NerpyBot; print('OK')"
 
 `docs/` contains per-module markdown files documenting commands, database models, background tasks, and data flows. When adding a new module or changing an existing one, update or create the corresponding `docs/<module>.md` file.
 
+For release procedures (tagging, release branches, hotfixes), see `docs/release-process.md`.
+
 ### Entry Point
 
 `NerdyPy/bot.py` - Contains `NerpyBot` class and `main()` entry point.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -84,9 +84,11 @@ Use this when a critical bug needs fixing against an already-released version.
    git checkout -b hotfix/1.2.4 v1.2.3
    ```
 
-2. Apply the fix, commit, and tag a patch release:
+2. Apply the fix, commit, then tag the patch release:
 
    ```bash
+   git add <changed-files>
+   git commit -m "fix: <hotfix summary>"
    git tag -a v1.2.4 -m "Hotfix v1.2.4"
    git push origin hotfix/1.2.4 v1.2.4
    ```

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,102 @@
+# Release Process
+
+NerpyBot uses **tag-driven versioning**: pushing a `v*` tag to GitHub is the single action that kicks off a release. CI handles image building, pushing, and badge updates automatically — there's no manual publish step.
+
+## Version Format
+
+| Scenario             | Example version      | How it's derived                                     |
+| -------------------- | -------------------- | ---------------------------------------------------- |
+| Tagged release       | `1.2.3`              | Tag `v1.2.3` → strip `v`                             |
+| Untagged `main` push | `1.2.3.dev4+gabcdef` | `git describe --tags --always` → PEP 440 dev version |
+| No prior tag         | `abcdef` (short SHA) | `git describe` falls back to commit SHA              |
+
+Always use `v<major>.<minor>.<patch>` for release tags (e.g. `v0.7.0`). Pre-release tags aren't currently used.
+
+## What CI Does Automatically
+
+When a `v*` tag is pushed, two workflows fire:
+
+| Workflow            | Trigger       | What it does                                                                                                                      |
+| ------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `docker.yml`        | `v*` tag push | Builds multi-arch (`amd64`/`arm64`) bot and web images; pushes semver + SHA tags to ghcr.io; verifies version in the pushed image |
+| `release-badge.yml` | `v*.*.*` tag  | Opens a PR against `main` to update the version badge in `README.md`                                                              |
+
+Docker image tags produced per release (both `nerpybot` and `nerpybot-web`):
+
+- `1.2.3` — exact version
+- `1.2` — minor alias
+- `1` — major alias
+- `<sha>` — commit SHA (7 chars)
+
+The `latest` tag is only published on `main` branch pushes, not on tag pushes.
+
+## Simple Release Flow (tag `main` directly)
+
+Use this when `main` is clean and ready to ship.
+
+1. Confirm `main` is in the desired state and all CI is green.
+2. Create and push the annotated tag:
+
+   ```bash
+   git tag -a v1.2.3 -m "Release v1.2.3"
+   git push origin v1.2.3
+   ```
+
+3. Watch the `docker.yml` run in GitHub Actions — it will build, push, and verify both images.
+4. Merge the auto-opened badge PR from `release-badge.yml` once it appears.
+5. Create a GitHub Release from the tag (optional but recommended for changelogs).
+
+## Release Branch Flow (when `main` has unfinished work)
+
+Use this when `main` has commits that shouldn't go out yet (e.g. half-finished features).
+
+1. Branch off the last good commit on `main`:
+
+   ```bash
+   git checkout -b release/1.2.3 <good-sha-or-main>
+   git push origin release/1.2.3
+   ```
+
+2. Apply only the fixes/changes needed for this release (cherry-pick from `main` if needed).
+3. Tag the release branch:
+
+   ```bash
+   git tag -a v1.2.3 -m "Release v1.2.3"
+   git push origin v1.2.3
+   ```
+
+4. CI builds and publishes images from the tagged commit.
+5. Merge the badge PR targeting `main`.
+6. Cherry-pick any release-branch fixes back to `main` that `main` doesn't already have.
+7. Delete the release branch once merged back:
+
+   ```bash
+   git push origin --delete release/1.2.3
+   ```
+
+## Hotfix Flow
+
+Use this when a critical bug needs fixing against an already-released version.
+
+1. Branch off the release tag:
+
+   ```bash
+   git checkout -b hotfix/1.2.4 v1.2.3
+   ```
+
+2. Apply the fix, commit, and tag a patch release:
+
+   ```bash
+   git tag -a v1.2.4 -m "Hotfix v1.2.4"
+   git push origin hotfix/1.2.4 v1.2.4
+   ```
+
+3. CI builds and publishes the patched images.
+4. Cherry-pick the fix to `main`:
+
+   ```bash
+   git cherry-pick <fix-sha>
+   git push origin main
+   ```
+
+5. Delete the hotfix branch.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -14,7 +14,7 @@ Always use `v<major>.<minor>.<patch>` for release tags (e.g. `v0.7.0`). Pre-rele
 
 ## What CI Does Automatically
 
-When a `v*` tag is pushed, two workflows fire:
+For a properly formatted semver tag (e.g. `v1.2.3`), two workflows fire. Note that `docker.yml` triggers on any `v*` tag (including `v1` or future pre-release tags), while `release-badge.yml` requires the full `v*.*.*` format to trigger:
 
 | Workflow            | Trigger       | What it does                                                                                                                      |
 | ------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
@@ -28,7 +28,7 @@ Docker image tags produced per release (both `nerpybot` and `nerpybot-web`):
 - `1` — major alias
 - `<sha>` — commit SHA (7 chars)
 
-The `latest` tag is only published on `main` branch pushes, not on tag pushes.
+The `latest` tag is only published on `main` branch pushes, not on tag pushes — `docker.yml` also triggers on pushes to `main`, and those runs are what keep `latest` up to date.
 
 ## Simple Release Flow (tag `main` directly)
 


### PR DESCRIPTION
## Summary

- Adds `docs/release-process.md` documenting tag-driven versioning, the three release flows (simple, release branch, hotfix), CI automation summary, and version format table
- Adds a one-liner pointer in `CLAUDE.md` under the Documentation section

## Test plan

- [x] `prettier --check docs/release-process.md` passes
- [x] Content verified against `docker.yml` and `release-badge.yml` CI workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive release process guide covering versioning semantics, Docker image tag conventions, CI release workflows, latest-tag behavior, and step-by-step release flows (simple, branch, hotfix), plus badge and optional release handling.
  * Updated an existing document to reference the new release-procedure guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->