### PR TITLE
perf(application): fix N+1 queries in language-refresh helpers

### DIFF
--- a/NerdyPy/models/application.py
+++ b/NerdyPy/models/application.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     UnicodeText,
 )
 from sqlalchemy import Enum as SAEnum
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import joinedload, relationship
 from utils import database as db
 
 
@@ -228,8 +228,8 @@ class ApplicationSubmission(db.BASE):
 
     @classmethod
     def get_by_guild(cls, guild_id, session):
-        """Returns all submissions for a guild."""
-        return session.query(cls).filter(cls.GuildId == guild_id).all()
+        """Returns all submissions for a guild, with the form relationship eager-loaded."""
+        return session.query(cls).options(joinedload(cls.form)).filter(cls.GuildId == guild_id).all()
 
     @classmethod
     def get_by_user_and_form(cls, user_id: int, form_id: int, session):

--- a/NerdyPy/models/application.py
+++ b/NerdyPy/models/application.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     UnicodeText,
 )
 from sqlalchemy import Enum as SAEnum
-from sqlalchemy.orm import joinedload, relationship
+from sqlalchemy.orm import relationship, selectinload
 from utils import database as db
 
 
@@ -229,7 +229,12 @@ class ApplicationSubmission(db.BASE):
     @classmethod
     def get_by_guild(cls, guild_id, session):
         """Returns all submissions for a guild, with the form relationship eager-loaded."""
