### PR TITLE
fix(web): prevent JWT session fixation via crafted URL fragments

### DIFF
--- a/web/frontend/src/router/index.ts
+++ b/web/frontend/src/router/index.ts
@@ -43,6 +43,8 @@ const router = createRouter({
   ],
 });
 
+const TOKEN_HASH_PREFIX = "#token=";
+
 router.beforeEach(async (to) => {
   const auth = useAuthStore();
   const guild = useGuildStore();
@@ -51,8 +53,8 @@ router.beforeEach(async (to) => {
   // Fragment is used instead of query param so the token never appears in server logs.
   // Restrict to root path — the only legitimate OAuth callback target — to prevent
   // session fixation via crafted URLs on other routes (e.g. /login#token=ATTACKER_JWT).
-  if (to.path === "/" && to.hash.startsWith("#token=")) {
-    auth.setToken(to.hash.slice("#token=".length));
+  if (to.path === "/" && to.hash.startsWith(TOKEN_HASH_PREFIX)) {
+    auth.setToken(to.hash.slice(TOKEN_HASH_PREFIX.length));
     return { path: to.path, hash: "", replace: true };
   }
 

--- a/web/frontend/src/router/index.ts
+++ b/web/frontend/src/router/index.ts
@@ -49,7 +49,9 @@ router.beforeEach(async (to) => {
 
   // Extract JWT handed off by /api/auth/callback redirect (#token=<jwt>).
   // Fragment is used instead of query param so the token never appears in server logs.
-  if (to.hash.startsWith("#token=")) {
+  // Restrict to root path — the only legitimate OAuth callback target — to prevent
+  // session fixation via crafted URLs on other routes (e.g. /login#token=ATTACKER_JWT).
+  if (to.path === "/" && to.hash.startsWith("#token=")) {
     auth.setToken(to.hash.slice("#token=".length));
     return { path: to.path, hash: "", replace: true };
   }


### PR DESCRIPTION
## Summary

- Restricts JWT token extraction from URL fragments to `to.path === "/"` only — the sole legitimate OAuth callback target
- Prevents session fixation attacks where an attacker crafts `/login#token=ATTACKER_JWT` to overwrite a victim's session
- Extracts `TOKEN_HASH_PREFIX` constant to eliminate the duplicated `"#token="` magic string

## Security context

The backend OAuth callback always redirects to `/#token=<jwt>`. Token extraction on any other path is illegitimate. Before this fix, visiting `/login#token=ATTACKER_JWT` would silently store the attacker's JWT before the public-route check could short-circuit.

## Test plan

- [ ] `npm run build --prefix web/frontend` passes (type-check + build)
- [ ] OAuth flow (`/api/auth/callback` → `/#token=...` → `/guilds`) still works end-to-end
- [ ] Visiting `/login#token=fake` no longer stores the token in the auth store

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JWT token extraction is now restricted to the root path only and requires a specific token hash prefix. This prevents unintended token processing in other application areas, enhancing security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->