### PR TITLE
docs: add GitHub FUNDING.yml for Ko-fi and Patreon

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+ko_fi: C1C21W04KA
+patreon: karakTaka


### PR DESCRIPTION
## Summary

- Adds `.github/FUNDING.yml` so GitHub shows a native Sponsor button on the repo page
- Links Ko-fi (`C1C21W04KA`) and Patreon (`karakTaka`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Funding configuration to enable project support through Ko-fi and Patreon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->