-        return session.query(cls).options(joinedload(cls.form)).filter(cls.GuildId == guild_id).all()
+        return (
+            session.query(cls)
+            .options(selectinload(cls.form).lazyload(ApplicationForm.questions))
+            .filter(cls.GuildId == guild_id)
+            .all()
+        )
 
     @classmethod
     def get_by_user_and_form(cls, user_id: int, form_id: int, session):

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -19,6 +19,7 @@ from models.application import (
     ApplicationTemplate,
     ApplicationTemplateQuestion,
     SubmissionStatus,
+    VoteType,
     seed_built_in_templates,
 )
 from modules.conversations.application import (
@@ -1291,48 +1292,94 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
 
     async def _refresh_apply_embeds(self, guild_id: int) -> None:
         """Re-post or edit the Apply button embed for each configured form in the guild."""
-        from modules.views.application import edit_apply_button_message
+        from modules.views.application import _ApplyEmbedData, edit_apply_button_message
 
+        lang = self.bot.get_guild_language(guild_id)
         with self.bot.session_scope() as session:
             forms = ApplicationForm.get_all_by_guild(guild_id, session)
-            form_ids = [f.Id for f in forms if f.ApplyMessageId and f.ApplyChannelId]
+            preloaded = [
+                _ApplyEmbedData(
+                    channel_id=f.ApplyChannelId,
+                    message_id=f.ApplyMessageId,
+                    form_name=f.Name,
+                    description=f.ApplyDescription,
+                    lang=lang,
+                )
+                for f in forms
+                if f.ApplyMessageId and f.ApplyChannelId
+            ]
 
-        for form_id in form_ids:
+        for data in preloaded:
             try:
-                await edit_apply_button_message(self.bot, form_id)
-                self.bot.log.info("application: refreshed apply embed for form %d (guild %d)", form_id, guild_id)
+                await edit_apply_button_message(self.bot, preloaded=data)
+                self.bot.log.info(
+                    "application: refreshed apply embed for message %d (guild %d)", data.message_id, guild_id
+                )
             except discord.HTTPException as exc:
                 self.bot.log.warning(
-                    "application: failed to refresh apply embed for form %d (guild %d): %s", form_id, guild_id, exc
+                    "application: failed to refresh apply embed for message %d (guild %d): %s",
+                    data.message_id,
+                    guild_id,
+                    exc,
                 )
 
     async def _refresh_review_embeds(self, guild_id: int) -> None:
         """Re-render each pending review embed in the guild with the new language."""
-        from modules.views.application import _update_review_embed
+        from modules.views.application import _ReviewEmbedData, _update_review_embed
 
+        lang = self.bot.get_guild_language(guild_id)
         with self.bot.session_scope() as session:
             submissions = ApplicationSubmission.get_by_guild(guild_id, session)
-            pending = [
-                (s.ReviewMessageId, s.form.ReviewChannelId)
-                for s in submissions
-                if s.Status == SubmissionStatus.PENDING and s.ReviewMessageId and s.form and s.form.ReviewChannelId
-            ]
+            pending = []
+            for s in submissions:
+                if not (
+                    s.Status == SubmissionStatus.PENDING and s.ReviewMessageId and s.form and s.form.ReviewChannelId
+                ):
+                    continue
+                answers = [
+                    (a.question.QuestionText if a.question else f"Question {a.QuestionId}", a.AnswerText)
+                    for a in s.answers
+                ]
+                pending.append(
+                    _ReviewEmbedData(
+                        user_id=s.UserId,
+                        user_name=s.UserName,
+                        submitted_at=s.SubmittedAt,
+                        status=s.Status,
+                        applicant_notified=s.ApplicantNotified,
+                        form_name=s.form.Name,
+                        required_approvals=s.form.RequiredApprovals,
+                        required_denials=s.form.RequiredDenials,
+                        lang=lang,
+                        approve_count=sum(1 for v in s.votes if v.Vote == VoteType.APPROVE),
+                        deny_count=sum(1 for v in s.votes if v.Vote == VoteType.DENY),
+                        answers=answers,
+                        review_channel_id=s.form.ReviewChannelId,
+                        review_message_id=s.ReviewMessageId,
+                    )
+                )
 
-        for i, (review_message_id, review_channel_id) in enumerate(pending):
+        for i, data in enumerate(pending):
             try:
                 await _update_review_embed(
                     self.bot,
-                    review_channel_id=review_channel_id,
-                    review_message_id=review_message_id,
+                    review_channel_id=data.review_channel_id,
+                    review_message_id=data.review_message_id,
+                    preloaded=data,
                 )
-                self.bot.log.info("application: refreshed review embed %d (guild %d)", review_message_id, guild_id)
+                self.bot.log.info("application: refreshed review embed %d (guild %d)", data.review_message_id, guild_id)
             except (discord.NotFound, discord.Forbidden):
                 self.bot.log.warning(
-                    "application: review message %d not accessible (guild %d) — skipping", review_message_id, guild_id
+                    "application: review message %d not accessible (guild %d) — skipping",
+                    data.review_message_id,
+                    guild_id,
                 )
             except discord.HTTPException as exc:
                 self.bot.log.warning(
-                    "application: failed to refresh review embed %d (guild %d): %s", review_message_id, guild_id, exc
+                    "application: failed to refresh review embed %d (guild %d): %s",
+                    data.review_message_id,
+                    guild_id,
+                    exc,
                 )
             if i < len(pending) - 1:
                 await asyncio.sleep(1)

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -1325,7 +1325,12 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
 
     async def _refresh_review_embeds(self, guild_id: int) -> None:
         """Re-render each pending review embed in the guild with the new language."""
-        from modules.views.application import _ReviewEmbedData, _update_review_embed
+        from modules.views.application import (
+            _ReviewEmbedData,
+            _RoutedReviewEmbed,
+            _extract_answers,
+            _update_review_embed,
+        )
 
         lang = self.bot.get_guild_language(guild_id)
         with self.bot.session_scope() as session:
@@ -1336,48 +1341,46 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
                     s.Status == SubmissionStatus.PENDING and s.ReviewMessageId and s.form and s.form.ReviewChannelId
                 ):
                     continue
