### PR TITLE
refactor: replace _send_ephemeral with send_hidden_message; fix Tag.get_random_entry memory usage

### DIFF
--- a/NerdyPy/models/tagging.py
+++ b/NerdyPy/models/tagging.py
@@ -2,10 +2,9 @@
 """Tag DB Model"""
 
 from enum import Enum
-from random import randint
 
 from discord.ext.commands import Context, Converter
-from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Index, Integer, LargeBinary, Unicode, asc
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Index, Integer, LargeBinary, Unicode, asc, func
 from sqlalchemy.orm import relationship
 from utils import database as db
 from utils.errors import NerpyValidationError
@@ -82,10 +81,10 @@ class Tag(db.BASE):
 
     def get_random_entry(self):
         """gets a random tag entry"""
-        count = self.entries.count()
-        if count == 0:
+        entry = self.entries.order_by(func.random()).limit(1).first()
+        if entry is None:
             raise NerpyValidationError(f"Tag '{self.Name}' has no entries.")
-        return self.entries.offset(randint(0, count - 1)).limit(1).first()
+        return entry
 
     def __str__(self):
         msg = f"==== {self.Name} ====\n\n"

--- a/NerdyPy/models/tagging.py
+++ b/NerdyPy/models/tagging.py
@@ -83,6 +83,8 @@ class Tag(db.BASE):
     def get_random_entry(self):
         """gets a random tag entry"""
         count = self.entries.count()
+        if count == 0:
+            raise NerpyValidationError(f"Tag '{self.Name}' has no entries.")
         return self.entries.offset(randint(0, count - 1)).limit(1).first()
 
     def __str__(self):

--- a/NerdyPy/models/tagging.py
+++ b/NerdyPy/models/tagging.py
@@ -82,9 +82,8 @@ class Tag(db.BASE):
 
     def get_random_entry(self):
         """gets a random tag entry"""
