### PR TITLE
feat(wow): gate recipe cache swap on sync completeness

### DIFF
--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -480,5 +480,9 @@ class CraftingRecipeCache(db.BASE):
         return f"https://www.wowhead.com/spell={self.RecipeId}"
 
     @classmethod
+    def count(cls, session) -> int:
+        return session.query(cls).count()
+
+    @classmethod
     def delete_all(cls, session):
         session.query(cls).delete()

--- a/NerdyPy/modules/admin.py
+++ b/NerdyPy/modules/admin.py
@@ -265,12 +265,15 @@ class Admin(NerpyBotCog, Cog):
 
                 expansion = self.bot.config.get("wow", {}).get("expansion")
                 stats = await sync_crafting_recipes(self.bot, expansion=expansion)
-                await ctx.send(
+                summary = (
                     f"Recipe sync complete: **{stats['crafted']}** crafted · "
                     f"**{stats['housing']}** housing · "
                     f"**{stats['errors']}** errors · "
                     f"{stats['duration_seconds']}s"
                 )
+                if not stats["cache_updated"]:
+                    summary += "\n⚠️ Cache was **not** updated due to errors — stale data preserved. Retry when Blizzard API is stable."
+                await ctx.send(summary)
             except Exception as ex:
                 self.bot.log.error("Recipe sync failed: %s", ex, exc_info=True)
                 await ctx.send(f"Recipe sync failed: {ex}")

--- a/NerdyPy/modules/admin.py
+++ b/NerdyPy/modules/admin.py
@@ -272,7 +272,7 @@ class Admin(NerpyBotCog, Cog):
                     f"{stats['duration_seconds']}s"
                 )
                 if not stats["cache_updated"]:
-                    summary += "\n⚠️ Cache was **not** updated due to errors — stale data preserved. Retry when Blizzard API is stable."
+                    summary += "\n**Warning:** Cache was **not** updated due to errors — stale data preserved. Retry when Blizzard API is stable."
                 await ctx.send(summary)
             except Exception as ex:
                 self.bot.log.error("Recipe sync failed: %s", ex, exc_info=True)