-                answers = [
-                    (a.question.QuestionText if a.question else f"Question {a.QuestionId}", a.AnswerText)
-                    for a in s.answers
-                ]
                 pending.append(
-                    _ReviewEmbedData(
-                        user_id=s.UserId,
-                        user_name=s.UserName,
-                        submitted_at=s.SubmittedAt,
-                        status=s.Status,
-                        applicant_notified=s.ApplicantNotified,
-                        form_name=s.form.Name,
-                        required_approvals=s.form.RequiredApprovals,
-                        required_denials=s.form.RequiredDenials,
-                        lang=lang,
-                        approve_count=sum(1 for v in s.votes if v.Vote == VoteType.APPROVE),
-                        deny_count=sum(1 for v in s.votes if v.Vote == VoteType.DENY),
-                        answers=answers,
-                        review_channel_id=s.form.ReviewChannelId,
-                        review_message_id=s.ReviewMessageId,
+                    _RoutedReviewEmbed(
+                        data=_ReviewEmbedData(
+                            user_id=s.UserId,
+                            user_name=s.UserName,
+                            submitted_at=s.SubmittedAt,
+                            status=s.Status,
+                            applicant_notified=s.ApplicantNotified,
+                            form_name=s.form.Name,
+                            required_approvals=s.form.RequiredApprovals,
+                            required_denials=s.form.RequiredDenials,
+                            lang=lang,
+                            approve_count=sum(1 for v in s.votes if v.Vote == VoteType.APPROVE),
+                            deny_count=sum(1 for v in s.votes if v.Vote == VoteType.DENY),
+                            answers=_extract_answers(s.answers),
+                        ),
+                        channel_id=s.form.ReviewChannelId,
+                        message_id=s.ReviewMessageId,
                     )
                 )
 
-        for i, data in enumerate(pending):
+        for i, routed in enumerate(pending):
             try:
                 await _update_review_embed(
                     self.bot,
-                    review_channel_id=data.review_channel_id,
-                    review_message_id=data.review_message_id,
-                    preloaded=data,
+                    review_channel_id=routed.channel_id,
+                    review_message_id=routed.message_id,
+                    preloaded=routed.data,
                 )
-                self.bot.log.info("application: refreshed review embed %d (guild %d)", data.review_message_id, guild_id)
+                self.bot.log.info("application: refreshed review embed %d (guild %d)", routed.message_id, guild_id)
             except (discord.NotFound, discord.Forbidden):
                 self.bot.log.warning(
                     "application: review message %d not accessible (guild %d) — skipping",
-                    data.review_message_id,
+                    routed.message_id,
                     guild_id,
                 )
             except discord.HTTPException as exc:
                 self.bot.log.warning(
                     "application: failed to refresh review embed %d (guild %d): %s",
-                    data.review_message_id,
+                    routed.message_id,
                     guild_id,
                     exc,
                 )

--- a/NerdyPy/modules/views/application.py
+++ b/NerdyPy/modules/views/application.py
@@ -9,7 +9,8 @@ ApplicationApplyView — single-button persistent view ("Apply") posted in a pub
 Clicking it starts the same DM conversation as ``/apply``.
 """
 
-from datetime import UTC
+from dataclasses import dataclass
+from datetime import UTC, datetime
 
 import discord
 from sqlalchemy.exc import IntegrityError
@@ -23,6 +24,43 @@ from models.application import (
     VoteType,
 )
 from utils.strings import get_string
+
+
+# ---------------------------------------------------------------------------
+# Pre-loaded data carriers (used by bulk language-refresh to avoid N+1 sessions)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ApplyEmbedData:
+    """Scalar data needed to edit an Apply button embed without a DB session."""
+
+    channel_id: int
+    message_id: int
+    form_name: str
+    description: str | None
+    lang: str
+
+
+@dataclass
+class _ReviewEmbedData:
+    """Scalar data needed to rebuild a review embed without a DB session."""
+
+    user_id: int
+    user_name: str
+    submitted_at: datetime
+    status: SubmissionStatus
+    applicant_notified: bool
+    form_name: str
+    required_approvals: int
+    required_denials: int
+    lang: str
+    approve_count: int
+    deny_count: int
+    answers: list[tuple[str, str | None]]
+    # Routing — used by _refresh_review_embeds for message resolution; ignored by embed builders
+    review_channel_id: int = 0
+    review_message_id: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -63,40 +101,59 @@ def check_override_permission(interaction: discord.Interaction, bot) -> bool:
 
 def build_review_embed(submission, form, session, lang: str = "en") -> discord.Embed:
     """Build the review embed shown in the review channel for a submission."""
-    approve_count = ApplicationVote.count_by_type(submission.Id, VoteType.APPROVE, session)
-    deny_count = ApplicationVote.count_by_type(submission.Id, VoteType.DENY, session)
+    answers = [
+        (a.question.QuestionText if a.question else f"Question {a.QuestionId}", a.AnswerText)
+        for a in submission.answers
+    ]
+    return _build_review_embed_from_data(
+        _ReviewEmbedData(
+            user_id=submission.UserId,
+            user_name=submission.UserName,
+            submitted_at=submission.SubmittedAt,
+            status=submission.Status,
+            applicant_notified=submission.ApplicantNotified,
+            form_name=form.Name,
+            required_approvals=form.RequiredApprovals,
+            required_denials=form.RequiredDenials,
+            lang=lang,
+            approve_count=ApplicationVote.count_by_type(submission.Id, VoteType.APPROVE, session),
+            deny_count=ApplicationVote.count_by_type(submission.Id, VoteType.DENY, session),
+            answers=answers,
+        )
+    )
 
-    embed = discord.Embed(title=f"\U0001f4cb {form.Name}", colour=_status_colour(submission.Status))
+
+def _build_review_embed_from_data(data: "_ReviewEmbedData") -> discord.Embed:
+    """Build the review embed from pre-extracted scalar data (no DB session needed)."""
+    embed = discord.Embed(title=f"\U0001f4cb {data.form_name}", colour=_status_colour(data.status))
     embed.add_field(
-        name=get_string(lang, "application.review.applicant"),
-        value=f"<@{submission.UserId}> ({submission.UserName})",
+        name=get_string(data.lang, "application.review.applicant"),
+        value=f"<@{data.user_id}> ({data.user_name})",
         inline=True,
     )
-    submitted_at = submission.SubmittedAt
+    submitted_at = data.submitted_at
     if submitted_at.tzinfo is None:
         submitted_at = submitted_at.replace(tzinfo=UTC)
     embed.add_field(
-        name=get_string(lang, "application.review.submitted"),
+        name=get_string(data.lang, "application.review.submitted"),
         value=discord.utils.format_dt(submitted_at, style="R"),
         inline=True,
     )
-
-    for answer in submission.answers:
-        label = answer.question.QuestionText if answer.question else f"Question {answer.QuestionId}"
+    for label, answer_text in data.answers:
         embed.add_field(
-            name=label, value=answer.AnswerText or get_string(lang, "application.review.no_answer"), inline=False
+            name=label,
+            value=answer_text or get_string(data.lang, "application.review.no_answer"),
+            inline=False,
         )
-
-    status_display = submission.Status.capitalize()
     embed.set_footer(
         text=get_string(
-            lang,
+            data.lang,
             "application.review.footer",
-            status=status_display,
-            approvals=approve_count,
-            required_approvals=form.RequiredApprovals,
-            denials=deny_count,
-            required_denials=form.RequiredDenials,
+            status=data.status.value.capitalize(),
+            approvals=data.approve_count,
+            required_approvals=data.required_approvals,
+            denials=data.deny_count,
+            required_denials=data.required_denials,
         )
     )
     return embed
@@ -108,6 +165,7 @@ async def _update_review_embed(
     interaction: discord.Interaction | None = None,
     review_channel_id: int | None = None,
     review_message_id: int | None = None,
+    preloaded: "_ReviewEmbedData | None" = None,
 ):
     """Rebuild and edit the review embed with current vote counts.
 
@@ -117,6 +175,8 @@ async def _update_review_embed(
     ``interaction.message`` is None).
 
     If the submission is no longer pending, all buttons are disabled.
+
+    Pass ``preloaded`` to skip the database lookup entirely (used by bulk language-refresh).
     """
     # Resolve the review message
     if interaction is not None and interaction.message is not None:
@@ -131,16 +191,22 @@ async def _update_review_embed(
     else:
         raise ValueError("Either interaction (with .message) or review_channel_id+review_message_id must be provided")
 
-    with bot.session_scope() as session:
-        submission = ApplicationSubmission.get_by_review_message(msg_id, session)
-        if submission is None:
-            bot.log.warning("application: no submission found for review message %d — was it deleted?", msg_id)
-            return
-        form = ApplicationForm.get_by_id(submission.FormId, session)
-        lang = bot.get_guild_language(submission.GuildId)
-        embed = build_review_embed(submission, form, session, lang)
-        status = submission.Status
-        applicant_notified = submission.ApplicantNotified
+    if preloaded is not None:
+        embed = _build_review_embed_from_data(preloaded)
+        status = preloaded.status
+        applicant_notified = preloaded.applicant_notified
+        lang = preloaded.lang
+    else:
+        with bot.session_scope() as session:
+            submission = ApplicationSubmission.get_by_review_message(msg_id, session)
+            if submission is None:
+                bot.log.warning("application: no submission found for review message %d — was it deleted?", msg_id)
+                return
+            form = ApplicationForm.get_by_id(submission.FormId, session)
+            lang = bot.get_guild_language(submission.GuildId)
+            embed = build_review_embed(submission, form, session, lang)
+            status = submission.Status
+            applicant_notified = submission.ApplicantNotified
 
     view = ApplicationReviewView(bot=bot, lang=lang)
     for item in view.children:
@@ -1123,20 +1189,31 @@ async def post_apply_button_message(bot, form_id: int) -> None:
             form.ApplyMessageId = msg.id
 
 
-async def edit_apply_button_message(bot, form_id: int) -> None:
+async def edit_apply_button_message(
+    bot, form_id: int | None = None, *, preloaded: "_ApplyEmbedData | None" = None
+) -> None:
     """Edit the Apply button message in-place (e.g. after description change).
 
     Raises discord.HTTPException on failure — callers must catch.
+
+    Pass ``preloaded`` to skip the database lookup (used by bulk language-refresh).
     """
-    with bot.session_scope() as session:
-        form = ApplicationForm.get_by_id(form_id, session)
-        if form is None or not form.ApplyMessageId or not form.ApplyChannelId:
-            return
-        channel_id = form.ApplyChannelId
-        message_id = form.ApplyMessageId
-        form_name = form.Name
-        description = form.ApplyDescription
-        lang = bot.get_guild_language(form.GuildId)
+    if preloaded is not None:
+        channel_id = preloaded.channel_id
+        message_id = preloaded.message_id
+        form_name = preloaded.form_name
+        description = preloaded.description
+        lang = preloaded.lang
+    else:
+        with bot.session_scope() as session:
+            form = ApplicationForm.get_by_id(form_id, session)
+            if form is None or not form.ApplyMessageId or not form.ApplyChannelId:
+                return
+            channel_id = form.ApplyChannelId
+            message_id = form.ApplyMessageId
+            form_name = form.Name
+            description = form.ApplyDescription
+            lang = bot.get_guild_language(form.GuildId)
 
     try:
         channel = bot.get_channel(channel_id)

--- a/NerdyPy/modules/views/application.py
+++ b/NerdyPy/modules/views/application.py
@@ -123,8 +123,8 @@ def build_review_embed(submission, form, session, lang: str = "en") -> discord.E
             required_approvals=form.RequiredApprovals,
             required_denials=form.RequiredDenials,
             lang=lang,
-            approve_count=ApplicationVote.count_by_type(submission.Id, VoteType.APPROVE, session),
-            deny_count=ApplicationVote.count_by_type(submission.Id, VoteType.DENY, session),
+            approve_count=sum(1 for v in submission.votes if v.Vote == VoteType.APPROVE),
+            deny_count=sum(1 for v in submission.votes if v.Vote == VoteType.DENY),
             answers=_extract_answers(submission.answers),
         )
     )

--- a/NerdyPy/modules/views/application.py
+++ b/NerdyPy/modules/views/application.py
@@ -58,9 +58,20 @@ class _ReviewEmbedData:
     approve_count: int
     deny_count: int
     answers: list[tuple[str, str | None]]
-    # Routing — used by _refresh_review_embeds for message resolution; ignored by embed builders
-    review_channel_id: int = 0
-    review_message_id: int = 0
+
+
+@dataclass
+class _RoutedReviewEmbed:
+    """Pairs pre-extracted review embed data with its Discord message location."""
+
+    data: "_ReviewEmbedData"
+    channel_id: int
+    message_id: int
+
+
+def _extract_answers(answers) -> list[tuple[str, str | None]]:
+    """Extract (question_text, answer_text) pairs from an answer collection."""
+    return [(a.question.QuestionText if a.question else f"Question {a.QuestionId}", a.AnswerText) for a in answers]
 
 
 # ---------------------------------------------------------------------------
@@ -101,10 +112,6 @@ def check_override_permission(interaction: discord.Interaction, bot) -> bool:
 
 def build_review_embed(submission, form, session, lang: str = "en") -> discord.Embed:
     """Build the review embed shown in the review channel for a submission."""
-    answers = [
-        (a.question.QuestionText if a.question else f"Question {a.QuestionId}", a.AnswerText)
-        for a in submission.answers
-    ]
     return _build_review_embed_from_data(
         _ReviewEmbedData(
             user_id=submission.UserId,
@@ -118,7 +125,7 @@ def build_review_embed(submission, form, session, lang: str = "en") -> discord.E
             lang=lang,
             approve_count=ApplicationVote.count_by_type(submission.Id, VoteType.APPROVE, session),
             deny_count=ApplicationVote.count_by_type(submission.Id, VoteType.DENY, session),
-            answers=answers,
+            answers=_extract_answers(submission.answers),
         )
     )
 
@@ -149,7 +156,7 @@ def _build_review_embed_from_data(data: "_ReviewEmbedData") -> discord.Embed:
         text=get_string(
             data.lang,
             "application.review.footer",
-            status=data.status.value.capitalize(),
+            status=data.status.capitalize(),
             approvals=data.approve_count,
             required_approvals=data.required_approvals,
             denials=data.deny_count,

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -101,13 +101,16 @@ class GuildConfigCache:
         """
         session = session_factory()
         try:
+            from sqlalchemy import select
+
             from models.reactionrole import ReactionRoleMessage
 
             by_guild: dict[int, set[int]] = {}
             all_ids: set[int] = set()
-            for row in session.query(ReactionRoleMessage).all():
-                by_guild.setdefault(row.GuildId, set()).add(row.MessageId)
-                all_ids.add(row.MessageId)
+            rows = session.execute(select(ReactionRoleMessage.GuildId, ReactionRoleMessage.MessageId)).all()
+            for guild_id, message_id in rows:
+                by_guild.setdefault(guild_id, set()).add(message_id)
+                all_ids.add(message_id)
         finally:
             session.close()
 
@@ -140,9 +143,11 @@ class GuildConfigCache:
         """
         session = session_factory()
         try:
+            from sqlalchemy import select
+
             from models.leavemsg import LeaveMessage
 
-            ids = {row.GuildId for row in LeaveMessage.get_all_enabled(session)}
+            ids = set(session.scalars(select(LeaveMessage.GuildId).where(LeaveMessage.Enabled.is_(True))))
         finally:
             session.close()
 

--- a/NerdyPy/utils/checks.py
+++ b/NerdyPy/utils/checks.py
@@ -58,7 +58,10 @@ async def is_bot_moderator(interaction: Interaction) -> bool:
     if perms.mute_members or perms.manage_channels or perms.administrator or interaction.user.id in bot.ops:
         return True
 
-    role_id = bot.guild_cache.get_modrole(interaction.guild.id, bot.SESSION)
+    guild_id = interaction.guild_id
+    if guild_id is None:
+        return False
+    role_id = bot.guild_cache.get_modrole(guild_id, bot.SESSION)
     if role_id is not None:
         return any(r.id == role_id for r in interaction.user.roles)
 


### PR DESCRIPTION
## Summary

- Extracts all needed scalar data from ORM objects while the session is still open, passed via `_ApplyEmbedData` / `_ReviewEmbedData` dataclasses to `edit_apply_button_message()` and `_update_review_embed()` — both helpers now skip their DB session entirely in the bulk-refresh path
- Vote counts in `_refresh_review_embeds` replaced `count_by_type()` SQL calls with `sum()` over the already-loaded `s.votes` collection (`lazy="subquery"`), eliminating 2N redundant COUNT queries
- `build_review_embed()` now delegates to `_build_review_embed_from_data()`, removing the duplicate embed-building logic and establishing a single canonical implementation

The N+1 pattern occurred on every `on_guild_language_changed` event. With N forms or N pending reviews, the old code opened N+1 DB sessions; the new code opens exactly one.

Other callers (description-change path at `application.py:300`, button/modal callbacks) are unaffected — they continue to use `form_id` / `interaction` and fall back to the DB path.

Closes #346

## Test plan

- [ ] Existing 105 application tests pass (`uv run python -m pytest tests/modules/test_application.py`)
- [ ] Trigger a guild language change on a server with multiple forms and pending reviews — confirm embeds refresh correctly and DB query count is flat
- [ ] Confirm single-form / single-review edge cases still work
- [ ] Confirm the description-change path (`edit_apply_button_message` called with `form_id`) still works after a form description edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Embed refresh flows now preload embed/review data so update operations run from complete objects, improving responsiveness and consistency.
  * Review panels render approve/deny counts, answers, localization, and applicant-notified state from pre-extracted data for stable displays.
  * Apply-button messages update reliably using preloaded routing and localized content.

* **Bug Fixes**
  * Permission check now safely handles missing guild context.
  * Cache warm-up routines streamlined for more efficient ID loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->