-        tag_entries = self.entries.all()
-        random_entry = tag_entries[randint(0, (len(tag_entries) - 1))]
-        return random_entry
+        count = self.entries.count()
+        return self.entries.offset(randint(0, count - 1)).limit(1).first()
 
     def __str__(self):
         msg = f"==== {self.Name} ====\n\n"

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -29,16 +29,8 @@ from modules.conversations.application import (
 from modules.views.application import check_override_permission
 from sqlalchemy.exc import SQLAlchemyError
 from utils.cog import NerpyBotCog
-from utils.helpers import fetch_message_content
+from utils.helpers import fetch_message_content, send_hidden_message
 from utils.strings import get_raw, get_string
-
-
-async def _send_ephemeral(interaction: Interaction, msg: str) -> None:
-    """Send an ephemeral message, choosing response vs followup based on whether the response is used."""
-    if not interaction.response.is_done():
-        await interaction.response.send_message(msg, ephemeral=True)
-    else:
-        await interaction.followup.send(msg, ephemeral=True)
 
 
 def _localize_field(
@@ -242,7 +234,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
             form = ApplicationForm.get(name, interaction.guild.id, session)
             if not form:
                 msg = get_string(lang, "application.form_not_found", name=name)
-                await _send_ephemeral(interaction, msg)
+                await send_hidden_message(interaction, msg)
                 return
 
             changes = []
@@ -275,13 +267,13 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
 
             if not changes:
                 msg = get_string(lang, "application.settings.nothing_to_change")
-                await _send_ephemeral(interaction, msg)
+                await send_hidden_message(interaction, msg)
                 return
 
             form_id = form.Id
 
         msg = get_string(lang, "application.settings.success", name=name, changes=", ".join(changes))
-        await _send_ephemeral(interaction, msg)
+        await send_hidden_message(interaction, msg)
 
         if repost_apply:
             from modules.views.application import post_apply_button_message
@@ -899,11 +891,11 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
             tpl = ApplicationTemplate.get_by_name(template_name, interaction.guild.id, session)
             if not tpl:
                 msg = get_string(lang, "application.template.not_found", name=template_name)
-                await _send_ephemeral(interaction, msg)
+                await send_hidden_message(interaction, msg)
                 return
             if tpl.IsBuiltIn:
                 msg = get_string(lang, "application.template.edit_messages.builtin_forbidden")
-                await _send_ephemeral(interaction, msg)
+                await send_hidden_message(interaction, msg)
                 return
 
             changes = []
@@ -921,7 +913,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
                 lang, "application.template.edit_messages.success", name=template_name, changes=", ".join(changes)
             )
 
-        await _send_ephemeral(interaction, msg)
+        await send_hidden_message(interaction, msg)
 
     @template_group.command(name="edit-messages")
     @app_commands.describe(

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -237,6 +237,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
             if not form:
                 msg = get_string(lang, "application.form_not_found", name=name)
             else:
+                form_id = form.Id
                 if review_channel is not None:
                     form.ReviewChannelId = review_channel.id
                     changes.append(
@@ -266,8 +267,6 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
 
                 if not changes:
                     msg = get_string(lang, "application.settings.nothing_to_change")
-                else:
-                    form_id = form.Id
 
         if msg is not None:
             await send_hidden_message(interaction, msg)

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -229,48 +229,49 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
         repost_apply = False
         edit_apply = False
         form_id = None
+        msg = None
+        changes = []
 
         with self.bot.session_scope() as session:
             form = ApplicationForm.get(name, interaction.guild.id, session)
             if not form:
                 msg = get_string(lang, "application.form_not_found", name=name)
-                await send_hidden_message(interaction, msg)
-                return
+            else:
+                if review_channel is not None:
+                    form.ReviewChannelId = review_channel.id
+                    changes.append(
+                        get_string(lang, "application.settings.change_review_channel", channel=review_channel.mention)
+                    )
+                if channel is not None:
+                    form.ApplyChannelId = channel.id
+                    changes.append(get_string(lang, "application.settings.change_channel", channel=channel.mention))
+                    repost_apply = True
+                if description is not None:
+                    form.ApplyDescription = description
+                    changes.append(get_string(lang, "application.settings.change_description"))
+                    if not repost_apply and form.ApplyMessageId:
+                        edit_apply = True
+                if approvals is not None:
+                    form.RequiredApprovals = approvals
+                    changes.append(get_string(lang, "application.settings.change_approvals", count=approvals))
+                if denials is not None:
+                    form.RequiredDenials = denials
+                    changes.append(get_string(lang, "application.settings.change_denials", count=denials))
+                if approval_message is not None:
+                    form.ApprovalMessage = approval_message
+                    changes.append(get_string(lang, "application.settings.change_approval_message"))
+                if denial_message is not None:
+                    form.DenialMessage = denial_message
+                    changes.append(get_string(lang, "application.settings.change_denial_message"))
 
-            changes = []
-            if review_channel is not None:
-                form.ReviewChannelId = review_channel.id
-                changes.append(
-                    get_string(lang, "application.settings.change_review_channel", channel=review_channel.mention)
-                )
-            if channel is not None:
-                form.ApplyChannelId = channel.id
-                changes.append(get_string(lang, "application.settings.change_channel", channel=channel.mention))
-                repost_apply = True
-            if description is not None:
-                form.ApplyDescription = description
-                changes.append(get_string(lang, "application.settings.change_description"))
-                if not repost_apply and form.ApplyMessageId:
-                    edit_apply = True
-            if approvals is not None:
-                form.RequiredApprovals = approvals
-                changes.append(get_string(lang, "application.settings.change_approvals", count=approvals))
-            if denials is not None:
-                form.RequiredDenials = denials
-                changes.append(get_string(lang, "application.settings.change_denials", count=denials))
-            if approval_message is not None:
-                form.ApprovalMessage = approval_message
-                changes.append(get_string(lang, "application.settings.change_approval_message"))
-            if denial_message is not None:
-                form.DenialMessage = denial_message
-                changes.append(get_string(lang, "application.settings.change_denial_message"))
+                if not changes:
+                    msg = get_string(lang, "application.settings.nothing_to_change")
+                else:
+                    form_id = form.Id
 
-            if not changes:
-                msg = get_string(lang, "application.settings.nothing_to_change")
-                await send_hidden_message(interaction, msg)
-                return
-
-            form_id = form.Id
+        if msg is not None:
+            await send_hidden_message(interaction, msg)
+            return
 
         msg = get_string(lang, "application.settings.success", name=name, changes=", ".join(changes))
         await send_hidden_message(interaction, msg)
@@ -887,24 +888,26 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
         lang: str,
     ) -> None:
         """Validate and persist template message changes, then confirm."""
+        changes = []
+        msg = None
+
         with self.bot.session_scope() as session:
             tpl = ApplicationTemplate.get_by_name(template_name, interaction.guild.id, session)
             if not tpl:
                 msg = get_string(lang, "application.template.not_found", name=template_name)
-                await send_hidden_message(interaction, msg)
-                return
-            if tpl.IsBuiltIn:
+            elif tpl.IsBuiltIn:
                 msg = get_string(lang, "application.template.edit_messages.builtin_forbidden")
-                await send_hidden_message(interaction, msg)
-                return
+            else:
+                if approval_message is not None:
+                    tpl.ApprovalMessage = approval_message
+                    changes.append(get_string(lang, "application.template.edit_messages.change_approval"))
+                if denial_message is not None:
+                    tpl.DenialMessage = denial_message
+                    changes.append(get_string(lang, "application.template.edit_messages.change_denial"))
 
-            changes = []
-            if approval_message is not None:
-                tpl.ApprovalMessage = approval_message
-                changes.append(get_string(lang, "application.template.edit_messages.change_approval"))
-            if denial_message is not None:
-                tpl.DenialMessage = denial_message
-                changes.append(get_string(lang, "application.template.edit_messages.change_denial"))
+        if msg is not None:
+            await send_hidden_message(interaction, msg)
+            return
 
         if not changes:
             msg = get_string(lang, "application.template.edit_messages.nothing_to_update")

--- a/NerdyPy/utils/audio.py
+++ b/NerdyPy/utils/audio.py
@@ -213,7 +213,7 @@ class Audio:
         }
 
     async def _update_buffer(self, guild_id):
-        songs = [s for s in self.list_queue(guild_id)[: self.buffer_limit] if s.stream is None]
+        songs = [s for s in self.list_queue(guild_id) if s.stream is None][: self.buffer_limit]
 
         if songs:
             guild = self.bot.get_guild(guild_id)

--- a/NerdyPy/utils/audio.py
+++ b/NerdyPy/utils/audio.py
@@ -213,20 +213,15 @@ class Audio:
         }
 
     async def _update_buffer(self, guild_id):
