### PR TITLE
feat(cache): in-memory GuildConfigCache to eliminate redundant DB queries

### DIFF
--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -354,12 +354,15 @@ class NerpyBot(Bot):
         except Exception as e:
             self.log.warning(f"Failed to sync BotGuild table: {e}")
 
-        try:
-            self.guild_cache.warm_reaction_roles(self.SESSION)
-            self.guild_cache.warm_leave_messages(self.SESSION)
-            self.log.debug("Guild config cache warmed up.")
-        except Exception as e:
-            self.log.warning(f"Failed to warm guild config cache: {e}")
+        for cache_name, warm in (
+            ("reaction-role", self.guild_cache.warm_reaction_roles),
+            ("leave-message", self.guild_cache.warm_leave_messages),
+        ):
+            try:
+                warm(self.SESSION)
+            except Exception as e:
+                self.log.warning(f"Failed to warm {cache_name} cache: {e}")
+        self.log.debug("Guild config cache warm-up finished.")
 
         required = required_permissions_for(self.modules)
         for guild in self.guilds:

--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -44,6 +44,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from models.admin import BotGuild
 from utils import logging
 from utils.audio import Audio
+from utils.cache import GuildConfigCache
 from utils.config import parse_config
 from utils.conversation import AnswerType, ConversationManager
 from utils.database import BASE
@@ -51,7 +52,7 @@ from utils.error_throttle import ErrorCounter, ErrorThrottle
 from utils.errors import NerpyException, NerpyInfraException, SilentCheckFailure
 from utils.helpers import error_context, notify_error, parse_id, send_hidden_message
 from utils.permissions import build_permissions_embed, check_guild_permissions, required_permissions_for
-from utils.strings import get_localized_string, get_string, load_strings
+from utils.strings import get_string, load_strings
 from utils.valkey import valkey_listener_loop
 
 SENTINEL_PATH = Path("/tmp/nerpybot_ready")
@@ -151,6 +152,7 @@ class NerpyBot(Bot):
         self.error_throttle = ErrorThrottle()
         self.error_counter = ErrorCounter()
         self.disabled_modules: set[str] = set()
+        self.guild_cache = GuildConfigCache()
 
         # database variables
         db_connection_string = self.build_connection_string(config)
@@ -188,6 +190,20 @@ class NerpyBot(Bot):
     def create_all(self) -> None:
         """creates all tables previously defined"""
         BASE.metadata.create_all(self.ENGINE)
+
+    def get_guild_language(self, guild_id: int | None) -> str:
+        """Return the configured language for a guild, defaulting to 'en'.
+
+        Uses the in-memory cache; loads from DB on first access per guild.
+        """
+        if guild_id is None:
+            return "en"
+        return self.guild_cache.get_guild_language(guild_id, self.SESSION)
+
+    def get_localized_string(self, guild_id: int | None, key: str, **kwargs) -> str:
+        """Resolve the guild language from cache, then look up and format a string."""
+        lang = self.get_guild_language(guild_id)
+        return get_string(lang, key, **kwargs)
 
     @contextmanager
     def session_scope(self) -> Generator[Session, Any, None]:
@@ -290,8 +306,7 @@ class NerpyBot(Bot):
         module_name = type(cog).__module__.rsplit(".", 1)[-1]
         if module_name in self.disabled_modules:
             try:
-                with self.session_scope() as session:
-                    msg = get_localized_string(interaction.guild_id, "bot.module_disabled", session, module=module_name)
+                msg = self.get_localized_string(interaction.guild_id, "bot.module_disabled", module=module_name)
             except Exception:
                 msg = get_string("en", "bot.module_disabled", module=module_name)
             if not interaction.response.is_done():
@@ -338,6 +353,13 @@ class NerpyBot(Bot):
                 BotGuild.sync([g.id for g in self.guilds], session)
         except Exception as e:
             self.log.warning(f"Failed to sync BotGuild table: {e}")
+
+        try:
+            self.guild_cache.warm_reaction_roles(self.SESSION)
+            self.guild_cache.warm_leave_messages(self.SESSION)
+            self.log.debug("Guild config cache warmed up.")
+        except Exception as e:
+            self.log.warning(f"Failed to warm guild config cache: {e}")
 
         required = required_permissions_for(self.modules)
         for guild in self.guilds:
@@ -390,8 +412,7 @@ class NerpyBot(Bot):
                 self.log.error(f"{err_ctx}: {error.original.__class__.__name__}: {error.original}")
                 print_tb(error.original.__traceback__)
                 try:
-                    with self.session_scope() as session:
-                        msg = get_localized_string(interaction.guild_id, "common.error_generic", session)
+                    msg = self.get_localized_string(interaction.guild_id, "common.error_generic")
                 except Exception:
                     msg = get_string("en", "common.error_generic")
                 await send_hidden_message(interaction, msg)
@@ -430,6 +451,15 @@ class NerpyBot(Bot):
                 BotGuild.remove(guild.id, session)
         except Exception as e:
             self.log.warning(f"Failed to remove guild {guild.id} from BotGuild table: {e}")
+        self.guild_cache.evict_guild(guild.id)
+
+    async def on_guild_language_changed(self, guild_id: int, language: str) -> None:
+        """Update the language cache when a guild changes its language setting."""
+        self.guild_cache.set_guild_language(guild_id, language)
+
+    async def on_modrole_changed(self, guild_id: int, role_id: int | None) -> None:
+        """Update the modrole cache when a guild's bot-moderator role is set or cleared."""
+        self.guild_cache.set_modrole(guild_id, role_id)
 
     async def on_raw_reaction_add(self, payload: RawReactionActionEvent) -> None:
         """

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -29,7 +29,7 @@ from modules.views.application import check_override_permission
 from sqlalchemy.exc import SQLAlchemyError
 from utils.cog import NerpyBotCog
 from utils.helpers import fetch_message_content
-from utils.strings import get_guild_language, get_raw, get_string
+from utils.strings import get_raw, get_string
 
 
 async def _send_ephemeral(interaction: Interaction, msg: str) -> None:
@@ -72,8 +72,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
         super().__init__(bot)
 
     def _lang(self, guild_id: int) -> str:
-        with self.bot.session_scope() as session:
-            return get_guild_language(guild_id, session)
+        return self.bot.get_guild_language(guild_id)
 
     async def cog_load(self):
         # Ensure any new tables introduced by this cog exist before seeding.
@@ -93,8 +92,8 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
             return _filter_choices(ApplicationForm.get_all_by_guild(interaction.guild.id, session), current)
 
     async def _template_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             templates = ApplicationTemplate.get_available(interaction.guild.id, session)
             choices = []
             for tpl in templates:
@@ -167,7 +166,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
         interaction: Interaction, name: str, session
     ) -> tuple[str, "ApplicationForm"] | None:
         """Look up a form by name; returns (lang, form) or sends an error and returns None."""
-        lang = get_guild_language(interaction.guild_id, session)
+        lang = interaction.client.get_guild_language(interaction.guild_id)
         form = ApplicationForm.get(name, interaction.guild.id, session)
         if not form:
             await interaction.response.send_message(
@@ -406,13 +405,12 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
     @app_commands.command(name="list")
     async def _list(self, interaction: Interaction):
         """List all application forms for this server."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         if not self._has_manage_permission(interaction):
-            lang = self._lang(interaction.guild_id)
             await interaction.response.send_message(get_string(lang, "application.no_permission"), ephemeral=True)
             return
 
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             forms = ApplicationForm.get_all_by_guild(interaction.guild.id, session)
             if not forms:
                 await interaction.response.send_message(get_string(lang, "application.list.empty"), ephemeral=True)
@@ -556,13 +554,12 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
     @template_group.command(name="list")
     async def _template_list(self, interaction: Interaction):
         """Show available application form templates."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         if not self._has_manage_permission(interaction):
-            lang = self._lang(interaction.guild_id)
             await interaction.response.send_message(get_string(lang, "application.no_permission"), ephemeral=True)
             return
 
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             templates = ApplicationTemplate.get_available(interaction.guild.id, session)
             if not templates:
                 await interaction.response.send_message(
@@ -607,13 +604,12 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
     @app_commands.autocomplete(name=_template_autocomplete)
     async def _template_view(self, interaction: Interaction, name: str):
         """Show the contents of a template (questions, approval/denial messages)."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         if not self._has_manage_permission(interaction):
-            lang = self._lang(interaction.guild_id)
             await interaction.response.send_message(get_string(lang, "application.no_permission"), ephemeral=True)
             return
 
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             tpl = ApplicationTemplate.get_by_name(name, interaction.guild.id, session)
             if not tpl:
                 await interaction.response.send_message(
@@ -672,13 +668,12 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
         name: str,
     ):
         """Create a new guild template via DM conversation."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         if not self._has_manage_permission(interaction):
-            lang = self._lang(interaction.guild_id)
             await interaction.response.send_message(get_string(lang, "application.no_permission"), ephemeral=True)
             return
 
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             existing = ApplicationTemplate.get_by_name(name, interaction.guild.id, session)
             if existing and not existing.IsBuiltIn:
                 await interaction.response.send_message(
@@ -821,13 +816,12 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
     @app_commands.autocomplete(form=_form_name_autocomplete)
     async def _template_save(self, interaction: Interaction, form: str, template_name: str):
         """Save an existing form as a guild template."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         if not self._has_manage_permission(interaction):
