### PR TITLE
fix(web): support mode guild state, redaction, and UX improvements

### DIFF
--- a/web/frontend/src/dev/fixtures.ts
+++ b/web/frontend/src/dev/fixtures.ts
@@ -507,6 +507,23 @@ export const guild3ApplicationSubmissions: ApplicationSubmissionSchema[] = [
     ],
     votes: [{ voter_id: "333000000000000001", voter_name: "ExtAdmin", vote: "approve" }],
   },
+  {
+    id: 12,
+    form_name: "External Server Membership",
+    user_id: "222000000000000003",
+    user_name: "GhostByte",
+    status: "denied",
+    submitted_at: "2026-03-07T20:15:00Z",
+    decision_reason: "Prior conduct issues reported by other members.",
+    answers: [
+      { question_id: 10, question_text: "Where are you from?", answer_text: "EU, hardcore raider." },
+      { question_id: 11, question_text: "How did you find us?", answer_text: "Saw your recruitment post." },
+    ],
+    votes: [
+      { voter_id: "333000000000000001", voter_name: "ExtAdmin", vote: "deny" },
+      { voter_id: "333000000000000002", voter_name: "ExtMod", vote: "deny" },
+    ],
+  },
 ];
 
 export const guild3WowGuildNews: WowGuildNewsSchema[] = [

--- a/web/frontend/src/i18n/locales/de.ts
+++ b/web/frontend/src/i18n/locales/de.ts
@@ -227,10 +227,6 @@ export const de: typeof en = {
       add_title: "Zu einem Server hinzufügen",
       add_desc: "Du hast ausreichende Berechtigungen, um NerpyBot auf diesen Servern einzuladen.",
       invite: "Einladen",
-      all_bot_guilds: "Alle Bot-Server",
-      all_bot_guilds_desc:
-        "Alle Server, auf denen NerpyBot aktuell aktiv ist. Klicke auf eine Karte, um die Einstellungen im Support-Modus zu öffnen.",
-      members: "{count} Mitglieder",
     },
 
     operator_guilds: {

--- a/web/frontend/src/i18n/locales/de.ts
+++ b/web/frontend/src/i18n/locales/de.ts
@@ -231,7 +231,7 @@ export const de: typeof en = {
 
     operator_guilds: {
       title: "Alle Bot-Server",
-      desc: "Jeder Server, auf dem der Bot aktuell aktiv ist. Klicke auf einen Server, um ihn im Support-Modus zu öffnen.",
+      desc: "Server, auf denen der Bot aktiv ist, für die du aber keine Verwaltungsrechte hast. Klicke auf einen Server, um ihn im Support-Modus zu öffnen.",
       loading: "Server werden geladen…",
       empty: "Keine Server gefunden.",
       count_one: "{count} Server insgesamt",

--- a/web/frontend/src/i18n/locales/en.ts
+++ b/web/frontend/src/i18n/locales/en.ts
@@ -224,10 +224,6 @@ export const en = {
       add_title: "Add to a Server",
       add_desc: "You have sufficient permissions to invite NerpyBot to these servers.",
       invite: "Invite",
-      all_bot_guilds: "All Bot Guilds",
-      all_bot_guilds_desc:
-        "All servers NerpyBot is currently in. Click any card to open that server's settings (support mode).",
-      members: "{count} members",
     },
 
     operator_guilds: {

--- a/web/frontend/src/i18n/locales/en.ts
+++ b/web/frontend/src/i18n/locales/en.ts
@@ -228,7 +228,7 @@ export const en = {
 
     operator_guilds: {
       title: "All Bot Guilds",
-      desc: "Every server the bot is currently in. Click a server to open it in support mode.",
+      desc: "Servers the bot is in where you don't have management access. Click a server to open it in support mode.",
       loading: "Loading guilds…",
       empty: "No guilds found.",
       count_one: "{count} server total",

--- a/web/frontend/src/views/guild/GuildDetailView.vue
+++ b/web/frontend/src/views/guild/GuildDetailView.vue
@@ -82,6 +82,9 @@ async function probeGuildAccess(id: string | undefined) {
   if (guildId.value === probeId) {
     supportMode.value = newMode;
     if (newMode && botGuild) {
+      // permission_level is hardcoded to "admin" here because effectiveLevel (in sectionGroups)
+      // always uses "admin" as the fallback when supportMode is true, making this value irrelevant.
+      // The tabs shown in support mode are governed solely by the supportMode flag, not permission_level.
       guild.setCurrent({
         id: botGuild.id,
         name: botGuild.name,

--- a/web/frontend/src/views/guild/GuildDetailView.vue
+++ b/web/frontend/src/views/guild/GuildDetailView.vue
@@ -65,44 +65,46 @@ const probeLoading = ref(true);
 
 async function probeGuildAccess(id: string | undefined) {
   probeLoading.value = true;
-  if (!id || !auth.user?.is_operator) {
-    supportMode.value = false;
-    probeLoading.value = false;
-    return;
-  }
-  const probeId = id;
-  let newMode = false;
-  let botGuild: BotGuildInfo | null = null;
   try {
-    const { supportMode: serverMode } = await api.getWithHeaders<unknown>(`/guilds/${id}/language`);
-    newMode = serverMode;
-    if (newMode) {
-      try {
-        botGuild = await api.get<BotGuildInfo>(`/operator/guilds/${id}`);
-      } catch {
-        // non-critical — guild name may be unavailable if bot is offline
+    if (!id || !auth.user?.is_operator) {
+      supportMode.value = false;
+      return;
+    }
+    const probeId = id;
+    let newMode = false;
+    let botGuild: BotGuildInfo | null = null;
+    try {
+      const { supportMode: serverMode } = await api.getWithHeaders<unknown>(`/guilds/${id}/language`);
+      newMode = serverMode;
+      if (newMode) {
+        try {
+          botGuild = await api.get<BotGuildInfo>(`/operator/guilds/${id}`);
+        } catch {
+          // non-critical — guild name may be unavailable if bot is offline
+        }
+      }
+    } catch {
+      // network error → treat as non-support access
+    }
+    if (guildId.value === probeId) {
+      supportMode.value = newMode;
+      if (newMode && botGuild) {
+        // permission_level is hardcoded to "admin" here because effectiveLevel (in sectionGroups)
+        // always uses "admin" as the fallback when supportMode is true, making this value irrelevant.
+        // The tabs shown in support mode are governed solely by the supportMode flag, not permission_level.
+        guild.setCurrent({
+          id: botGuild.id,
+          name: botGuild.name,
+          icon: botGuild.icon,
+          permission_level: "admin",
+          bot_present: true,
+          invite_url: null,
+        });
       }
     }
-  } catch {
-    // network error → treat as non-support access
+  } finally {
+    probeLoading.value = false;
   }
-  if (guildId.value === probeId) {
-    supportMode.value = newMode;
-    if (newMode && botGuild) {
-      // permission_level is hardcoded to "admin" here because effectiveLevel (in sectionGroups)
-      // always uses "admin" as the fallback when supportMode is true, making this value irrelevant.
-      // The tabs shown in support mode are governed solely by the supportMode flag, not permission_level.
-      guild.setCurrent({
-        id: botGuild.id,
-        name: botGuild.name,
-        icon: botGuild.icon,
-        permission_level: "admin",
-        bot_present: true,
-        invite_url: null,
-      });
-    }
-  }
-  probeLoading.value = false;
 }
 
 // Reset to overview when switching guilds, clear mockup, and probe support mode

--- a/web/frontend/src/views/guild/GuildDetailView.vue
+++ b/web/frontend/src/views/guild/GuildDetailView.vue
@@ -50,12 +50,15 @@ const activeSection = computed(() => toQueryScalar(route.query.tab) ?? "server-o
 const switcherOpen = ref(false);
 const LG_BREAKPOINT = 1024;
 
-// Persist sidebar state across refreshes; mobile always starts closed.
+// Persist sidebar state across refreshes; mobile always starts closed but does not
+// overwrite the stored desktop preference (guard: only write on lg+ screens).
 const sidebarOpen = ref(localStorage.getItem("sidebarOpen") !== "false");
 onMounted(() => {
   if (window.innerWidth < LG_BREAKPOINT) sidebarOpen.value = false;
 });
-watch(sidebarOpen, (v) => localStorage.setItem("sidebarOpen", String(v)));
+watch(sidebarOpen, (v) => {
+  if (window.innerWidth >= LG_BREAKPOINT) localStorage.setItem("sidebarOpen", String(v));
+});
 
 // Support mode: set by server via X-Support-Mode header on the first guild API call.
 const supportMode = ref(false);

--- a/web/frontend/src/views/guild/GuildDetailView.vue
+++ b/web/frontend/src/views/guild/GuildDetailView.vue
@@ -26,6 +26,7 @@ import SupportTab from "./tabs/SupportTab.vue";
 import MockupToolbar from "@/components/MockupToolbar.vue";
 import LanguageSwitcher from "@/components/LanguageSwitcher.vue";
 import { api } from "@/api/client";
+import type { BotGuildInfo } from "@/api/types";
 import { defineAsyncComponent } from "vue";
 
 const TestModeIndicator =
@@ -64,13 +65,33 @@ async function probeGuildAccess(id: string | undefined) {
   }
   const probeId = id;
   let newMode = false;
+  let botGuild: BotGuildInfo | null = null;
   try {
     const { supportMode: serverMode } = await api.getWithHeaders<unknown>(`/guilds/${id}/language`);
     newMode = serverMode;
+    if (newMode) {
+      try {
+        botGuild = await api.get<BotGuildInfo>(`/operator/guilds/${id}`);
+      } catch {
+        // non-critical — guild name may be unavailable if bot is offline
+      }
+    }
   } catch {
     // network error → treat as non-support access
   }
-  if (guildId.value === probeId) supportMode.value = newMode;
+  if (guildId.value === probeId) {
+    supportMode.value = newMode;
+    if (newMode && botGuild) {
+      guild.setCurrent({
+        id: botGuild.id,
+        name: botGuild.name,
+        icon: botGuild.icon,
+        permission_level: "admin",
+        bot_present: true,
+        invite_url: null,
+      });
+    }
+  }
 }
 
 // Reset to overview when switching guilds, clear mockup, and probe support mode
@@ -232,7 +253,7 @@ function guildIconUrl(): string | null {
 
   <div class="flex flex-col h-screen overflow-hidden">
     <!-- Mobile top bar — only visible below lg breakpoint -->
-    <div class="lg:hidden flex items-center h-12 px-4 border-b border-border flex-shrink-0 bg-card gap-3">
+    <div :class="['lg:hidden flex items-center h-12 px-4 border-b flex-shrink-0 bg-card gap-3', supportMode ? 'border-amber-500/50' : 'border-border']">
       <button
         class="text-muted-foreground hover:text-foreground transition-colors"
         :aria-label="t('nav.sidebar.open_nav')"
@@ -291,9 +312,11 @@ function guildIconUrl(): string | null {
       <!-- Guild switcher -->
       <div class="relative border-b border-border flex-shrink-0">
         <button
-          class="w-full p-4 flex items-center gap-2.5 hover:bg-muted transition-colors text-left"
+          :class="[
+            'w-full p-4 flex items-center gap-2.5 hover:bg-muted transition-colors text-left',
+            { 'cursor-default': !guildId, 'ring-2 ring-inset ring-amber-500/50': supportMode },
+          ]"
           @click="guildId ? (switcherOpen = !switcherOpen) : undefined"
-          :class="{ 'cursor-default': !guildId }"
         >
           <img
             v-if="guildId && guildIconUrl()"

--- a/web/frontend/src/views/guild/GuildDetailView.vue
+++ b/web/frontend/src/views/guild/GuildDetailView.vue
@@ -59,16 +59,17 @@ watch(sidebarOpen, (v) => localStorage.setItem("sidebarOpen", String(v)));
 
 // Support mode: set by server via X-Support-Mode header on the first guild API call.
 const supportMode = ref(false);
-// True while probeGuildAccess is in flight — prevents activeComponent from redirecting
-// away from the active tab before we know which tabs are available in support mode.
-const probeLoading = ref(false);
+// Starts true so the first synchronous computed evaluation (before onMounted) never fires
+// the tab fallback redirect. Set to false once probeGuildAccess resolves or exits early.
+const probeLoading = ref(true);
 
 async function probeGuildAccess(id: string | undefined) {
+  probeLoading.value = true;
   if (!id || !auth.user?.is_operator) {
     supportMode.value = false;
+    probeLoading.value = false;
     return;
   }
-  probeLoading.value = true;
   const probeId = id;
   let newMode = false;
   let botGuild: BotGuildInfo | null = null;

--- a/web/frontend/src/views/guild/GuildDetailView.vue
+++ b/web/frontend/src/views/guild/GuildDetailView.vue
@@ -48,21 +48,27 @@ const guildId = computed(() => route.params.id as string | undefined);
 
 const activeSection = computed(() => toQueryScalar(route.query.tab) ?? "server-overview");
 const switcherOpen = ref(false);
-const sidebarOpen = ref(true);
 const LG_BREAKPOINT = 1024;
 
+// Persist sidebar state across refreshes; mobile always starts closed.
+const sidebarOpen = ref(localStorage.getItem("sidebarOpen") !== "false");
 onMounted(() => {
   if (window.innerWidth < LG_BREAKPOINT) sidebarOpen.value = false;
 });
+watch(sidebarOpen, (v) => localStorage.setItem("sidebarOpen", String(v)));
 
 // Support mode: set by server via X-Support-Mode header on the first guild API call.
 const supportMode = ref(false);
+// True while probeGuildAccess is in flight — prevents activeComponent from redirecting
+// away from the active tab before we know which tabs are available in support mode.
+const probeLoading = ref(false);
 
 async function probeGuildAccess(id: string | undefined) {
   if (!id || !auth.user?.is_operator) {
     supportMode.value = false;
     return;
   }
+  probeLoading.value = true;
   const probeId = id;
   let newMode = false;
   let botGuild: BotGuildInfo | null = null;
@@ -95,6 +101,7 @@ async function probeGuildAccess(id: string | undefined) {
       });
     }
   }
+  probeLoading.value = false;
 }
 
 // Reset to overview when switching guilds, clear mockup, and probe support mode
@@ -234,6 +241,9 @@ const sectionGroups = computed(() => {
 
 const allSections = computed(() => sectionGroups.value.flatMap((g) => g.items));
 const activeComponent = computed(() => {
+  // While the support-mode probe is in flight, the visible section list is incomplete.
+  // Suppress the fallback redirect until we know the real set of available tabs.
+  if (probeLoading.value) return undefined;
   const found = allSections.value.find((s) => s.id === activeSection.value);
   if (!found && allSections.value.length > 0) {
     // Requested tab is no longer available (filtered out) — fall back silently.

--- a/web/frontend/src/views/guild/GuildDetailView.vue
+++ b/web/frontend/src/views/guild/GuildDetailView.vue
@@ -316,7 +316,8 @@ function guildIconUrl(): string | null {
       <div class="relative border-b border-border flex-shrink-0">
         <button
           :class="[
-            'w-full p-4 flex items-center gap-2.5 hover:bg-muted transition-colors text-left',
+            'w-full flex items-center hover:bg-muted transition-colors text-left',
+            sidebarOpen ? 'p-4 gap-2.5' : 'p-2 justify-center',
             { 'cursor-default': !guildId, 'ring-2 ring-inset ring-amber-500/50': supportMode },
           ]"
           @click="guildId ? (switcherOpen = !switcherOpen) : undefined"
@@ -386,11 +387,12 @@ function guildIconUrl(): string | null {
       </div>
 
       <!-- Navigation -->
-      <nav class="flex-1 p-2 space-y-4 overflow-y-auto">
-        <div v-for="group in sectionGroups" :key="group.id">
-          <p v-show="sidebarOpen" :class="['px-3 pb-1 text-xs font-semibold uppercase tracking-wider', group.accentClass]">
+      <nav class="flex-1 p-2 overflow-y-auto" :class="sidebarOpen ? 'space-y-4' : 'space-y-2'">
+        <div v-for="(group, idx) in sectionGroups" :key="group.id">
+          <p v-if="sidebarOpen" :class="['px-3 pb-1 text-xs font-semibold uppercase tracking-wider', group.accentClass]">
             {{ t(group.labelKey) }}
           </p>
+          <div v-else-if="idx > 0" class="border-t border-border/60 mx-1 mb-1.5" />
           <div class="space-y-0.5">
             <button
               v-for="section in group.items"
@@ -417,16 +419,13 @@ function guildIconUrl(): string | null {
       <!-- Sidebar footer -->
       <div class="flex flex-col flex-shrink-0">
         <component :is="TestModeIndicator" v-if="TestModeIndicator && sidebarOpen" />
-        <div class="border-t border-border p-4 flex items-center gap-3">
+        <div :class="['border-t border-border flex items-center', sidebarOpen ? 'p-4 gap-3' : 'p-2 justify-center']">
         <span v-show="sidebarOpen" class="text-sm text-muted-foreground truncate flex-1">
           {{ auth.user?.username }}
         </span>
         <LanguageSwitcher v-show="sidebarOpen" />
         <button
-          :class="[
-            'p-2 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors flex-shrink-0',
-            !sidebarOpen && 'mx-auto',
-          ]"
+          class="p-2 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
           :title="t('nav.sidebar.logout')"
           :aria-label="t('nav.sidebar.logout')"
           @click="auth.clear(); router.push('/login')"

--- a/web/frontend/src/views/guild/tabs/OperatorGuildsTab.vue
+++ b/web/frontend/src/views/guild/tabs/OperatorGuildsTab.vue
@@ -5,9 +5,11 @@ import { Icon } from "@iconify/vue";
 import { api } from "@/api/client";
 import type { BotGuildInfo } from "@/api/types";
 import { useI18n } from "@/i18n";
+import { useAuthStore } from "@/stores/auth";
 
 const router = useRouter();
 const { t, locale } = useI18n();
+const auth = useAuthStore();
 
 const guilds = ref<BotGuildInfo[]>([]);
 const loading = ref(false);
@@ -19,7 +21,8 @@ async function fetchGuilds() {
   error.value = null;
   try {
     const res = await api.get<{ guilds: BotGuildInfo[] }>("/operator/guilds");
-    guilds.value = res.guilds;
+    const managedIds = new Set(auth.guilds.map((g) => g.id));
+    guilds.value = res.guilds.filter((g) => !managedIds.has(g.id));
   } catch (e: unknown) {
     error.value = e instanceof Error ? e.message : t("common.load_failed");
   } finally {

--- a/web/frontend/src/views/guild/tabs/ServerOverviewTab.vue
+++ b/web/frontend/src/views/guild/tabs/ServerOverviewTab.vue
@@ -1,31 +1,18 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
+import { computed } from "vue";
 import { useRouter } from "vue-router";
 import { Icon } from "@iconify/vue";
 import { useAuthStore } from "@/stores/auth";
 import { useGuildStore } from "@/stores/guild";
-import { api } from "@/api/client";
-import type { BotGuildInfo } from "@/api/types";
 import { useI18n } from "@/i18n";
 
 const auth = useAuthStore();
 const guildStore = useGuildStore();
 const router = useRouter();
-const { t, locale } = useI18n();
+const { t } = useI18n();
 
 const managedGuilds = computed(() => auth.guilds.filter((g) => g.bot_present));
 const invitableGuilds = computed(() => auth.guilds.filter((g) => !g.bot_present));
-
-const botGuilds = ref<BotGuildInfo[]>([]);
-
-onMounted(async () => {
-  if (!auth.user?.is_operator) return;
-  try {
-    botGuilds.value = (await api.get<{ guilds: BotGuildInfo[] }>("/operator/guilds")).guilds;
-  } catch {
-    // non-critical
-  }
-});
 
 function iconUrl(guild: { id: string; icon: string | null }): string | null {
   if (!guild.icon) return null;
@@ -120,40 +107,6 @@ function iconUrl(guild: { id: string; icon: string | null }): string | null {
             {{ t("tabs.server_overview.invite") }}
           </a>
         </div>
-      </div>
-    </template>
-
-    <!-- All Bot Guilds — operator only -->
-    <template v-if="auth.user?.is_operator && botGuilds.length > 0">
-      <h2 class="text-xl font-bold mb-1 mt-10">{{ t("tabs.server_overview.all_bot_guilds") }}</h2>
-      <p class="text-muted-foreground text-sm mb-6">{{ t("tabs.server_overview.all_bot_guilds_desc") }}</p>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        <button
-          v-for="g in botGuilds"
-          :key="g.id"
-          class="rounded-lg p-4 flex items-center gap-3 text-left border bg-card hover:bg-muted border-border hover:border-primary transition-colors"
-          @click="router.push(`/guilds/${g.id}`)"
-        >
-          <img
-            v-if="iconUrl(g)"
-            :src="iconUrl(g)!"
-            :alt="g.name"
-            class="w-10 h-10 rounded-full object-cover flex-shrink-0"
-          />
-          <div
-            v-else
-            class="w-10 h-10 rounded-full bg-muted flex items-center justify-center text-base font-bold flex-shrink-0"
-            aria-hidden="true"
-          >
-            {{ g.name.charAt(0).toUpperCase() }}
-          </div>
-          <div class="min-w-0 flex-1">
-            <div class="font-semibold text-sm truncate">{{ g.name }}</div>
-            <div class="text-xs text-muted-foreground">
-              {{ t("tabs.server_overview.members", { count: g.member_count?.toLocaleString(locale.current) ?? "?" }) }}
-            </div>
-          </div>
-        </button>
       </div>
     </template>
   </div>

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -656,7 +656,7 @@ def _submission_to_schema(s, user: dict, question_texts: dict | None = None) -> 
         user_name=_redact(s.UserName, user),
         status=s.Status.value,
         submitted_at=str(s.SubmittedAt),
-        decision_reason=s.DecisionReason,
+        decision_reason=_redact(s.DecisionReason, user),
         answers=[
             ApplicationAnswerSchema(
                 question_id=a.QuestionId,

--- a/web/routes/operator.py
+++ b/web/routes/operator.py
@@ -164,16 +164,20 @@ async def unload_module(
     return ModuleActionResponse(module=name, action="unload", **result)
 
 
+async def _fetch_guild_list(vk: ValkeyClient) -> list[dict]:
+    result = await vk.send_bot_command("list_guilds", {})
+    if result is None:
+        raise HTTPException(status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE, detail="Bot unreachable")
+    return result.get("guilds", [])
+
+
 @router.get("/guilds", response_model=BotGuildListResponse)
 async def list_bot_guilds(
     user: dict = Depends(require_operator),
     vk: ValkeyClient = Depends(get_valkey),
 ):
     """List all guilds the bot is currently in."""
-    result = await vk.send_bot_command("list_guilds", {})
-    if result is None:
-        raise HTTPException(status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE, detail="Bot unreachable")
-    return BotGuildListResponse(guilds=[BotGuildInfo(**g) for g in result.get("guilds", [])])
+    return BotGuildListResponse(guilds=[BotGuildInfo(**g) for g in await _fetch_guild_list(vk)])
 
 
 @router.get("/guilds/{guild_id}", response_model=BotGuildInfo)
@@ -183,10 +187,7 @@ async def get_bot_guild(
     vk: ValkeyClient = Depends(get_valkey),
 ):
     """Get info for a single guild the bot is in."""
-    result = await vk.send_bot_command("list_guilds", {})
-    if result is None:
-        raise HTTPException(status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE, detail="Bot unreachable")
-    for g in result.get("guilds", []):
-        if str(g.get("id")) == guild_id:
+    for g in await _fetch_guild_list(vk):
+        if g.get("id") == guild_id:
             return BotGuildInfo(**g)
     raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail="Guild not found")

--- a/web/routes/operator.py
+++ b/web/routes/operator.py
@@ -174,3 +174,19 @@ async def list_bot_guilds(
     if result is None:
         raise HTTPException(status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE, detail="Bot unreachable")
     return BotGuildListResponse(guilds=[BotGuildInfo(**g) for g in result.get("guilds", [])])
+
+
+@router.get("/guilds/{guild_id}", response_model=BotGuildInfo)
+async def get_bot_guild(
+    guild_id: str,
+    user: dict = Depends(require_operator),
+    vk: ValkeyClient = Depends(get_valkey),
+):
+    """Get info for a single guild the bot is in."""
+    result = await vk.send_bot_command("list_guilds", {})
+    if result is None:
+        raise HTTPException(status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE, detail="Bot unreachable")
+    for g in result.get("guilds", []):
+        if str(g.get("id")) == guild_id:
+            return BotGuildInfo(**g)
+    raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail="Guild not found")


### PR DESCRIPTION
## Summary

- **Guild indicator & sidebar broken in support mode** — `probeGuildAccess` now fetches guild name/icon via a new `GET /operator/guilds/{id}` endpoint and calls `guild.setCurrent()` with a synthetic `GuildSummary` (`permission_level: "admin"`). This fixes the guild name showing as "Guild" and the sidebar only showing General + Support after a page refresh.
- **`decision_reason` not redacted in support mode** — `_submission_to_schema` now passes `decision_reason` through `_redact()` like all other PII fields.
- **No visual indicator for support mode in guild selector** — guild switcher button gets `ring-2 ring-inset ring-amber-500/50`; mobile top bar border switches to `border-amber-500/50` when `supportMode` is true.
- **Duplicate "All Bot Guilds" on Server Overview** — removed the operator-only section from `ServerOverviewTab` (it duplicates the Operator › All Guilds tab); cleaned up now-unused `api`, `BotGuildInfo`, `ref`, `onMounted`, and `locale` imports.
- **Stale i18n keys** — removed `all_bot_guilds`, `all_bot_guilds_desc`, and `members` from both EN and DE locales.

## New endpoint

`GET /operator/guilds/{guild_id}` — returns a single `BotGuildInfo` for a guild the bot is in (operator only). Reuses the existing `list_guilds` Valkey command and filters client-side.

## Test plan

- [x] Log in as operator → Server Overview should **not** show "All Bot Guilds" section
- [x] Navigate to a support-mode guild → top-left guild name shows correctly, amber ring visible on guild switcher
- [x] Refresh page while in support mode → sidebar shows all admin-level tabs, guild name still correct
- [x] View application submissions in support mode → `decision_reason` shows `[redacted]`
- [x] `npm run build` passes (vue-tsc + vite) ✅
- [x] `ruff check` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer guild info during support-mode probing and sidebar open/close now persists across sessions.

* **Behavior Changes**
  * Operators now see only servers where they lack management access; operator-only bot-guild list removed.

* **Privacy**
  * Decision reasons are now redact-aware in support mode.

* **Localization**
  * Clarified server-access translation strings and removed unused translation keys.

* **UX Improvements**
  * Support-mode visual cue (amber top border) and refined guild switcher and collapsed-sidebar rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->