-        _index = 0
-        _tasks = []
-        for s in self.list_queue(guild_id)[: self.buffer_limit]:
-            if _index >= self.buffer_limit:
-                break
-            if s.stream is None:
-                _tasks.append(s.fetch_buffer())
-            _index = _index + 1
+        songs = [s for s in self.list_queue(guild_id)[: self.buffer_limit] if s.stream is None]
 
-        if _tasks:
-            results = await asyncio.gather(*_tasks, return_exceptions=True)
-            for result in results:
+        if songs:
+            guild = self.bot.get_guild(guild_id)
+            guild_label = f"{guild.name} ({guild_id})" if guild else f"Unknown ({guild_id})"
+            results = await asyncio.gather(*[s.fetch_buffer() for s in songs], return_exceptions=True)
+            for song, result in zip(songs, results):
                 if isinstance(result, Exception):
-                    self.bot.log.error(f"Buffer prefetch failed: {result}")
+                    self.bot.log.error(f"[{guild_label}]: Buffer prefetch failed for '{song.title}': {result}")
 
     def _add_to_buffer(self, guild_id, song):
         self.buffer[guild_id][BufferKey.QUEUE].put(song)

--- a/NerdyPy/utils/audio.py
+++ b/NerdyPy/utils/audio.py
@@ -223,7 +223,10 @@ class Audio:
             _index = _index + 1
 
         if _tasks:
-            await asyncio.gather(*_tasks)
+            results = await asyncio.gather(*_tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception):
+                    self.bot.log.error(f"Buffer prefetch failed: {result}")
 
     def _add_to_buffer(self, guild_id, song):
         self.buffer[guild_id][BufferKey.QUEUE].put(song)


### PR DESCRIPTION
## Summary

- **`modules/application.py`**: Remove local `_send_ephemeral()` helper (7-line duplicate of `send_hidden_message` from `utils/helpers`). All 6 call sites switched to `send_hidden_message()`, which additionally silently swallows expired-interaction errors — important for post-send logic (error recording, operator DMs) to run uninterrupted.
- **`models/tagging.py`**: `get_random_entry()` previously called `.all()` on the dynamic relationship, loading every entry into Python memory before picking one with `randint`. Replaced with `COUNT` + `OFFSET/LIMIT 1` so only a single row is fetched regardless of tag size.

## Test plan

- [ ] All 1116 existing tests pass (`uv run python -m pytest`)
- [ ] Manually verify ephemeral responses still work in the application module
- [ ] Manually verify tag playback still works (sound/text/url types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Random tag selection now uses a database-driven approach for better scalability.
  * Confirmation and error messages are consistently delivered as hidden/ephemeral messages.
  * Audio buffer prefetch optimized to run grouped fetches and handle per-item failures with targeted logging.

* **Bug Fixes**
  * Returns a clear validation error when attempting to pick a random tag but none exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->