-            lang = self._lang(interaction.guild_id)
             await interaction.response.send_message(get_string(lang, "application.no_permission"), ephemeral=True)
             return
 
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             src_form = ApplicationForm.get(form, interaction.guild.id, session)
             if not src_form:
                 await interaction.response.send_message(
@@ -869,13 +863,12 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
     @app_commands.autocomplete(template_name=_guild_template_autocomplete)
     async def _template_delete(self, interaction: Interaction, template_name: str):
         """Delete a guild custom template."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         if not self._has_manage_permission(interaction):
-            lang = self._lang(interaction.guild_id)
             await interaction.response.send_message(get_string(lang, "application.no_permission"), ephemeral=True)
             return
 
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             tpl = ApplicationTemplate.get_by_name(template_name, interaction.guild.id, session)
             if not tpl:
                 await interaction.response.send_message(
@@ -1021,13 +1014,12 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
     @app_commands.autocomplete(name=_form_name_autocomplete)
     async def _export(self, interaction: Interaction, name: str):
         """Export an application form as a JSON file via DM."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         if not self._has_manage_permission(interaction):
-            lang = self._lang(interaction.guild_id)
             await interaction.response.send_message(get_string(lang, "application.no_permission"), ephemeral=True)
             return
 
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             form = ApplicationForm.get(name, interaction.guild.id, session)
             if not form:
                 await interaction.response.send_message(

--- a/NerdyPy/modules/league.py
+++ b/NerdyPy/modules/league.py
@@ -9,7 +9,7 @@ from discord.ext.commands import GroupCog
 from utils.cog import NerpyBotCog
 from utils.errors import NerpyInfraException
 from utils.helpers import error_context
-from utils.strings import get_guild_language, get_string
+from utils.strings import get_string
 
 
 class LeagueCommand(Enum):
@@ -30,8 +30,7 @@ class League(NerpyBotCog, GroupCog):
         self.config = self.bot.config["league"]
 
     def _lang(self, guild_id: int) -> str:
-        with self.bot.session_scope() as session:
-            return get_guild_language(guild_id, session)
+        return self.bot.get_guild_language(guild_id)
 
     async def _get_latest_version(self) -> str:
         if self.version is None:

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -19,7 +19,7 @@ from utils.cog import NerpyBotCog
 from utils.errors import NerpyValidationError
 from utils.helpers import fetch_message_content, notify_error, register_before_loop, send_paginated
 from utils.permissions import validate_channel_permissions
-from utils.strings import get_guild_language, get_string
+from utils.strings import get_string
 
 DEFAULT_LEAVE_MESSAGE = "{member} left the server :("
 
@@ -49,8 +49,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
 
     def _lang(self, guild_id):
         """Look up the guild's language preference."""
-        with self.bot.session_scope() as session:
-            return get_guild_language(guild_id, session)
+        return self.bot.get_guild_language(guild_id)
 
     def __init__(self, bot):
         super().__init__(bot)
@@ -71,7 +70,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
                 self.bot.log.debug("Fetching configurations")
                 configurations = AutoKicker.get_all(session)
                 self.bot.log.debug(f"Fetched {len(configurations)} configurations")
-                guild_langs = {c.GuildId: get_guild_language(c.GuildId, session) for c in configurations}
+            guild_langs = {c.GuildId: self.bot.get_guild_language(c.GuildId) for c in configurations}
 
             for configuration in configurations:
                 if configuration is None:
@@ -256,8 +255,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         reminder_message_source: Optional[str] = None,
     ):
         """Activates the AutoKicker. [bot-moderator]"""
-        with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
+        lang = self.bot.get_guild_language(interaction.guild.id)
 
         # Fetch from a message reference if provided
         if reminder_message_source:
@@ -322,8 +320,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         channel_id = channel.id
         channel_name = channel.name
 
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             configuration = AutoDelete.get_by_channel(interaction.guild.id, channel_id, session)
             if configuration is not None:
                 await interaction.response.send_message(
@@ -380,8 +378,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         channel_id = channel.id
         channel_name = channel.name
 
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             configuration = AutoDelete.get_by_channel(interaction.guild.id, channel_id, session)
             if configuration is not None:
                 AutoDelete.delete(interaction.guild.id, channel_id, session)
@@ -404,8 +402,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         interaction
         """
 
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             configurations = AutoDelete.get_by_guild(interaction.guild.id, session)
             if configurations:
                 msg = ""
@@ -446,8 +444,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         channel: discord.TextChannel
             The channel to pause auto-deletion for
         """
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             configuration = AutoDelete.get_by_channel(interaction.guild.id, channel.id, session)
             if configuration is None:
                 await interaction.response.send_message(
@@ -476,8 +474,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         channel: discord.TextChannel
             The channel to resume auto-deletion for
         """
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             configuration = AutoDelete.get_by_channel(interaction.guild.id, channel.id, session)
             if configuration is None:
                 await interaction.response.send_message(
@@ -522,8 +520,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         channel_id = channel.id
         channel_name = channel.name
 
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             configuration = AutoDelete.get_by_channel(interaction.guild.id, channel_id, session)
             if configuration is not None:
                 if delete_older_than is None:
@@ -620,6 +618,9 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         if member.bot:
             return
 
+        if not self.bot.guild_cache.is_leave_message_guild(member.guild.id):
+            return
+
         with self.bot.session_scope() as session:
             leave_config = LeaveMessage.get(member.guild.id, session)
 
@@ -669,8 +670,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         """
         validate_channel_permissions(channel, interaction.guild, "view_channel", "send_messages")
 
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             leave_config = LeaveMessage.get(interaction.guild.id, session)
             if leave_config is None:
                 leave_config = LeaveMessage(
@@ -686,6 +687,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
                 if leave_config.Message is None:
                     leave_config.Message = DEFAULT_LEAVE_MESSAGE
 
+        self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, True)
         await interaction.response.send_message(
             get_string(lang, "leavemsg.enable.success", channel=channel.mention), ephemeral=True
         )
@@ -694,13 +696,14 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
     @checks.has_permissions(administrator=True)
     async def _leavemsg_disable(self, interaction: Interaction) -> None:
         """Disable leave messages for this server. [administrator]"""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             leave_config = LeaveMessage.get(interaction.guild.id, session)
             if leave_config is None:
                 raise NerpyValidationError(get_string(lang, "leavemsg.disable.not_configured"))
             leave_config.Enabled = False
 
+        self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, False)
         await interaction.response.send_message(get_string(lang, "leavemsg.disable.success"), ephemeral=True)
 
     async def save_leave_message(self, interaction: Interaction, message: str, lang: str) -> None:
@@ -736,8 +739,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         message_source: Optional[str] = None,
     ) -> None:
         """Set a custom leave message. Use {member} as placeholder. [administrator]"""
-        with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
+        lang = self.bot.get_guild_language(interaction.guild_id)
 
         # Path 1: fetch from an existing Discord message
         if message_source:
@@ -762,8 +764,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
     @checks.has_permissions(administrator=True)
     async def _leavemsg_status(self, interaction: Interaction) -> None:
         """Show current leave message configuration. [administrator]"""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             leave_config = LeaveMessage.get(interaction.guild.id, session)
 
         if leave_config is None or not leave_config.Enabled:

--- a/NerdyPy/modules/music.py
+++ b/NerdyPy/modules/music.py
@@ -14,7 +14,7 @@ from utils.checks import is_connected_to_voice
 from utils.cog import NerpyBotCog
 from utils.download import download, fetch_yt_infos
 from utils.helpers import error_context, youtube
-from utils.strings import get_guild_language, get_string
+from utils.strings import get_string
 
 
 @app_commands.guild_only()
@@ -39,8 +39,7 @@ class Music(NerpyBotCog, QueueMixin, Cog):
         self.audio._on_song_start_hook = None
 
     def _lang(self, guild_id: int) -> str:
-        with self.bot.session_scope() as session:
-            return get_guild_language(guild_id, session)
+        return self.bot.get_guild_language(guild_id)
 
     async def _handle_song_start(self, guild_id: int, song: QueuedSong) -> None:
         """Called by Audio._play() when a new song starts. Creates or updates the now-playing embed."""

--- a/NerdyPy/modules/operator.py
+++ b/NerdyPy/modules/operator.py
@@ -16,7 +16,7 @@ from utils.constants import PROTECTED_MODULES
 from utils.duration import parse_duration
 from utils.errors import NerpyInfraException, NerpyPermissionError
 from utils.permissions import build_permissions_embed, check_guild_permissions, required_permissions_for
-from utils.strings import get_guild_language, get_string
+from utils.strings import get_string
 
 
 def _format_remaining(seconds: float) -> str:
@@ -69,8 +69,8 @@ class Operator(NerpyBotCog, Cog):
     @botpermissions.command(name="subscribe")
     async def _botpermissions_subscribe(self, interaction: Interaction) -> None:
         """Get DM notifications about missing permissions on bot restart."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             existing = PermissionSubscriber.get(interaction.guild.id, interaction.user.id, session)
             if existing is not None:
                 await interaction.response.send_message(
@@ -83,8 +83,8 @@ class Operator(NerpyBotCog, Cog):
     @botpermissions.command(name="unsubscribe")
     async def _botpermissions_unsubscribe(self, interaction: Interaction) -> None:
         """Stop receiving DM notifications about missing permissions."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             existing = PermissionSubscriber.get(interaction.guild.id, interaction.user.id, session)
             if existing is None:
                 await interaction.response.send_message(

--- a/NerdyPy/modules/reminder.py
+++ b/NerdyPy/modules/reminder.py
@@ -15,7 +15,7 @@ from utils.duration import parse_duration
 from utils.helpers import notify_error, register_before_loop, send_paginated
 from utils.permissions import validate_channel_permissions
 from utils.schedule import compute_next_fire
-from utils.strings import get_guild_language, get_string
+from utils.strings import get_string
 
 LOOP_MAX_SECONDS = 60.0
 LOOP_MIN_SECONDS = 5.0
@@ -147,8 +147,7 @@ class Reminder(NerpyBotCog, GroupCog, group_name="reminder"):
 
     def _lang(self, guild_id):
         """Look up the guild's language preference."""
-        with self.bot.session_scope() as session:
-            return get_guild_language(guild_id, session)
+        return self.bot.get_guild_language(guild_id)
 
     # -- /reminder create ----------------------------------------------
 
@@ -182,8 +181,8 @@ class Reminder(NerpyBotCog, GroupCog, group_name="reminder"):
         schedule_type = "interval" if repeat else "once"
         next_fire = datetime.now(UTC) + td
 
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             reminder = ReminderMessage(
                 GuildId=interaction.guild.id,
                 ChannelId=target.id,
@@ -332,8 +331,8 @@ class Reminder(NerpyBotCog, GroupCog, group_name="reminder"):
     @app_commands.command(name="list")
     async def _reminder_list(self, interaction: Interaction):
         """List all current reminder messages."""
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             msgs = ReminderMessage.get_all_by_guild(interaction.guild.id, session)
             if not msgs:
                 await interaction.response.send_message(get_string(lang, "reminder.no_reminders"), ephemeral=True)
@@ -444,8 +443,8 @@ class Reminder(NerpyBotCog, GroupCog, group_name="reminder"):
         timezone: Optional[str] = None,
     ):
         """Edit an existing reminder's message, channel, or timing."""
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             msg = ReminderMessage.get_by_id(reminder_id, interaction.guild.id, session)
             if msg is None:
                 await interaction.response.send_message(get_string(lang, "reminder.not_found"), ephemeral=True)
@@ -600,8 +599,8 @@ class Reminder(NerpyBotCog, GroupCog, group_name="reminder"):
     @app_commands.autocomplete(reminder_id=_reminder_id_autocomplete)
     async def _reminder_delete(self, interaction: Interaction, reminder_id: int):
         """Delete a reminder message."""
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             ReminderMessage.delete(reminder_id, interaction.guild.id, session)
         self._reschedule()
         await interaction.response.send_message(get_string(lang, "reminder.delete.success"), ephemeral=True)
@@ -612,8 +611,8 @@ class Reminder(NerpyBotCog, GroupCog, group_name="reminder"):
     @app_commands.autocomplete(reminder_id=_reminder_id_autocomplete)
     async def _reminder_pause(self, interaction: Interaction, reminder_id: int):
         """Pause a reminder without deleting it."""
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             msg = ReminderMessage.get_by_id(reminder_id, interaction.guild.id, session)
             if msg is None:
                 await interaction.response.send_message(get_string(lang, "reminder.not_found"), ephemeral=True)
@@ -635,8 +634,8 @@ class Reminder(NerpyBotCog, GroupCog, group_name="reminder"):
     @app_commands.autocomplete(reminder_id=_reminder_id_autocomplete)
     async def _reminder_resume(self, interaction: Interaction, reminder_id: int):
         """Resume a paused reminder."""
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             msg = ReminderMessage.get_by_id(reminder_id, interaction.guild.id, session)
             if msg is None:
                 await interaction.response.send_message(get_string(lang, "reminder.not_found"), ephemeral=True)

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -13,7 +13,7 @@ from utils.checks import is_role_assignable, is_role_below_bot
 from utils.cog import NerpyBotCog
 from utils.helpers import error_context, notify_error, send_paginated
 from utils.permissions import validate_channel_permissions
-from utils.strings import get_guild_language, get_string
+from utils.strings import get_string
 
 
 class Roles(NerpyBotCog, Cog):
@@ -42,8 +42,7 @@ class Roles(NerpyBotCog, Cog):
     # ── reactionrole helpers ──────────────────────────────────────────────────
 
     def _lang(self, guild_id: int) -> str:
-        with self.bot.session_scope() as session:
-            return get_guild_language(guild_id, session)
+        return self.bot.get_guild_language(guild_id)
 
     async def _message_id_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
         with self.bot.session_scope() as session:
@@ -64,6 +63,9 @@ class Roles(NerpyBotCog, Cog):
 
     def _get_role_for_reaction(self, payload):
         """Look up the role for a given reaction event payload."""
+        if not self.bot.guild_cache.is_reaction_role_message(payload.message_id):
+            return None
+
         with self.bot.session_scope() as session:
             rr_msg = ReactionRoleMessage.get_by_message(payload.message_id, session)
             if rr_msg is None:
@@ -170,9 +172,9 @@ class Roles(NerpyBotCog, Cog):
         if not await is_role_below_bot(interaction, target_role):
             return
 
+        lang = self.bot.get_guild_language(interaction.guild_id)
         error_msg = None
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             existing = RoleMapping.get(interaction.guild.id, source_role.id, target_role.id, session)
             if existing:
                 error_msg = get_string(
@@ -208,8 +210,8 @@ class Roles(NerpyBotCog, Cog):
         target_role: discord.Role
             The target role
         """
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             deleted = RoleMapping.delete(interaction.guild.id, source_role.id, target_role.id, session)
 
         if deleted:
@@ -224,8 +226,8 @@ class Roles(NerpyBotCog, Cog):
     @checks.has_permissions(manage_roles=True)
     async def _rolemanage_list(self, interaction: Interaction):
         """List all delegated role mappings for this server. [manage_roles]"""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             mappings = RoleMapping.get_by_guild(interaction.guild.id, session)
             msg = ""
             for m in mappings:
@@ -260,8 +262,8 @@ class Roles(NerpyBotCog, Cog):
         if not await is_role_below_bot(interaction, role):
             return
 
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             mappings = RoleMapping.get_by_target(interaction.guild.id, role.id, session)
 
         if not mappings or not self._has_source_role(interaction.user, mappings):
@@ -311,8 +313,8 @@ class Roles(NerpyBotCog, Cog):
         if not await is_role_below_bot(interaction, role):
             return
 
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             mappings = RoleMapping.get_by_target(interaction.guild.id, role.id, session)
 
         if not mappings or not self._has_source_role(interaction.user, mappings):
@@ -419,6 +421,8 @@ class Roles(NerpyBotCog, Cog):
             await interaction.response.send_message(error_msg, ephemeral=True)
             return
 
+        self.bot.guild_cache.add_reaction_role_message(msg_id)
+
         try:
             await discord_msg.add_reaction(emoji)
         except HTTPException as ex:
@@ -449,10 +453,11 @@ class Roles(NerpyBotCog, Cog):
             await interaction.response.send_message("Invalid message ID.", ephemeral=True)
             return
 
+        lang = self.bot.get_guild_language(interaction.guild_id)
         reply = None
         channel_id = None
+        last_entry_removed = False
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             rr_msg = ReactionRoleMessage.get_by_message(msg_id, session)
             if rr_msg is None:
                 reply = get_string(lang, "reactionrole.remove.no_config")
@@ -467,10 +472,14 @@ class Roles(NerpyBotCog, Cog):
                     # clean up the parent if no entries remain
                     if len(rr_msg.entries) == 1:
                         session.delete(rr_msg)
+                        last_entry_removed = True
 
         if reply:
             await interaction.response.send_message(reply, ephemeral=True)
             return
+
+        if last_entry_removed:
+            self.bot.guild_cache.remove_reaction_role_message(msg_id)
 
         await self._clear_reaction(interaction.guild, channel_id, msg_id, emoji)
         await interaction.response.send_message(
@@ -481,8 +490,8 @@ class Roles(NerpyBotCog, Cog):
     @checks.has_permissions(manage_roles=True)
     async def _reactionrole_list(self, interaction: Interaction):
         """List all reaction role configurations for this server."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             messages = ReactionRoleMessage.get_by_guild(interaction.guild.id, session)
             msg = ""
             for rr_msg in messages:
@@ -524,10 +533,10 @@ class Roles(NerpyBotCog, Cog):
             await interaction.response.send_message("Invalid message ID.", ephemeral=True)
             return
 
+        lang = self.bot.get_guild_language(interaction.guild_id)
         channel_id = None
         emojis = []
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             rr_msg = ReactionRoleMessage.get_by_message(msg_id, session)
             if rr_msg is None:
                 no_config_msg = get_string(lang, "reactionrole.remove.no_config")
@@ -540,6 +549,8 @@ class Roles(NerpyBotCog, Cog):
         if no_config_msg:
             await interaction.response.send_message(no_config_msg, ephemeral=True)
             return
+
+        self.bot.guild_cache.remove_reaction_role_message(msg_id)
 
         await asyncio.gather(
             *[self._clear_reaction(interaction.guild, channel_id, msg_id, emoji) for emoji in emojis],

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -421,7 +421,7 @@ class Roles(NerpyBotCog, Cog):
             await interaction.response.send_message(error_msg, ephemeral=True)
             return
 
-        self.bot.guild_cache.add_reaction_role_message(msg_id)
+        self.bot.guild_cache.add_reaction_role_message(interaction.guild.id, msg_id)
 
         try:
             await discord_msg.add_reaction(emoji)
@@ -479,7 +479,7 @@ class Roles(NerpyBotCog, Cog):
             return
 
         if last_entry_removed:
-            self.bot.guild_cache.remove_reaction_role_message(msg_id)
+            self.bot.guild_cache.remove_reaction_role_message(interaction.guild.id, msg_id)
 
         await self._clear_reaction(interaction.guild, channel_id, msg_id, emoji)
         await interaction.response.send_message(
@@ -550,7 +550,7 @@ class Roles(NerpyBotCog, Cog):
             await interaction.response.send_message(no_config_msg, ephemeral=True)
             return
 
-        self.bot.guild_cache.remove_reaction_role_message(msg_id)
+        self.bot.guild_cache.remove_reaction_role_message(interaction.guild.id, msg_id)
 
         await asyncio.gather(
             *[self._clear_reaction(interaction.guild, channel_id, msg_id, emoji) for emoji in emojis],

--- a/NerdyPy/modules/server_admin.py
+++ b/NerdyPy/modules/server_admin.py
@@ -50,6 +50,7 @@ class ServerAdmin(NerpyBotCog, Cog):
                 entry = BotModeratorRole(GuildId=interaction.guild.id)
                 session.add(entry)
             entry.RoleId = role.id
+        self.bot.guild_cache.set_modrole(interaction.guild.id, role.id)
         lang = self.bot.get_guild_language(interaction.guild_id)
         await interaction.response.send_message(
             get_string(lang, "admin.modrole.set_success", role=role.name), ephemeral=True
@@ -61,6 +62,7 @@ class ServerAdmin(NerpyBotCog, Cog):
         """Remove the bot-moderator role configuration."""
         with self.bot.session_scope() as session:
             BotModeratorRole.delete(interaction.guild.id, session)
+        self.bot.guild_cache.set_modrole(interaction.guild.id, None)
         lang = self.bot.get_guild_language(interaction.guild_id)
         await interaction.response.send_message(get_string(lang, "admin.modrole.delete_success"), ephemeral=True)
         self.bot.dispatch("modrole_changed", interaction.guild.id, None)

--- a/NerdyPy/modules/server_admin.py
+++ b/NerdyPy/modules/server_admin.py
@@ -6,7 +6,7 @@ from discord.ext.commands import Cog
 from models.admin import BotModeratorRole, GuildLanguageConfig
 from utils.checks import is_admin_or_operator
 from utils.cog import NerpyBotCog
-from utils.strings import available_languages, get_guild_language, get_localized_string, get_string
+from utils.strings import available_languages, get_string
 
 
 @app_commands.default_permissions(administrator=True)
@@ -27,41 +27,43 @@ class ServerAdmin(NerpyBotCog, Cog):
     @modrole.command(name="get")
     async def _modrole_get(self, interaction: Interaction):
         """Show the currently configured bot-moderator role."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             entry = BotModeratorRole.get(interaction.guild.id, session)
-            if entry is not None:
-                role = interaction.guild.get_role(entry.RoleId)
-                msg = (
-                    get_string(lang, "admin.modrole.get_current", role=role.name)
-                    if role is not None
-                    else get_string(lang, "admin.modrole.get_stale")
-                )
-            else:
-                msg = get_string(lang, "admin.modrole.get_none")
+        if entry is not None:
+            role = interaction.guild.get_role(entry.RoleId)
+            msg = (
+                get_string(lang, "admin.modrole.get_current", role=role.name)
+                if role is not None
+                else get_string(lang, "admin.modrole.get_stale")
+            )
+        else:
+            msg = get_string(lang, "admin.modrole.get_none")
         await interaction.response.send_message(msg, ephemeral=True)
 
     @modrole.command(name="set")
     async def _modrole_set(self, interaction: Interaction, role: Role):
         """Set the bot-moderator role for this server."""
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             entry = BotModeratorRole.get(interaction.guild.id, session)
             if entry is None:
                 entry = BotModeratorRole(GuildId=interaction.guild.id)
                 session.add(entry)
             entry.RoleId = role.id
+        lang = self.bot.get_guild_language(interaction.guild_id)
         await interaction.response.send_message(
             get_string(lang, "admin.modrole.set_success", role=role.name), ephemeral=True
         )
+        self.bot.dispatch("modrole_changed", interaction.guild.id, role.id)
 
     @modrole.command(name="delete")
     async def _modrole_del(self, interaction: Interaction):
         """Remove the bot-moderator role configuration."""
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             BotModeratorRole.delete(interaction.guild.id, session)
+        lang = self.bot.get_guild_language(interaction.guild_id)
         await interaction.response.send_message(get_string(lang, "admin.modrole.delete_success"), ephemeral=True)
+        self.bot.dispatch("modrole_changed", interaction.guild.id, None)
 
     @language.command(name="set")
     @app_commands.describe(language="Language code to set for this server")
@@ -69,14 +71,12 @@ class ServerAdmin(NerpyBotCog, Cog):
         """Set the server's language preference for bot responses."""
         language = language.lower()
         if language not in available_languages():
-            with self.bot.session_scope() as session:
-                msg = get_localized_string(
-                    interaction.guild.id,
-                    "admin.language.invalid",
-                    session,
-                    language=language,
-                    available=", ".join(sorted(available_languages())),
-                )
+            msg = self.bot.get_localized_string(
+                interaction.guild.id,
+                "admin.language.invalid",
+                language=language,
+                available=", ".join(sorted(available_languages())),
+            )
             await interaction.response.send_message(msg, ephemeral=True)
             return
 
@@ -87,14 +87,9 @@ class ServerAdmin(NerpyBotCog, Cog):
                 session.add(config)
             config.Language = language
 
-        # Read back with new language so confirmation is in the newly set language
-        with self.bot.session_scope() as session:
-            msg = get_localized_string(
-                interaction.guild.id,
-                "admin.language.set_success",
-                session,
-                language=language,
-            )
+        # Update cache immediately so confirmation reply uses the new language
+        self.bot.guild_cache.set_guild_language(interaction.guild.id, language)
+        msg = self.bot.get_localized_string(interaction.guild.id, "admin.language.set_success", language=language)
         await interaction.response.send_message(msg, ephemeral=True)
         self.bot.dispatch("guild_language_changed", interaction.guild.id, language)
 
@@ -103,15 +98,14 @@ class ServerAdmin(NerpyBotCog, Cog):
         """Show the current language preference for this server."""
         with self.bot.session_scope() as session:
             config = GuildLanguageConfig.get(interaction.guild.id, session)
-            if config is not None:
-                msg = get_localized_string(
-                    interaction.guild.id,
-                    "admin.language.get_current",
-                    session,
-                    language=config.Language,
-                )
-            else:
-                msg = get_localized_string(interaction.guild.id, "admin.language.get_default", session)
+        if config is not None:
+            msg = self.bot.get_localized_string(
+                interaction.guild.id,
+                "admin.language.get_current",
+                language=config.Language,
+            )
+        else:
+            msg = self.bot.get_localized_string(interaction.guild.id, "admin.language.get_default")
         await interaction.response.send_message(msg, ephemeral=True)
 
     async def _language_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:

--- a/NerdyPy/modules/server_admin.py
+++ b/NerdyPy/modules/server_admin.py
@@ -50,6 +50,8 @@ class ServerAdmin(NerpyBotCog, Cog):
                 entry = BotModeratorRole(GuildId=interaction.guild.id)
                 session.add(entry)
             entry.RoleId = role.id
+        # Update cache before await so any permission check in the send window sees the new role
+        self.bot.guild_cache.set_modrole(interaction.guild.id, role.id)
         lang = self.bot.get_guild_language(interaction.guild_id)
         await interaction.response.send_message(
             get_string(lang, "admin.modrole.set_success", role=role.name), ephemeral=True
@@ -61,6 +63,8 @@ class ServerAdmin(NerpyBotCog, Cog):
         """Remove the bot-moderator role configuration."""
         with self.bot.session_scope() as session:
             BotModeratorRole.delete(interaction.guild.id, session)
+        # Update cache before await so any permission check in the send window sees the cleared role
+        self.bot.guild_cache.set_modrole(interaction.guild.id, None)
         lang = self.bot.get_guild_language(interaction.guild_id)
         await interaction.response.send_message(get_string(lang, "admin.modrole.delete_success"), ephemeral=True)
         self.bot.dispatch("modrole_changed", interaction.guild.id, None)

--- a/NerdyPy/modules/server_admin.py
+++ b/NerdyPy/modules/server_admin.py
@@ -50,7 +50,6 @@ class ServerAdmin(NerpyBotCog, Cog):
                 entry = BotModeratorRole(GuildId=interaction.guild.id)
                 session.add(entry)
             entry.RoleId = role.id
-        self.bot.guild_cache.set_modrole(interaction.guild.id, role.id)
         lang = self.bot.get_guild_language(interaction.guild_id)
         await interaction.response.send_message(
             get_string(lang, "admin.modrole.set_success", role=role.name), ephemeral=True
@@ -62,7 +61,6 @@ class ServerAdmin(NerpyBotCog, Cog):
         """Remove the bot-moderator role configuration."""
         with self.bot.session_scope() as session:
             BotModeratorRole.delete(interaction.guild.id, session)
-        self.bot.guild_cache.set_modrole(interaction.guild.id, None)
         lang = self.bot.get_guild_language(interaction.guild_id)
         await interaction.response.send_message(get_string(lang, "admin.modrole.delete_success"), ephemeral=True)
         self.bot.dispatch("modrole_changed", interaction.guild.id, None)

--- a/NerdyPy/modules/tagging.py
+++ b/NerdyPy/modules/tagging.py
@@ -15,7 +15,7 @@ from utils.cog import NerpyBotCog
 from utils.download import download
 from utils.errors import NerpyNotFoundError
 from utils.helpers import error_context, send_paginated
-from utils.strings import get_guild_language, get_string
+from utils.strings import get_string
 
 
 @app_commands.guild_only()
@@ -31,8 +31,7 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
         self.audio = self.bot.audio
 
     def _lang(self, guild_id: int) -> str:
-        with self.bot.session_scope() as session:
-            return get_guild_language(guild_id, session)
+        return self.bot.get_guild_language(guild_id)
 
     async def _tag_name_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
         with self.bot.session_scope() as session:
@@ -75,8 +74,8 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
         self, interaction: Interaction, name: str, tag_type: Literal["sound", "text", "url"], content: str
     ) -> None:
         """Create Tags."""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             if Tag.exists(name, interaction.guild.id, session):
                 await interaction.response.send_message(
                     get_string(lang, "tagging.create.already_exists", name=name), ephemeral=True
@@ -110,8 +109,8 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
     @app_commands.autocomplete(name=_tag_name_autocomplete)
     async def _tag_add(self, interaction: Interaction, name: str, content: str):
         """add an entry to an existing tag"""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             if not Tag.exists(name, interaction.guild.id, session):
                 await interaction.response.send_message(
                     get_string(lang, "tagging.not_found", name=name), ephemeral=True
@@ -154,8 +153,8 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
     async def _tag_delete(self, interaction: Interaction, name: str):
         """delete a tag?"""
         self.bot.log.info(f'{error_context(interaction)}: deleting tag "{name}"')
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             if not Tag.exists(name, interaction.guild.id, session):
                 await interaction.response.send_message(
                     get_string(lang, "tagging.not_found", name=name), ephemeral=True
@@ -174,8 +173,8 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
     @app_commands.command(name="list")
     async def _tag_list(self, interaction: Interaction):
         """a list of all available tags"""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             tags = Tag.get_all_from_guild(interaction.guild.id, session)
 
             if not tags:
@@ -202,8 +201,8 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
     @app_commands.autocomplete(name=_tag_name_autocomplete)
     async def _tag_info(self, interaction: Interaction, name: str):
         """information about the tag"""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             t = Tag.get(name, interaction.guild.id, session)
             emoji = self._TAG_TYPE_EMOJI.get(t.Type, "\u2753")
             tag_type = TagType(t.Type).name.capitalize()
@@ -224,8 +223,8 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
     @app_commands.autocomplete(name=_tag_name_autocomplete)
     async def _tag_raw(self, interaction: Interaction, name: str):
         """raw tag data"""
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             t = Tag.get(name, interaction.guild.id, session)
             msg = ""
             for i, entry in enumerate(t.entries.all(), start=1):
@@ -240,8 +239,8 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
 
     async def _send_to_queue(self, interaction: Interaction, tag_name):
         self.bot.log.info(f'{error_context(interaction)}: requesting tag "{tag_name}"')
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             _tag = Tag.get(tag_name, interaction.guild.id, session)
             if _tag is None:
                 raise NerpyNotFoundError(get_string(lang, "tagging.get.not_found", name=tag_name))

--- a/NerdyPy/modules/views/application.py
+++ b/NerdyPy/modules/views/application.py
@@ -22,7 +22,7 @@ from models.application import (
     SubmissionStatus,
     VoteType,
 )
-from utils.strings import get_guild_language, get_string
+from utils.strings import get_string
 
 
 # ---------------------------------------------------------------------------
@@ -137,7 +137,7 @@ async def _update_review_embed(
             bot.log.warning("application: no submission found for review message %d — was it deleted?", msg_id)
             return
         form = ApplicationForm.get_by_id(submission.FormId, session)
-        lang = get_guild_language(submission.GuildId, session)
+        lang = bot.get_guild_language(submission.GuildId)
         embed = build_review_embed(submission, form, session, lang)
         status = submission.Status
         applicant_notified = submission.ApplicantNotified
@@ -313,7 +313,7 @@ async def _post_edit_and_update_embed(
 
 async def _validate_review_interaction(bot, interaction, session):
     """Check permission, look up submission, verify pending. Returns (lang, submission, existing_vote) or None."""
-    lang = get_guild_language(interaction.guild_id, session)
+    lang = bot.get_guild_language(interaction.guild_id)
     if not check_application_permission(interaction, bot):
         await interaction.response.send_message(
             get_string(lang, "application.review.no_review_permission"), ephemeral=True
@@ -893,8 +893,7 @@ class ApplicationReviewView(discord.ui.View):
     async def on_error(self, interaction: discord.Interaction, error: Exception, item: discord.ui.Item):
         if self.bot:
             self.bot.log.error("Error in ApplicationReviewView: %s", error, exc_info=error)
-            with self.bot.session_scope() as session:
-                lang = get_guild_language(interaction.guild_id, session)
+            lang = self.bot.get_guild_language(interaction.guild_id)
         else:
             lang = "en"
         msg = get_string(lang, "application.error_generic")
@@ -969,16 +968,14 @@ class ApplicationReviewView(discord.ui.View):
 
     @discord.ui.button(label="Message", style=discord.ButtonStyle.grey, custom_id="app_review_message")
     async def message_applicant(self, interaction: discord.Interaction, button: discord.ui.Button):
+        lang = self.bot.get_guild_language(interaction.guild_id)
         if not check_application_permission(interaction, self.bot):
-            with self.bot.session_scope() as session:
-                lang = get_guild_language(interaction.guild_id, session)
             await interaction.response.send_message(
                 get_string(lang, "application.review.no_review_permission"), ephemeral=True
             )
             return
 
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             submission = ApplicationSubmission.get_by_review_message(interaction.message.id, session)
             if submission is None:
                 await interaction.response.send_message(
@@ -1017,16 +1014,14 @@ class ApplicationReviewView(discord.ui.View):
 
     @discord.ui.button(label="Override", style=discord.ButtonStyle.danger, custom_id="app_review_override")
     async def override(self, interaction: discord.Interaction, button: discord.ui.Button):
+        lang = self.bot.get_guild_language(interaction.guild_id)
         if not check_override_permission(interaction, self.bot):
-            with self.bot.session_scope() as session:
-                lang = get_guild_language(interaction.guild_id, session)
             await interaction.response.send_message(
                 get_string(lang, "application.review.no_override_permission"), ephemeral=True
             )
             return
 
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             submission = ApplicationSubmission.get_by_review_message(interaction.message.id, session)
             if submission is None:
                 await interaction.response.send_message(
@@ -1102,7 +1097,7 @@ async def post_apply_button_message(bot, form_id: int) -> None:
         old_message_id = form.ApplyMessageId
         form_name = form.Name
         description = form.ApplyDescription
-        lang = get_guild_language(form.GuildId, session)
+        lang = bot.get_guild_language(form.GuildId)
 
     # Delete old message if it exists
     if old_message_id:
@@ -1141,7 +1136,7 @@ async def edit_apply_button_message(bot, form_id: int) -> None:
         message_id = form.ApplyMessageId
         form_name = form.Name
         description = form.ApplyDescription
-        lang = get_guild_language(form.GuildId, session)
+        lang = bot.get_guild_language(form.GuildId)
 
     try:
         channel = bot.get_channel(channel_id)
@@ -1176,8 +1171,7 @@ class ApplicationApplyView(discord.ui.View):
     async def on_error(self, interaction: discord.Interaction, error: Exception, item: discord.ui.Item):
         if self.bot:
             self.bot.log.error("Error in ApplicationApplyView: %s", error, exc_info=error)
-            with self.bot.session_scope() as session:
-                lang = get_guild_language(interaction.guild_id, session)
+            lang = self.bot.get_guild_language(interaction.guild_id)
         else:
             lang = "en"
         msg = get_string(lang, "application.error_generic")
@@ -1189,8 +1183,8 @@ class ApplicationApplyView(discord.ui.View):
     @discord.ui.button(label="Apply", style=discord.ButtonStyle.green, custom_id="app_apply_button")
     async def apply_button(self, interaction: discord.Interaction, button: discord.ui.Button):
         # 1. Look up form via apply message ID
+        lang = self.bot.get_guild_language(interaction.guild_id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
             form = ApplicationForm.get_by_apply_message(interaction.message.id, session)
             if form is None:
                 await interaction.response.send_message(

--- a/NerdyPy/modules/views/crafting_order.py
+++ b/NerdyPy/modules/views/crafting_order.py
@@ -18,15 +18,14 @@ from models.wow import (
     CraftingRoleMapping,
 )
 from utils.blizzard import CRAFTING_PROFESSIONS
-from utils.strings import get_guild_language, get_localized_string, get_string
+from utils.strings import get_string
 
 log = logging.getLogger(__name__)
 
 
 def _ls(interaction: Interaction, key: str, **kwargs) -> str:
     """Shorthand for localized string lookup."""
-    with interaction.client.session_scope() as session:
-        return get_localized_string(interaction.guild_id, f"wow.craftingorder.{key}", session, **kwargs)
+    return interaction.client.get_localized_string(interaction.guild_id, f"wow.craftingorder.{key}", **kwargs)
 
 
 def _get_locale(locales: dict | None, lang: str) -> str | None:
@@ -169,7 +168,7 @@ class CraftingBoardView(ui.View):
         """Load board lang + role maps from DB. Returns None if no board is configured for the guild."""
         if CraftingBoardConfig.get_by_guild(guild_id, session) is None:
             return None
-        lang = get_guild_language(guild_id, session)
+        lang = self.bot.get_guild_language(guild_id)
         mapped_prof_ids: set[int] = set()
         mapping_role_ids: list[int] = []
         for m in CraftingRoleMapping.get_by_guild(guild_id, session):
@@ -448,9 +447,9 @@ class ItemSelectView(ui.View):
 
         if value == self._OTHER_VALUE:
             # Fall back to profession select (free-text)
+            lang = self.bot.get_guild_language(interaction.guild_id)
             with self.bot.session_scope() as session:
                 mappings = CraftingRoleMapping.get_by_guild(interaction.guild_id, session)
-                lang = get_guild_language(interaction.guild_id, session)
             roles_found = [r for m in mappings if (r := interaction.guild.get_role(m.RoleId))]
             if not roles_found:
                 await interaction.response.edit_message(
@@ -685,7 +684,7 @@ class CraftingOrderModal(ui.Modal):
         with self.bot.session_scope() as session:
             config = CraftingBoardConfig.get_by_guild(self.guild_id, session)
             if config is not None:
-                lang = get_guild_language(self.guild_id, session)
+                lang = self.bot.get_guild_language(self.guild_id)
                 channel_id = config.ChannelId
 
                 order = CraftingOrder(
@@ -799,7 +798,7 @@ class AcceptOrderButton(ui.DynamicItem[ui.Button], template=r"crafting:accept:(?
                 not_open = True
             else:
                 order = CraftingOrder.get_by_id(self.order_id, session)
-                lang = get_guild_language(interaction.guild_id, session)
+                lang = interaction.client.get_guild_language(interaction.guild_id)
                 embed = build_order_embed(order, interaction.guild, lang)
                 view = build_order_view(order.Id, "in_progress", lang)
         if not_open:
@@ -841,7 +840,7 @@ class DropOrderButton(ui.DynamicItem[ui.Button], template=r"crafting:drop:(?P<or
             order.Status = "open"
             order.CrafterId = None
             order.CrafterName = None
-            lang = get_guild_language(interaction.guild_id, session)
+            lang = interaction.client.get_guild_language(interaction.guild_id)
             embed = build_order_embed(order, interaction.guild, lang)
             view = build_order_view(order.Id, "open", lang)
         await interaction.response.edit_message(embed=embed, view=view)
@@ -1002,8 +1001,7 @@ class AskQuestionButton(ui.DynamicItem[ui.Button], template=r"crafting:ask:(?P<o
         return cls(order_id=int(match["order_id"]))
 
     async def callback(self, interaction: Interaction):
-        with interaction.client.session_scope() as session:
-            lang = get_guild_language(interaction.guild_id, session)
+        lang = interaction.client.get_guild_language(interaction.guild_id)
         modal = AskQuestionModal(self.order_id, lang)
         await interaction.response.send_modal(modal)
 

--- a/NerdyPy/modules/wow.py
+++ b/NerdyPy/modules/wow.py
@@ -47,7 +47,7 @@ from utils.errors import (
 )
 from utils.helpers import notify_error, register_before_loop, send_paginated
 from utils.permissions import validate_channel_permissions
-from utils.strings import get_guild_language, get_string
+from utils.strings import get_string
 
 
 class WowApiLanguage(Enum):
@@ -77,8 +77,7 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
 
     def _lang(self, guild_id):
         """Look up the guild's language preference."""
-        with self.bot.session_scope() as session:
-            return get_guild_language(guild_id, session)
+        return self.bot.get_guild_language(guild_id)
 
     def __init__(self, bot):
         super().__init__(bot)
@@ -525,8 +524,8 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
     @checks.has_permissions(manage_channels=True)
     async def _guildnews_remove(self, interaction: Interaction, config: int):
         """remove a guild news tracking config [manage_channels]"""
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             cfg = WowGuildNewsConfig.get_by_id(config, interaction.guild.id, session)
             if not cfg:
                 await interaction.response.send_message(
@@ -541,8 +540,8 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
     @guildnews.command(name="list")
     async def _guildnews_list(self, interaction: Interaction):
         """list all tracked WoW guilds for this server"""
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             configs = WowGuildNewsConfig.get_all_by_guild(interaction.guild.id, session)
             if not configs:
                 await interaction.response.send_message(get_string(lang, "wow.guildnews.list.empty"), ephemeral=True)
@@ -573,8 +572,8 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
     @checks.has_permissions(manage_channels=True)
     async def _guildnews_pause(self, interaction: Interaction, config: int):
         """pause guild news tracking [manage_channels]"""
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             cfg = WowGuildNewsConfig.get_by_id(config, interaction.guild.id, session)
             if not cfg:
                 await interaction.response.send_message(
@@ -590,8 +589,8 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
     @checks.has_permissions(manage_channels=True)
     async def _guildnews_resume(self, interaction: Interaction, config: int):
         """resume guild news tracking [manage_channels]"""
+        lang = self.bot.get_guild_language(interaction.guild.id)
         with self.bot.session_scope() as session:
-            lang = get_guild_language(interaction.guild.id, session)
             cfg = WowGuildNewsConfig.get_by_id(config, interaction.guild.id, session)
             if not cfg:
                 await interaction.response.send_message(
@@ -752,7 +751,7 @@ class WorldofWarcraft(NerpyBotCog, GroupCog, group_name="wow"):
             wow_guild = config.WowGuildName
             realm = config.WowRealmSlug
             region = config.Region
-            language = get_guild_language(config.GuildId, session)
+            language = self.bot.get_guild_language(config.GuildId)
             min_level = config.MinLevel
             active_days = config.ActiveDays
             last_activity_ts = config.LastActivityTimestamp

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -104,13 +104,15 @@ class GuildConfigCache:
             from models.reactionrole import ReactionRoleMessage
 
             by_guild: dict[int, set[int]] = {}
+            all_ids: set[int] = set()
             for row in session.query(ReactionRoleMessage).all():
                 by_guild.setdefault(row.GuildId, set()).add(row.MessageId)
+                all_ids.add(row.MessageId)
         finally:
             session.close()
 
         self._rr_by_guild = by_guild
-        self._rr_message_ids = {mid for mids in by_guild.values() for mid in mids}
+        self._rr_message_ids = all_ids
         self._rr_warmed = True
 
     # ── Leave messages ────────────────────────────────────────────────────────

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -15,7 +15,8 @@ class GuildConfigCache:
     def __init__(self):
         self._lang: dict[int, str] = {}
         self._modrole: dict[int, int | None] = {}
-        self._rr_message_ids: set[int] = set()
+        self._rr_message_ids: set[int] = set()  # flat set for O(1) hot-path lookup
+        self._rr_by_guild: dict[int, set[int]] = {}  # guild_id -> set[message_id] for eviction
         self._rr_warmed: bool = False
         self._leave_guild_ids: set[int] = set()
         self._leave_warmed: bool = False
@@ -82,13 +83,16 @@ class GuildConfigCache:
             return True
         return message_id in self._rr_message_ids
 
-    def add_reaction_role_message(self, message_id: int) -> None:
+    def add_reaction_role_message(self, guild_id: int, message_id: int) -> None:
         """Register a new reaction role message ID in the cache."""
         self._rr_message_ids.add(message_id)
+        self._rr_by_guild.setdefault(guild_id, set()).add(message_id)
 
-    def remove_reaction_role_message(self, message_id: int) -> None:
+    def remove_reaction_role_message(self, guild_id: int, message_id: int) -> None:
         """Remove a reaction role message ID from the cache."""
         self._rr_message_ids.discard(message_id)
+        if guild_id in self._rr_by_guild:
+            self._rr_by_guild[guild_id].discard(message_id)
 
     def warm_reaction_roles(self, session_factory) -> None:
         """Bulk-load all reaction role message IDs from the database.
@@ -99,11 +103,14 @@ class GuildConfigCache:
         try:
             from models.reactionrole import ReactionRoleMessage
 
-            ids = {row.MessageId for row in session.query(ReactionRoleMessage).all()}
+            by_guild: dict[int, set[int]] = {}
+            for row in session.query(ReactionRoleMessage).all():
+                by_guild.setdefault(row.GuildId, set()).add(row.MessageId)
         finally:
             session.close()
 
-        self._rr_message_ids = ids
+        self._rr_by_guild = by_guild
+        self._rr_message_ids = {mid for mids in by_guild.values() for mid in mids}
         self._rr_warmed = True
 
     # ── Leave messages ────────────────────────────────────────────────────────
@@ -147,3 +154,6 @@ class GuildConfigCache:
         self._lang.pop(guild_id, None)
         self._modrole.pop(guild_id, None)
         self._leave_guild_ids.discard(guild_id)
+        guild_rr = self._rr_by_guild.pop(guild_id, None)
+        if guild_rr:
+            self._rr_message_ids -= guild_rr

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""In-memory guild configuration cache to reduce redundant DB queries."""
+
+
+class GuildConfigCache:
+    """Lightweight in-memory cache for per-guild configuration that rarely changes.
+
+    Sub-caches:
+    - Guild language: lazy (DB on miss), invalidated by ``guild_language_changed`` event
+    - Bot moderator role: lazy (DB on miss), invalidated by ``modrole_changed`` event
+    - Reaction role message IDs: bulk-loaded on startup, updated on add/remove
+    - Leave message guild IDs: bulk-loaded on startup, updated on enable/disable
+    """
+
+    def __init__(self):
+        self._lang: dict[int, str] = {}
+        self._modrole: dict[int, int | None] = {}
+        self._rr_message_ids: set[int] = set()
+        self._rr_warmed: bool = False
+        self._leave_guild_ids: set[int] = set()
+        self._leave_warmed: bool = False
+
+    # ── Language ──────────────────────────────────────────────────────────────
+
+    def get_guild_language(self, guild_id: int, session_factory) -> str:
+        """Return the guild's language, loading from DB on first access."""
+        if guild_id in self._lang:
+            return self._lang[guild_id]
+
+        session = session_factory()
+        try:
+            from models.admin import GuildLanguageConfig
+
+            config = GuildLanguageConfig.get(guild_id, session)
+            lang = config.Language if config is not None else "en"
+        finally:
+            session.close()
+
+        self._lang[guild_id] = lang
+        return lang
+
+    def set_guild_language(self, guild_id: int, lang: str) -> None:
+        """Update the cached language for a guild."""
+        self._lang[guild_id] = lang
+
+    # ── Moderator role ────────────────────────────────────────────────────────
+
+    def get_modrole(self, guild_id: int, session_factory) -> int | None:
+        """Return the guild's bot-moderator role ID, loading from DB on first access."""
+        if guild_id in self._modrole:
+            return self._modrole[guild_id]
+
+        session = session_factory()
+        try:
+            from models.admin import BotModeratorRole
+
+            entry = BotModeratorRole.get(guild_id, session)
+            role_id = entry.RoleId if entry is not None else None
+        finally:
+            session.close()
+
+        self._modrole[guild_id] = role_id
+        return role_id
+
+    def set_modrole(self, guild_id: int, role_id: int | None) -> None:
+        """Update or clear the cached modrole for a guild."""
+        self._modrole[guild_id] = role_id
+
+    def delete_modrole(self, guild_id: int) -> None:
+        """Remove the modrole entry for a guild."""
+        self._modrole.pop(guild_id, None)
+
+    # ── Reaction roles ────────────────────────────────────────────────────────
+
+    def is_reaction_role_message(self, message_id: int) -> bool:
+        """Return True if the message has reaction roles configured.
+
+        Returns True unconditionally before warm-up completes (conservative: always
+        falls through to the DB query so no reactions are missed).
+        """
+        if not self._rr_warmed:
+            return True
+        return message_id in self._rr_message_ids
+
+    def add_reaction_role_message(self, message_id: int) -> None:
+        """Register a new reaction role message ID in the cache."""
+        self._rr_message_ids.add(message_id)
+
+    def remove_reaction_role_message(self, message_id: int) -> None:
+        """Remove a reaction role message ID from the cache."""
+        self._rr_message_ids.discard(message_id)
+
+    def warm_reaction_roles(self, session_factory) -> None:
+        """Bulk-load all reaction role message IDs from the database.
+
+        Idempotent — safe to call again on reconnect.
+        """
+        session = session_factory()
+        try:
+            from models.reactionrole import ReactionRoleMessage
+
+            ids = {row.MessageId for row in session.query(ReactionRoleMessage).all()}
+        finally:
+            session.close()
+
+        self._rr_message_ids = ids
+        self._rr_warmed = True
+
+    # ── Leave messages ────────────────────────────────────────────────────────
+
+    def is_leave_message_guild(self, guild_id: int) -> bool:
+        """Return True if the guild has leave messages enabled.
+
+        Returns True unconditionally before warm-up completes (conservative).
+        """
+        if not self._leave_warmed:
+            return True
+        return guild_id in self._leave_guild_ids
+
+    def set_leave_message_guild(self, guild_id: int, enabled: bool) -> None:
+        """Add or remove a guild from the leave-message set."""
+        if enabled:
+            self._leave_guild_ids.add(guild_id)
+        else:
+            self._leave_guild_ids.discard(guild_id)
+
+    def warm_leave_messages(self, session_factory) -> None:
+        """Bulk-load all guild IDs with enabled leave messages from the database.
+
+        Idempotent — safe to call again on reconnect.
+        """
+        session = session_factory()
+        try:
+            from models.leavemsg import LeaveMessage
+
+            ids = {row.GuildId for row in LeaveMessage.get_all_enabled(session)}
+        finally:
+            session.close()
+
+        self._leave_guild_ids = ids
+        self._leave_warmed = True
+
+    # ── Eviction ──────────────────────────────────────────────────────────────
+
+    def evict_guild(self, guild_id: int) -> None:
+        """Remove all cached entries for a guild (called when bot leaves a guild)."""
+        self._lang.pop(guild_id, None)
+        self._modrole.pop(guild_id, None)
+        self._leave_guild_ids.discard(guild_id)

--- a/NerdyPy/utils/checks.py
+++ b/NerdyPy/utils/checks.py
@@ -5,9 +5,8 @@ from typing import cast
 from bot import NerpyBot
 from discord import Interaction, Role, app_commands
 from discord.ext.commands import Context
-from models.admin import BotModeratorRole
 from utils.errors import NerpyPermissionError, SilentCheckFailure
-from utils.strings import get_localized_string, get_string
+from utils.strings import get_string
 
 
 def _localized(interaction: Interaction, key: str, **kwargs) -> str:
@@ -15,8 +14,7 @@ def _localized(interaction: Interaction, key: str, **kwargs) -> str:
     bot = cast("NerpyBot", interaction.client)
     if interaction.guild_id is None:
         return get_string("en", key, **kwargs)
-    with bot.session_scope() as session:
-        return get_localized_string(interaction.guild_id, key, session, **kwargs)
+    return bot.get_localized_string(interaction.guild_id, key, **kwargs)
 
 
 def require_operator(ctx_or_interaction: Context | Interaction) -> None:
@@ -60,10 +58,9 @@ async def is_bot_moderator(interaction: Interaction) -> bool:
     if perms.mute_members or perms.manage_channels or perms.administrator or interaction.user.id in bot.ops:
         return True
 
-    with bot.session_scope() as session:
-        entry = BotModeratorRole.get(interaction.guild.id, session)
-        if entry is not None:
-            return any(r.id == entry.RoleId for r in interaction.user.roles)
+    role_id = bot.guild_cache.get_modrole(interaction.guild.id, bot.SESSION)
+    if role_id is not None:
+        return any(r.id == role_id for r in interaction.user.roles)
 
     return False
 

--- a/NerdyPy/utils/conversation.py
+++ b/NerdyPy/utils/conversation.py
@@ -4,8 +4,6 @@ from enum import Enum
 
 from discord import Embed
 
-from utils.strings import get_guild_language
-
 
 class AnswerType(Enum):
     REACTION = 0
@@ -20,11 +18,7 @@ class Conversation:
         self.user = user
         self.guild = guild
 
-        if guild is not None:
-            with self.bot.session_scope() as session:
-                self.lang = get_guild_language(guild.id, session)
-        else:
-            self.lang = "en"
+        self.lang = self.bot.get_guild_language(guild.id) if guild is not None else "en"
 
         self.isActive = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,9 @@ def mock_log():
 @pytest.fixture
 def mock_bot(db_session, mock_log):
     """Create a mock bot with session_scope context manager."""
+    from utils.cache import GuildConfigCache
+    from utils.strings import get_string
+
     bot = MagicMock()
     bot.log = mock_log
 
@@ -95,6 +98,20 @@ def mock_bot(db_session, mock_log):
 
     bot.session_scope = session_scope
     bot.config = MagicMock()
+
+    # Wire up a real GuildConfigCache backed by the test DB session so that
+    # tests inserting GuildLanguageConfig/BotModeratorRole rows see correct results.
+    db_session.close = MagicMock()  # prevent cache from closing the shared test session
+    _factory = MagicMock(return_value=db_session)
+    _cache = GuildConfigCache()
+    bot.guild_cache = _cache
+    bot.SESSION = _factory
+    bot.get_guild_language = lambda guild_id: (
+        "en" if guild_id is None else _cache.get_guild_language(guild_id, _factory)
+    )
+    bot.get_localized_string = lambda guild_id, key, **kwargs: get_string(
+        bot.get_guild_language(guild_id), key, **kwargs
+    )
 
     return bot
 

--- a/tests/test_app_command_errors.py
+++ b/tests/test_app_command_errors.py
@@ -20,11 +20,14 @@ def _load_locale_strings():
 @pytest.fixture
 def bot(db_session):
     """Minimal mock of NerpyBot sufficient for _on_app_command_error."""
+    from utils.strings import get_string
+
     b = MagicMock()
     b.log = MagicMock()
     b.error_throttle = MagicMock()
     b.error_throttle.should_notify = MagicMock(return_value=True)
     b.config = {"notifications": {"error_recipients": []}}
+    b.get_localized_string = lambda guild_id, key, **kwargs: get_string("en", key, **kwargs)
 
     @contextmanager
     def session_scope():

--- a/tests/test_bot_functions.py
+++ b/tests/test_bot_functions.py
@@ -589,6 +589,8 @@ class TestGlobalInteractionCheck:
             await NerpyBot._global_interaction_check(mock_self, mock_interaction)
 
         mock_interaction.response.send_message.assert_called_once()
+        mock_self.get_localized_string.assert_called_once()
+        assert mock_self.get_localized_string.call_args.args[0] == mock_interaction.guild_id
 
 
 class TestRunMigrations:

--- a/tests/test_bot_functions.py
+++ b/tests/test_bot_functions.py
@@ -583,15 +583,12 @@ class TestGlobalInteractionCheck:
 
         mock_self = MagicMock()
         mock_self.disabled_modules = {"music"}
-        mock_session = MagicMock()
-        mock_self.session_scope.return_value.__enter__ = MagicMock(return_value=mock_session)
-        mock_self.session_scope.return_value.__exit__ = MagicMock(return_value=False)
+        mock_self.get_localized_string.return_value = "Module disabled"
 
-        with patch("NerdyPy.bot.get_localized_string", return_value="Module disabled"):
-            with pytest.raises(SilentCheckFailure):
-                await NerpyBot._global_interaction_check(mock_self, mock_interaction)
+        with pytest.raises(SilentCheckFailure):
+            await NerpyBot._global_interaction_check(mock_self, mock_interaction)
 
-            mock_interaction.response.send_message.assert_called_once()
+        mock_interaction.response.send_message.assert_called_once()
 
 
 class TestRunMigrations:

--- a/tests/test_module_disable.py
+++ b/tests/test_module_disable.py
@@ -18,9 +18,12 @@ def _load_locale_strings():
 @pytest.fixture
 def mock_bot_with_disable():
     """Minimal mock of NerpyBot with disabled_modules set."""
+    from utils.strings import get_string
+
     bot = MagicMock()
     bot.disabled_modules = set()
     bot.log = MagicMock()
+    bot.get_localized_string = lambda guild_id, key, **kwargs: get_string("en", key, **kwargs)
     return bot
 
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -144,17 +144,17 @@ class TestReactionRoles:
     def test_add_after_warm(self, cache, session_factory):
         cache.warm_reaction_roles(session_factory)
         assert cache.is_reaction_role_message(77) is False
-        cache.add_reaction_role_message(77)
+        cache.add_reaction_role_message(GUILD_ID, 77)
         assert cache.is_reaction_role_message(77) is True
 
     def test_remove_after_add(self, cache, session_factory):
         cache.warm_reaction_roles(session_factory)
-        cache.add_reaction_role_message(77)
-        cache.remove_reaction_role_message(77)
+        cache.add_reaction_role_message(GUILD_ID, 77)
+        cache.remove_reaction_role_message(GUILD_ID, 77)
         assert cache.is_reaction_role_message(77) is False
 
     def test_remove_nonexistent_is_safe(self, cache):
-        cache.remove_reaction_role_message(999)  # must not raise
+        cache.remove_reaction_role_message(GUILD_ID, 999)  # must not raise
 
     def test_warm_is_idempotent(self, cache, session_factory, db_session):
         from models.reactionrole import ReactionRoleMessage
@@ -163,7 +163,7 @@ class TestReactionRoles:
         db_session.commit()
 
         cache.warm_reaction_roles(session_factory)
-        cache.add_reaction_role_message(99)  # locally added
+        cache.add_reaction_role_message(GUILD_ID, 99)  # locally added
 
         cache.warm_reaction_roles(session_factory)  # re-warm clears local addition
         assert cache.is_reaction_role_message(99) is False
@@ -245,6 +245,14 @@ class TestEviction:
         cache.set_leave_message_guild(GUILD_ID, True)
         cache.evict_guild(GUILD_ID)
         assert cache.is_leave_message_guild(GUILD_ID) is False
+
+    def test_evict_removes_reaction_role_messages(self, cache, session_factory):
+        cache.warm_reaction_roles(session_factory)
+        cache.add_reaction_role_message(GUILD_ID, 42)
+        cache.add_reaction_role_message(GUILD_ID_2, 99)
+        cache.evict_guild(GUILD_ID)
+        assert cache.is_reaction_role_message(42) is False  # evicted
+        assert cache.is_reaction_role_message(99) is True  # other guild unaffected
 
     def test_evict_nonexistent_is_safe(self, cache):
         cache.evict_guild(GUILD_ID)  # must not raise

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+"""Tests for GuildConfigCache — language, modrole, reaction roles, and leave messages."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from utils.cache import GuildConfigCache
+
+
+GUILD_ID = 987654321
+GUILD_ID_2 = 111222333
+
+
+@pytest.fixture
+def cache():
+    return GuildConfigCache()
+
+
+@pytest.fixture
+def session_factory(db_session):
+    """Provide a session factory that always yields the test db_session."""
+    factory = MagicMock()
+    factory.return_value = db_session
+    # The cache calls session.close() — make it a no-op so the session stays open
+    db_session.close = MagicMock()
+    return factory
+
+
+# ── Language ──────────────────────────────────────────────────────────────────
+
+
+class TestGuildLanguage:
+    def test_miss_defaults_to_en(self, cache, session_factory):
+        lang = cache.get_guild_language(GUILD_ID, session_factory)
+        assert lang == "en"
+        session_factory.assert_called_once()
+
+    def test_miss_loads_from_db(self, cache, session_factory, db_session):
+        from models.admin import GuildLanguageConfig
+
+        db_session.add(GuildLanguageConfig(GuildId=GUILD_ID, Language="de"))
+        db_session.commit()
+
+        lang = cache.get_guild_language(GUILD_ID, session_factory)
+        assert lang == "de"
+
+    def test_hit_skips_db(self, cache, session_factory):
+        cache.set_guild_language(GUILD_ID, "fr")
+        lang = cache.get_guild_language(GUILD_ID, session_factory)
+        assert lang == "fr"
+        session_factory.assert_not_called()
+
+    def test_set_overwrites(self, cache, session_factory):
+        cache.set_guild_language(GUILD_ID, "de")
+        cache.set_guild_language(GUILD_ID, "fr")
+        lang = cache.get_guild_language(GUILD_ID, session_factory)
+        assert lang == "fr"
+        session_factory.assert_not_called()
+
+    def test_second_call_uses_cache(self, cache, session_factory, db_session):
+        from models.admin import GuildLanguageConfig
+
+        db_session.add(GuildLanguageConfig(GuildId=GUILD_ID, Language="de"))
+        db_session.commit()
+
+        cache.get_guild_language(GUILD_ID, session_factory)
+        cache.get_guild_language(GUILD_ID, session_factory)  # should be cached
+
+        assert session_factory.call_count == 1
+
+    def test_different_guilds_are_independent(self, cache, session_factory, db_session):
+        from models.admin import GuildLanguageConfig
+
+        db_session.add(GuildLanguageConfig(GuildId=GUILD_ID, Language="de"))
+        db_session.add(GuildLanguageConfig(GuildId=GUILD_ID_2, Language="fr"))
+        db_session.commit()
+
+        assert cache.get_guild_language(GUILD_ID, session_factory) == "de"
+        assert cache.get_guild_language(GUILD_ID_2, session_factory) == "fr"
+
+
+# ── Moderator role ────────────────────────────────────────────────────────────
+
+
+class TestModrole:
+    def test_miss_returns_none_when_no_entry(self, cache, session_factory):
+        role_id = cache.get_modrole(GUILD_ID, session_factory)
+        assert role_id is None
+        session_factory.assert_called_once()
+
+    def test_miss_loads_from_db(self, cache, session_factory, db_session):
+        from models.admin import BotModeratorRole
+
+        db_session.add(BotModeratorRole(GuildId=GUILD_ID, RoleId=555))
+        db_session.commit()
+
+        role_id = cache.get_modrole(GUILD_ID, session_factory)
+        assert role_id == 555
+
+    def test_hit_skips_db(self, cache, session_factory):
+        cache.set_modrole(GUILD_ID, 555)
+        role_id = cache.get_modrole(GUILD_ID, session_factory)
+        assert role_id == 555
+        session_factory.assert_not_called()
+
+    def test_set_none_is_cached(self, cache, session_factory):
+        # Explicitly set None (no modrole) — should still cache and skip DB
+        cache.set_modrole(GUILD_ID, None)
+        role_id = cache.get_modrole(GUILD_ID, session_factory)
+        assert role_id is None
+        session_factory.assert_not_called()
+
+    def test_delete_forces_next_miss(self, cache, session_factory):
+        cache.set_modrole(GUILD_ID, 555)
+        cache.delete_modrole(GUILD_ID)
+        cache.get_modrole(GUILD_ID, session_factory)
+        session_factory.assert_called_once()
+
+    def test_delete_nonexistent_is_safe(self, cache):
+        cache.delete_modrole(GUILD_ID)  # must not raise
+
+
+# ── Reaction roles ────────────────────────────────────────────────────────────
+
+
+class TestReactionRoles:
+    def test_unwarmed_always_returns_true(self, cache):
+        assert cache.is_reaction_role_message(999999) is True
+
+    def test_warmed_returns_false_for_unknown(self, cache, session_factory):
+        cache.warm_reaction_roles(session_factory)
+        assert cache.is_reaction_role_message(999999) is False
+
+    def test_warmed_returns_true_for_known(self, cache, session_factory, db_session):
+        from models.reactionrole import ReactionRoleMessage
+
+        db_session.add(ReactionRoleMessage(GuildId=GUILD_ID, ChannelId=111, MessageId=42))
+        db_session.commit()
+
+        cache.warm_reaction_roles(session_factory)
+        assert cache.is_reaction_role_message(42) is True
+
+    def test_add_after_warm(self, cache, session_factory):
+        cache.warm_reaction_roles(session_factory)
+        assert cache.is_reaction_role_message(77) is False
+        cache.add_reaction_role_message(77)
+        assert cache.is_reaction_role_message(77) is True
+
+    def test_remove_after_add(self, cache, session_factory):
+        cache.warm_reaction_roles(session_factory)
+        cache.add_reaction_role_message(77)
+        cache.remove_reaction_role_message(77)
+        assert cache.is_reaction_role_message(77) is False
+
+    def test_remove_nonexistent_is_safe(self, cache):
+        cache.remove_reaction_role_message(999)  # must not raise
+
+    def test_warm_is_idempotent(self, cache, session_factory, db_session):
+        from models.reactionrole import ReactionRoleMessage
+
+        db_session.add(ReactionRoleMessage(GuildId=GUILD_ID, ChannelId=111, MessageId=42))
+        db_session.commit()
+
+        cache.warm_reaction_roles(session_factory)
+        cache.add_reaction_role_message(99)  # locally added
+
+        cache.warm_reaction_roles(session_factory)  # re-warm clears local addition
+        assert cache.is_reaction_role_message(99) is False
+        assert cache.is_reaction_role_message(42) is True
+
+
+# ── Leave messages ────────────────────────────────────────────────────────────
+
+
+class TestLeaveMessages:
+    def test_unwarmed_always_returns_true(self, cache):
+        assert cache.is_leave_message_guild(GUILD_ID) is True
+
+    def test_warmed_returns_false_for_unknown(self, cache, session_factory):
+        cache.warm_leave_messages(session_factory)
+        assert cache.is_leave_message_guild(GUILD_ID) is False
+
+    def test_warmed_returns_true_for_enabled_guild(self, cache, session_factory, db_session):
+        from models.leavemsg import LeaveMessage
+
+        db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye", Enabled=True))
+        db_session.commit()
+
+        cache.warm_leave_messages(session_factory)
+        assert cache.is_leave_message_guild(GUILD_ID) is True
+
+    def test_disabled_guild_not_in_cache(self, cache, session_factory, db_session):
+        from models.leavemsg import LeaveMessage
+
+        db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye", Enabled=False))
+        db_session.commit()
+
+        cache.warm_leave_messages(session_factory)
+        assert cache.is_leave_message_guild(GUILD_ID) is False
+
+    def test_set_enabled(self, cache, session_factory):
+        cache.warm_leave_messages(session_factory)
+        cache.set_leave_message_guild(GUILD_ID, True)
+        assert cache.is_leave_message_guild(GUILD_ID) is True
+
+    def test_set_disabled(self, cache, session_factory):
+        cache.warm_leave_messages(session_factory)
+        cache.set_leave_message_guild(GUILD_ID, True)
+        cache.set_leave_message_guild(GUILD_ID, False)
+        assert cache.is_leave_message_guild(GUILD_ID) is False
+
+    def test_warm_is_idempotent(self, cache, session_factory, db_session):
+        from models.leavemsg import LeaveMessage
+
+        db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye", Enabled=True))
+        db_session.commit()
+
+        cache.warm_leave_messages(session_factory)
+        cache.set_leave_message_guild(GUILD_ID_2, True)  # local addition
+
+        cache.warm_leave_messages(session_factory)  # re-warm clears local addition
+        assert cache.is_leave_message_guild(GUILD_ID_2) is False
+        assert cache.is_leave_message_guild(GUILD_ID) is True
+
+
+# ── Eviction ──────────────────────────────────────────────────────────────────
+
+
+class TestEviction:
+    def test_evict_clears_language(self, cache, session_factory):
+        cache.set_guild_language(GUILD_ID, "de")
+        cache.evict_guild(GUILD_ID)
+        cache.get_guild_language(GUILD_ID, session_factory)
+        session_factory.assert_called_once()
+
+    def test_evict_clears_modrole(self, cache, session_factory):
+        cache.set_modrole(GUILD_ID, 555)
+        cache.evict_guild(GUILD_ID)
+        cache.get_modrole(GUILD_ID, session_factory)
+        session_factory.assert_called_once()
+
+    def test_evict_removes_from_leave_guild_set(self, cache, session_factory):
+        cache.warm_leave_messages(session_factory)
+        cache.set_leave_message_guild(GUILD_ID, True)
+        cache.evict_guild(GUILD_ID)
+        assert cache.is_leave_message_guild(GUILD_ID) is False
+
+    def test_evict_nonexistent_is_safe(self, cache):
+        cache.evict_guild(GUILD_ID)  # must not raise
+
+    def test_evict_does_not_affect_other_guilds(self, cache, session_factory):
+        cache.set_guild_language(GUILD_ID, "de")
+        cache.set_guild_language(GUILD_ID_2, "fr")
+        cache.evict_guild(GUILD_ID)
+        lang = cache.get_guild_language(GUILD_ID_2, session_factory)
+        assert lang == "fr"
+        session_factory.assert_not_called()

--- a/tests/utils/test_checks.py
+++ b/tests/utils/test_checks.py
@@ -83,7 +83,9 @@ def mock_interaction(db_session):
     _cache = GuildConfigCache()
     client.guild_cache = _cache
     client.SESSION = _factory
-    client.get_localized_string = lambda guild_id, key, **kwargs: get_string("en", key, **kwargs)
+    client.get_localized_string = lambda guild_id, key, **kwargs: get_string(
+        "en" if guild_id is None else _cache.get_guild_language(guild_id, _factory), key, **kwargs
+    )
 
     interaction.client = client
 

--- a/tests/utils/test_checks.py
+++ b/tests/utils/test_checks.py
@@ -65,6 +65,9 @@ def mock_interaction(db_session):
     interaction.followup.send = AsyncMock()
 
     # interaction.client (the bot)
+    from utils.cache import GuildConfigCache
+    from utils.strings import get_string
+
     client = MagicMock()
     client.ops = []
 
@@ -73,6 +76,15 @@ def mock_interaction(db_session):
         yield db_session
 
     client.session_scope = session_scope
+
+    # Wire up cache so checks that query modrole or emit localized strings work correctly.
+    db_session.close = MagicMock()  # prevent cache from closing the shared test session
+    _factory = MagicMock(return_value=db_session)
+    _cache = GuildConfigCache()
+    client.guild_cache = _cache
+    client.SESSION = _factory
+    client.get_localized_string = lambda guild_id, key, **kwargs: get_string("en", key, **kwargs)
+
     interaction.client = client
 
     return interaction


### PR DESCRIPTION
## Summary

- Introduces `GuildConfigCache` in `utils/cache.py` with four sub-caches: guild language (lazy, DB on miss), bot moderator role (lazy, DB on miss), reaction role message IDs (bulk warm-up), and leave message guild IDs (bulk warm-up)
- Migrates all 90+ `get_guild_language` call sites across the entire codebase to `bot.get_guild_language()` / `bot.get_localized_string()` convenience methods — eliminates one DB session open/close per call
- Reaction role lookups now use an O(1) set check before hitting the DB, avoiding a query on every reaction in every guild when 99%+ are on non-tracked messages
- Adds 31 unit tests for `GuildConfigCache` (miss→load→cache, hit→skip DB, invalidation, warm-up idempotency, eviction)

## How it works

| Sub-cache | Strategy | Invalidation |
|-----------|----------|-------------|
| Guild language | Lazy — DB on first miss per guild | `guild_language_changed` event |
| Bot moderator role | Lazy — DB on first miss per guild | `modrole_changed` event (new) |
| Reaction role message IDs | Bulk warm-up on `on_ready` | `add`/`remove` on mutation commands |
| Leave message guild IDs | Bulk warm-up on `on_ready` | `set_leave_message_guild` on enable/disable |

Before warm-up, the set-based caches return `True` (conservative fallback to DB) so no events are missed during startup.

## Test plan

- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — all files formatted
- [x] `uv run python -m pytest` — 1058 passed, 0 failed
- [x] `uv run python -m pytest tests/utils/test_cache.py` — 31 new cache tests passed
- [x] Manual: verify first slash command triggers a DB miss-fill (debug log), subsequent commands use cache
- [x] Manual: `/language set de` updates cache immediately without restart
- [x] Manual: reaction on non-tracked message does NOT hit DB after warm-up (check debug logs)
- [x] Manual: member leave in guild without leave message does NOT hit DB after warm-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bot exposes a cache-backed localization API so per-guild language and localized strings are resolved without DB sessions.
  * In-memory caches for reaction-role messages, moderator role, and leave-message settings keep config state synced.

* **Performance Improvements**
  * Caches are warmed on startup and used across flows to reduce latency and DB queries.

* **Bug Fixes**
  * More reliable localization and consistent cache updates on config changes.

* **Tests**
  * Added comprehensive cache unit tests and updated localization-related test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->