### PR TITLE
fix(web): correct JWT token extraction path after Vue Router redirect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - **`route.query` TypeScript types** — Vue Router types query values as `LocationQueryValue | LocationQueryValue[]` where `LocationQueryValue = string | null`. Any helper that normalizes a query param must accept `(string | null)[]`, not `string[]`.
 - **Support mode GET endpoints need the `X-Support-Mode` header** — Add `response: Response = None` to the function signature and call `_set_support_mode_header(user, response)` at the top. Also guard any lazy ORM mutations (e.g. name backfill loops) with `if not user.get("support_mode")` — SQLAlchemy auto-commits ORM changes at request end, so mutations inside GET handlers persist even for support-mode reads.
 - **Tests for `require_guild_access` must first grant premium** — The guild router has `dependencies=[Depends(require_premium)]` at router level. A test user without premium hits `require_premium` (not `require_guild_access`) and gets 403 for the wrong reason. Call `PremiumUser.grant(user_id, operator_id, session)` before asserting access behavior.
+- **Vue Router `beforeEach` never sees the source of a declarative redirect** — `{ path: "/", redirect: "/guilds" }` is resolved before guards fire; `to.path` will be `"/guilds"`, never `"/"`. Guard conditions using the pre-redirect path silently never match.
 
 ## Configuration
 

--- a/web/frontend/src/router/index.ts
+++ b/web/frontend/src/router/index.ts
@@ -51,9 +51,10 @@ router.beforeEach(async (to) => {
 
   // Extract JWT handed off by /api/auth/callback redirect (#token=<jwt>).
   // Fragment is used instead of query param so the token never appears in server logs.
-  // Restrict to root path — the only legitimate OAuth callback target — to prevent
-  // session fixation via crafted URLs on other routes (e.g. /login#token=ATTACKER_JWT).
-  if (to.path === "/" && to.hash.startsWith(TOKEN_HASH_PREFIX)) {
+  // Restrict to /guilds — the actual path beforeEach sees, because Vue Router resolves the
+  // "/" → "/guilds" declarative redirect before firing navigation guards. Restricting to this
+  // path prevents session fixation via crafted URLs on public routes (e.g. /login#token=ATTACKER_JWT).
+  if (to.path === "/guilds" && to.hash.startsWith(TOKEN_HASH_PREFIX)) {
     auth.setToken(to.hash.slice(TOKEN_HASH_PREFIX.length));
     return { path: to.path, hash: "", replace: true };
   }


### PR DESCRIPTION
## Summary

- Fixes login regression introduced in #335: after OAuth callback, users were redirected back to the login page instead of being authenticated
- Root cause: `beforeEach` guard checked `to.path === "/"` but Vue Router resolves the `"/" → "/guilds"` declarative redirect **before** firing navigation guards — so the guard never saw `to.path === "/"`, the hash token was never extracted, and every login attempt fell through to `/login`
- Fix: change the path guard to `to.path === "/guilds"` (the actual resolved path) while preserving the session-fixation protection from #335

## Test plan

- [ ] `npm run build --prefix web/frontend` passes
- [ ] OAuth flow (`/api/auth/callback` → `/#token=...` → `/guilds`) works end-to-end
- [ ] Visiting `/login#token=fake` still does **not** store the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)