### PR TITLE
config(coderabbit): reduce quota usage on OSS plan

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,18 +7,39 @@ tone_instructions: >
 reviews:
   profile: "assertive"
   high_level_summary: true
-  high_level_summary_in_walkthrough: true
+  high_level_summary_in_walkthrough: false
   collapse_walkthrough: true
   poem: false
   review_status: true
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  assess_linked_issues: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  suggested_reviewers: false
   auto_review:
     enabled: true
     drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 3
     labels:
       - "review"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "renovate[bot]"
+      - "pre-commit-ci[bot]"
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
 
   path_filters:
     - "!uv.lock"
+    - "!web/frontend/package-lock.json"
+    - "!web/frontend/tsconfig*.json"
+    - "!web/frontend/.vscode/**"
     - "!coverage.xml"
     - "!**/__pycache__/**"
     - "!docs/superpowers/**"
@@ -90,5 +111,9 @@ reviews:
         - Never interpolate untrusted event inputs (PR title/body, issue title, head ref, commit message)
           directly into `run:` steps. Pass through `env:` variables instead.
 
+knowledge_base:
+  web_search:
+    enabled: false
+
 chat:
-  auto_reply: true
+  auto_reply: false


### PR DESCRIPTION
## Summary

- Disable default-on features that each cost extra LLM passes per review: `finishing_touches` (docstrings + unit tests), `sequence_diagrams`, `knowledge_base.web_search`, `assess_linked_issues`, `related_issues`/`related_prs`, `suggested_labels`/`suggested_reviewers`
- Turn off `chat.auto_reply` — was triggering a full LLM round-trip on every comment thread
- Exclude generated files from review: `package-lock.json`, `tsconfig*.json`, `.vscode/`
- Add `dependabot[bot]`, `renovate[bot]`, `pre-commit-ci[bot]` to `ignore_usernames` so bot PRs don't burn a review slot
- Make `auto_incremental_review: true` explicit (was implicit default)
- Lower `auto_pause_after_reviewed_commits` from 5 → 3

## Test plan

- [ ] Open a labeled PR and verify CodeRabbit still reviews it
- [ ] Verify no sequence diagrams or finishing touches appear in the review
- [ ] Verify CodeRabbit does not auto-reply to comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)