--- a/NerdyPy/utils/blizzard.py
+++ b/NerdyPy/utils/blizzard.py
@@ -402,23 +402,20 @@ async def sync_crafting_recipes(
     await asyncio.gather(*[_sync_profession(name, pid) for name, pid in CRAFTING_PROFESSIONS.items()])
 
     # ── Upsert into database ──────────────────────────────────────────────
-    cache_updated = False
-
-    def _upsert():
-        nonlocal cache_updated
+    def _upsert() -> bool:
         with bot.session_scope() as session:
             if errors > 0 and CraftingRecipeCache.count(session) > 0:
                 log.warning(
                     "sync_crafting_recipes: %d error(s) during fetch — keeping stale cache, retry later",
                     errors,
                 )
-                return
+                return False
             CraftingRecipeCache.delete_all(session)
             if all_rows:
                 session.execute(insert(CraftingRecipeCache), all_rows)
-            cache_updated = True
+            return True
 
-    await asyncio.to_thread(_upsert)
+    cache_updated = await asyncio.to_thread(_upsert)
 
     crafted_count = sum(1 for r in all_rows if r["RecipeType"] == RECIPE_TYPE_CRAFTED)
     housing_count = sum(1 for r in all_rows if r["RecipeType"] == RECIPE_TYPE_HOUSING)

--- a/NerdyPy/utils/blizzard.py
+++ b/NerdyPy/utils/blizzard.py
@@ -157,7 +157,13 @@ async def sync_crafting_recipes(
     recipes from non-matching tiers are skipped.  Housing recipes from ALL
     tiers are always cached regardless of the expansion filter.
 
-    Returns {"crafted": N, "housing": N, "errors": N, "duration_seconds": float}.
+    Returns {
+        "crafted": int,
+        "housing": int,
+        "errors": int,
+        "cache_updated": bool,  # False when errors > 0 and stale cache was preserved
+        "duration_seconds": float,
+    }.
     """
     import asyncio
     import logging

--- a/NerdyPy/utils/blizzard.py
+++ b/NerdyPy/utils/blizzard.py
@@ -402,11 +402,21 @@ async def sync_crafting_recipes(
     await asyncio.gather(*[_sync_profession(name, pid) for name, pid in CRAFTING_PROFESSIONS.items()])
 
     # ── Upsert into database ──────────────────────────────────────────────
+    cache_updated = False
+
     def _upsert():
+        nonlocal cache_updated
         with bot.session_scope() as session:
+            if errors > 0 and CraftingRecipeCache.count(session) > 0:
+                log.warning(
+                    "sync_crafting_recipes: %d error(s) during fetch — keeping stale cache, retry later",
+                    errors,
+                )
+                return
             CraftingRecipeCache.delete_all(session)
             if all_rows:
                 session.execute(insert(CraftingRecipeCache), all_rows)
+            cache_updated = True
 
     await asyncio.to_thread(_upsert)
 
@@ -415,10 +425,11 @@ async def sync_crafting_recipes(
     duration = round(time.monotonic() - start, 1)
 
     log.info(
-        "sync_crafting_recipes: done — crafted=%d housing=%d errors=%d duration=%.1fs",
+        "sync_crafting_recipes: done — crafted=%d housing=%d errors=%d cache_updated=%s duration=%.1fs",
         crafted_count,
         housing_count,
         errors,
+        cache_updated,
         duration,
     )
 
@@ -426,6 +437,7 @@ async def sync_crafting_recipes(
         "crafted": crafted_count,
         "housing": housing_count,
         "errors": errors,
+        "cache_updated": cache_updated,
         "duration_seconds": duration,
     }
 

--- a/tests/utils/test_blizzard.py
+++ b/tests/utils/test_blizzard.py
@@ -96,9 +96,40 @@ class TestSyncCraftingRecipesGuard:
         session.query.return_value.delete.assert_not_called()
 
     async def test_errors_with_empty_cache_writes_partial_data(self):
-        """errors>0 but cache is empty → write partial data (something > nothing)."""
+        """errors>0 but cache is empty → partial rows are written (something > nothing)."""
+        import threading
+
         bot, session = _make_bot(cache_row_count=0)
-        with patch("blizzapi.RetailClient", return_value=_make_client(fail=True)):
+
+        # First profession call returns one skill tier with one recipe; all others raise.
+        # threading.Lock ensures the call counter is safe across asyncio.to_thread workers.
+        _lock = threading.Lock()
+        _n = [0]
+
+        def _profession_side_effect(**kwargs):
+            with _lock:
+                _n[0] += 1
+                n = _n[0]
+            if n == 1:
+                return {"skill_tiers": [{"id": 1, "name": "Shadowlands Blacksmithing"}]}
+            raise RuntimeError("Blizzard API unavailable")
+
+        client = MagicMock()
+        client.profession.side_effect = _profession_side_effect
+        client.profession_skill_tier.return_value = {
+            "categories": [{"name": "Gear", "recipes": [{"id": 100, "name": "Iron Sword"}]}]
+        }
+        client.recipe.return_value = {"id": 100, "crafted_item": {"id": 200, "name": "Iron Sword"}}
+        client.item.return_value = {
+            "id": 200,
+            "item_class": {"id": 2, "name": "Weapon"},
+            "item_subclass": {"id": 0, "name": "Sword"},
+        }
+        client.item_media.return_value = None
+        client.item_search.return_value = None
+        client.recipe_media.return_value = None
+
+        with patch("blizzapi.RetailClient", return_value=client):
             with patch.object(CraftingRecipeCache, "count", return_value=0):
                 from utils.blizzard import sync_crafting_recipes
 
@@ -106,3 +137,4 @@ class TestSyncCraftingRecipesGuard:
 
         assert result["errors"] > 0
         assert result["cache_updated"] is True
+        assert result["crafted"] > 0  # partial rows were actually written

--- a/tests/utils/test_blizzard.py
+++ b/tests/utils/test_blizzard.py
@@ -40,10 +40,9 @@ class TestRoleAutoMatch:
         assert matched is None
 
 
-def _make_bot(cache_row_count: int = 0):
+def _make_bot():
     """Return a (bot, session) pair with a working session_scope context manager."""
     session = MagicMock()
-    session.query.return_value.count.return_value = cache_row_count
 
     bot = MagicMock()
     bot.config.get.return_value = {"wow_id": "fake_id", "wow_secret": "fake_secret"}
@@ -71,7 +70,7 @@ class TestSyncCraftingRecipesGuard:
 
     async def test_clean_sync_updates_cache(self):
         """errors=0 → cache is always replaced."""
-        bot, session = _make_bot(cache_row_count=5)
+        bot, session = _make_bot()
         with patch("blizzapi.RetailClient", return_value=_make_client(fail=False)):
             with patch.object(CraftingRecipeCache, "count", return_value=5):
                 from utils.blizzard import sync_crafting_recipes
@@ -83,7 +82,7 @@ class TestSyncCraftingRecipesGuard:
 
     async def test_errors_with_populated_cache_skips_swap(self):
         """errors>0 and cache has rows → keep stale cache, do not wipe."""
-        bot, session = _make_bot(cache_row_count=10)
+        bot, session = _make_bot()
         with patch("blizzapi.RetailClient", return_value=_make_client(fail=True)):
             with patch.object(CraftingRecipeCache, "count", return_value=10):
                 from utils.blizzard import sync_crafting_recipes
@@ -99,7 +98,7 @@ class TestSyncCraftingRecipesGuard:
         """errors>0 but cache is empty → partial rows are written (something > nothing)."""
         import threading
 
-        bot, session = _make_bot(cache_row_count=0)
+        bot, session = _make_bot()
 
         # First profession call returns one skill tier with one recipe; all others raise.
         # threading.Lock ensures the call counter is safe across asyncio.to_thread workers.

--- a/tests/utils/test_blizzard.py
+++ b/tests/utils/test_blizzard.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 """Tests for blizzard.py utilities."""
 
-from unittest.mock import MagicMock
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
+from models.wow import CraftingRecipeCache
 from utils.blizzard import CRAFTING_PROFESSIONS
 
 
@@ -36,3 +38,71 @@ class TestRoleAutoMatch:
                 matched = prof_id
                 break
         assert matched is None
+
+
+def _make_bot(cache_row_count: int = 0):
+    """Return a (bot, session) pair with a working session_scope context manager."""
+    session = MagicMock()
+    session.query.return_value.count.return_value = cache_row_count
+
+    bot = MagicMock()
+    bot.config.get.return_value = {"wow_id": "fake_id", "wow_secret": "fake_secret"}
+
+    @contextmanager
+    def _scope():
+        yield session
+
+    bot.session_scope = _scope
+    return bot, session
+
+
+def _make_client(fail: bool = False):
+    """Return a mock RetailClient whose profession() either raises or returns empty data."""
+    client = MagicMock()
+    if fail:
+        client.profession.side_effect = RuntimeError("Blizzard API unavailable")
+    else:
+        client.profession.return_value = {}  # no skill_tiers → no rows collected
+    return client
+
+
+class TestSyncCraftingRecipesGuard:
+    """Test the pre-swap guard that protects the cache on partial sync errors."""
+
+    async def test_clean_sync_updates_cache(self):
+        """errors=0 → cache is always replaced."""
+        bot, session = _make_bot(cache_row_count=5)
+        with patch("blizzapi.RetailClient", return_value=_make_client(fail=False)):
+            with patch.object(CraftingRecipeCache, "count", return_value=5):
+                from utils.blizzard import sync_crafting_recipes
+
+                result = await sync_crafting_recipes(bot)
+
+        assert result["errors"] == 0
+        assert result["cache_updated"] is True
+
+    async def test_errors_with_populated_cache_skips_swap(self):
+        """errors>0 and cache has rows → keep stale cache, do not wipe."""
+        bot, session = _make_bot(cache_row_count=10)
+        with patch("blizzapi.RetailClient", return_value=_make_client(fail=True)):
+            with patch.object(CraftingRecipeCache, "count", return_value=10):
+                from utils.blizzard import sync_crafting_recipes
+
+                result = await sync_crafting_recipes(bot)
+
+        assert result["errors"] > 0
+        assert result["cache_updated"] is False
+        # delete_all must NOT have been called — stale rows are preserved
+        session.query.return_value.delete.assert_not_called()
+
+    async def test_errors_with_empty_cache_writes_partial_data(self):
+        """errors>0 but cache is empty → write partial data (something > nothing)."""
+        bot, session = _make_bot(cache_row_count=0)
+        with patch("blizzapi.RetailClient", return_value=_make_client(fail=True)):
+            with patch.object(CraftingRecipeCache, "count", return_value=0):
+                from utils.blizzard import sync_crafting_recipes
+
+                result = await sync_crafting_recipes(bot)
+
+        assert result["errors"] > 0
+        assert result["cache_updated"] is True


### PR DESCRIPTION
## Summary

- Adds a pre-swap guard to `sync_crafting_recipes()`: if the Blizzard API returned errors **and** the cache already has rows, the delete+insert is skipped and stale data is preserved
- Exception: if the cache is empty, partial data is written anyway (something > nothing)
- Adds `cache_updated: bool` to the sync return dict; `!sync recipes` in Discord shows a warning when the swap was skipped
- Adds `CraftingRecipeCache.count()` classmethod used by the guard

## Test plan

- [x] 3 new unit tests covering all guard scenarios (errors=0, errors>0+populated, errors>0+empty) — `tests/utils/test_blizzard.py`
- [x] Full test suite: 920 passed

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin sync command and sync API now include explicit cache update status (top-level and per-item) and surface a conditional warning when the cache wasn’t updated.

* **Bug Fixes**
  * Prevents overwriting an existing populated cache when synchronization errors occur; preserves data and logs a warning.

* **Tests**
  * Added tests for cache-sync guard, error recovery, and partial-write scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->