### PR TITLE
fix(bot): call load_strings() before registering persistent views

### DIFF
--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -240,6 +240,9 @@ class NerpyBot(Bot):
                     self.log.error(f"failed to auto-load {module} extension. {e}")
                     self.log.debug(print_exc())
 
+        # load localization strings before registering persistent views (views call get_string in __init__)
+        load_strings()
+
         # Register persistent views so buttons on old messages keep working
         if "application" in self.modules:
             try:
@@ -270,9 +273,6 @@ class NerpyBot(Bot):
             except Exception as e:
                 self.log.error(f"failed to register crafting order persistent views. {e}")
                 self.log.debug(print_exc())
-
-        # load localization strings
-        load_strings()
 
         # create database/tables and such stuff
         self.create_all()


### PR DESCRIPTION
## Summary

- `ApplicationReviewView.__init__` calls `get_string()` to set button labels, but `_strings` was empty at that point
- `load_strings()` was running *after* `add_view()`, so the localization cache was never populated when views were constructed
- Moved `load_strings()` before the persistent view registration block — fixes the `KeyError: Missing localization key: application.review.btn_vote` crash on startup

## Test plan

- [ ] Bot starts without the `Missing localization key: application.review.btn_vote` error
- [ ] Application review buttons render with correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)