### PR TITLE
config(ci): custom CodeQL workflow — label-gated, source-scoped

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,4 +1,13 @@
 name: "NerpyBot CodeQL Config"
 
+paths:
+  - NerdyPy/
+  - web/
+
 paths-ignore:
   - database-migrations/*/versions
+  - web/frontend/dist
+  - web/frontend/node_modules
+  - .worktrees/
+  - "**/__pycache__/**"
+  - "**/*.min.js"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'review')
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql-config.yml
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Replaces GitHub Default Setup (disabled via API) with a custom workflow triggered only when the `review` label is present — same gate as CodeRabbit
- Adds `javascript-typescript` analysis for the Vue/TypeScript frontend alongside Python
- Upgrades query suite to `security-extended` for broader SSRF, injection, and taint-tracking coverage
- Scopes analysis to `NerdyPy/` and `web/` only — excludes migrations, worktrees, `__pycache__`, build output

## Test plan

- [x] Add `review` label to a PR — both `python` and `javascript-typescript` CodeQL jobs should trigger
- [x] Open/push to a PR without `review` label — CodeQL jobs should be skipped
- [ ] Verify results appear in Security → Code scanning alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)