### PR TITLE
perf: add in-memory caches to reduce DB and Valkey call frequency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - `permissions.py` - Per-module bot permission requirements map and guild-level permission audit helpers
 - `duration.py` - `parse_duration()` for human-friendly duration strings (`2h30m`, `1d12h`, `1w`); wraps `pytimeparse2`
 - `schedule.py` - `compute_next_fire()` for DST-aware next-fire-time computation (interval/daily/weekly/monthly)
-- `strings.py` - Localized string lookup: `load_strings()` at startup, `get_string(lang, key, **kwargs)` for templates, `get_guild_language(guild_id, session)` for DB lookup, `get_localized_string(guild_id, key, session, **kwargs)` convenience wrapper
+- `strings.py` - Localized string lookup: `load_strings()` at startup, `get_string(lang, key, **kwargs)` for templates
 
 ### Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - `permissions.py` - Per-module bot permission requirements map and guild-level permission audit helpers
 - `duration.py` - `parse_duration()` for human-friendly duration strings (`2h30m`, `1d12h`, `1w`); wraps `pytimeparse2`
 - `schedule.py` - `compute_next_fire()` for DST-aware next-fire-time computation (interval/daily/weekly/monthly)
-- `strings.py` - Localized string lookup: `load_strings()` at startup, `get_string(lang, key, **kwargs)` for templates
+- `strings.py` - Localized string lookup: `load_strings()` at startup, `get_string(lang, key, **kwargs)` for templates. Guild-language helpers moved to bot level: use `bot.get_guild_language(guild_id)` / `bot.get_localized_string(guild_id, key, **kwargs)` (bot-level wrappers) or `GuildConfigCache.get_guild_language(guild_id, session_factory)` directly.
 
 ### Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,9 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - `permissions.py` - Per-module bot permission requirements map and guild-level permission audit helpers
 - `duration.py` - `parse_duration()` for human-friendly duration strings (`2h30m`, `1d12h`, `1w`); wraps `pytimeparse2`
 - `schedule.py` - `compute_next_fire()` for DST-aware next-fire-time computation (interval/daily/weekly/monthly)
-- `strings.py` - Localized string lookup: `load_strings()` at startup, `get_string(lang, key, **kwargs)` for templates. Guild-language helpers moved to bot level: use `bot.get_guild_language(guild_id)` / `bot.get_localized_string(guild_id, key, **kwargs)` (bot-level wrappers) or `GuildConfigCache.get_guild_language(guild_id, session_factory)` directly.
+- `strings.py` - Localized string lookup: `load_strings()` at startup, `get_string(lang, key, **kwargs)` for templates.
+  Guild-language helpers moved to bot level: use `bot.get_guild_language(guild_id)` / `bot.get_localized_string(guild_id, key, **kwargs)`
+  (bot-level wrappers) or `GuildConfigCache.get_guild_language(guild_id, session_factory)` directly.
 
 ### Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Modules live in `NerdyPy/modules/` as discord.py Cogs. They're loaded dynamicall
 - `schedule.py` - `compute_next_fire()` for DST-aware next-fire-time computation (interval/daily/weekly/monthly)
 - `strings.py` - Localized string lookup: `load_strings()` at startup, `get_string(lang, key, **kwargs)` for templates.
   Guild-language helpers moved to bot level: use `bot.get_guild_language(guild_id)` / `bot.get_localized_string(guild_id, key, **kwargs)`
-  (bot-level wrappers) or `GuildConfigCache.get_guild_language(guild_id, session_factory)` directly.
+  (bot-level wrappers) or `bot.guild_cache.get_guild_language(guild_id, bot.SESSION)` directly.
 
 ### Gotchas
 

--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -363,6 +363,14 @@ class NerpyBot(Bot):
             except Exception as e:
                 self.log.error(f"Failed to warm {cache_name} cache: {e}", exc_info=True)
         self.log.debug("Guild config cache warm-up finished.")
+        if not self.guild_cache.rr_warmed:
+            self.log.error(
+                "reaction-role cache warm-up failed — every reaction event will fall back to DB indefinitely"
+            )
+        if not self.guild_cache.leave_warmed:
+            self.log.error(
+                "leave-message cache warm-up failed — every member-remove event will fall back to DB indefinitely"
+            )
 
         required = required_permissions_for(self.modules)
         for guild in self.guilds:

--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -361,7 +361,7 @@ class NerpyBot(Bot):
             try:
                 warm(self.SESSION)
             except Exception as e:
-                self.log.warning(f"Failed to warm {cache_name} cache: {e}", exc_info=True)
+                self.log.error(f"Failed to warm {cache_name} cache: {e}", exc_info=True)
         self.log.debug("Guild config cache warm-up finished.")
 
         required = required_permissions_for(self.modules)

--- a/NerdyPy/bot.py
+++ b/NerdyPy/bot.py
@@ -361,7 +361,7 @@ class NerpyBot(Bot):
             try:
                 warm(self.SESSION)
             except Exception as e:
-                self.log.warning(f"Failed to warm {cache_name} cache: {e}")
+                self.log.warning(f"Failed to warm {cache_name} cache: {e}", exc_info=True)
         self.log.debug("Guild config cache warm-up finished.")
 
         required = required_permissions_for(self.modules)

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -38,6 +38,10 @@ def _cache_recipe_query(method):
 
     Builds a key from the method name + all arguments except ``cls`` and ``session``.
     ``set`` arguments are converted to ``frozenset`` for hashability.
+
+    Warning: cached results are session-detached ORM instances. Callers must not
+    access lazy-loaded relationships on returned objects — only eagerly-loaded columns
+    are safe. Accessing a lazy attribute raises ``DetachedInstanceError``.
     """
     sig = inspect.signature(method)
 

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -54,8 +54,7 @@ def _cache_recipe_query(method):
             key_parts.append(val)
         key = tuple(key_parts)
         if key in _recipe_cache:
-            cached = _recipe_cache[key]
-            return list(cached) if isinstance(cached, list) else cached
+            return _recipe_cache[key]
         result = method(*args, **kwargs)
         _recipe_cache[key] = result
         return result

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -56,7 +56,7 @@ def _cache_recipe_query(method):
         key = (
             method.__name__,
             *(
-                frozenset(val) if isinstance(val, set) else val
+                None if (isinstance(val, set) and not val) else (frozenset(val) if isinstance(val, set) else val)
                 for name, val in bound.arguments.items()
                 if name not in ("cls", "session")
             ),

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 """wow dbmodel"""
 
+import functools
+import inspect
 from datetime import UTC, datetime
 
+from cachetools import TTLCache
 from sqlalchemy import (
     BigInteger,
     Boolean,
@@ -22,6 +25,50 @@ from sqlalchemy import (
     or_,
 )
 from utils import database as db
+
+# ── CraftingRecipeCache query cache ───────────────────────────────────────────
+# Recipe data changes only on operator-triggered sync (daily/weekly at most).
+# TTL of 1 hour prevents stale data without ever needing a bot restart.
+
+_recipe_cache: TTLCache = TTLCache(maxsize=256, ttl=3600)
+
+
+def _cache_recipe_query(method):
+    """Wrap a CraftingRecipeCache classmethod with TTL result caching.
+
+    Builds a key from the method name + all arguments except ``cls`` and ``session``.
+    ``set`` arguments are converted to ``frozenset`` for hashability.
+    """
+    sig = inspect.signature(method)
+
+    @functools.wraps(method)
+    def wrapper(*args, **kwargs):
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        key_parts = [method.__name__]
+        for name, val in bound.arguments.items():
+            if name in ("cls", "session"):
+                continue
+            if isinstance(val, set):
+                val = frozenset(val)
+            key_parts.append(val)
+        key = tuple(key_parts)
+        if key in _recipe_cache:
+            cached = _recipe_cache[key]
+            return list(cached) if isinstance(cached, list) else cached
+        result = method(*args, **kwargs)
+        _recipe_cache[key] = result
+        return result
+
+    return wrapper
+
+
+def invalidate_recipe_cache() -> None:
+    """Clear all cached CraftingRecipeCache query results.
+
+    Call this after a recipe sync completes to ensure fresh data on next access.
+    """
+    _recipe_cache.clear()
 
 
 class WoW(db.BASE):
@@ -411,6 +458,7 @@ class CraftingRecipeCache(db.BASE):
         )
 
     @classmethod
+    @_cache_recipe_query
     def get_prof_knowledge_items(
         cls, recipe_type, session, profession_ids: set[int] | None = None
     ) -> list["CraftingRecipeCache"]:
@@ -424,6 +472,7 @@ class CraftingRecipeCache(db.BASE):
         return q.order_by(asc(cls.ItemName)).all()
 
     @classmethod
+    @_cache_recipe_query
     def has_prof_knowledge_items(cls, recipe_type, session, profession_ids: set[int] | None = None) -> bool:
         """Return True if there are any profession knowledge items for the given filters."""
         q = session.query(cls.RecipeId).filter(
@@ -435,6 +484,7 @@ class CraftingRecipeCache(db.BASE):
         return q.limit(1).scalar() is not None
 
     @classmethod
+    @_cache_recipe_query
     def get_by_profession(cls, prof_id, recipe_type, session):
         return (
             session.query(cls)
@@ -444,6 +494,7 @@ class CraftingRecipeCache(db.BASE):
         )
 
     @classmethod
+    @_cache_recipe_query
     def get_by_profession_and_expansion(cls, prof_id, recipe_type, expansion, session):
         return (
             session.query(cls)
@@ -453,6 +504,7 @@ class CraftingRecipeCache(db.BASE):
         )
 
     @classmethod
+    @_cache_recipe_query
     def get_by_type_and_subclass(
         cls,
         recipe_type,
@@ -477,6 +529,7 @@ class CraftingRecipeCache(db.BASE):
         return q.order_by(asc(cls.ItemName)).all()
 
     @classmethod
+    @_cache_recipe_query
     def get_expansions_for_profession(cls, prof_id, recipe_type, session):
         """Return distinct non-null expansion names for a profession, ordered alphabetically."""
         rows = (
@@ -523,6 +576,7 @@ class CraftingRecipeCache(db.BASE):
         return list(seen.values())
 
     @classmethod
+    @_cache_recipe_query
     def get_item_classes(
         cls,
         recipe_type,
@@ -549,6 +603,7 @@ class CraftingRecipeCache(db.BASE):
         return cls._dedup_rows(q, cls.ItemClassName)
 
     @classmethod
+    @_cache_recipe_query
     def get_item_subclasses(
         cls,
         recipe_type,
@@ -576,6 +631,7 @@ class CraftingRecipeCache(db.BASE):
         return cls._dedup_rows(q, cls.ItemSubClassName)
 
     @classmethod
+    @_cache_recipe_query
     def get_pvp_item_classes(cls, recipe_type, session, profession_ids: set[int] | None = None):
         """Return distinct (ItemClassId, ItemClassName, locales) for PvP items (bound, PvP category)."""
         q = session.query(cls.ItemClassId, cls.ItemClassName, cls.ItemClassNameLocales).filter(
@@ -589,6 +645,7 @@ class CraftingRecipeCache(db.BASE):
         return cls._dedup_rows(q, cls.ItemClassName)
 
     @classmethod
+    @_cache_recipe_query
     def get_pvp_item_subclasses(cls, recipe_type, item_class_id, session, profession_ids: set[int] | None = None):
         """Return distinct (ItemSubClassId, ItemSubClassName, locales) for PvP items in a class."""
         q = session.query(cls.ItemSubClassId, cls.ItemSubClassName, cls.ItemSubClassNameLocales).filter(
@@ -603,6 +660,7 @@ class CraftingRecipeCache(db.BASE):
         return cls._dedup_rows(q, cls.ItemSubClassName)
 
     @classmethod
+    @_cache_recipe_query
     def get_pvp_items(
         cls, recipe_type, item_class_id, item_subclass_id, session, profession_ids: set[int] | None = None
     ):
@@ -623,6 +681,7 @@ class CraftingRecipeCache(db.BASE):
         return q.order_by(asc(cls.ItemName)).all()
 
     @classmethod
+    @_cache_recipe_query
     def get_raid_prep_categories(
         cls, recipe_type, session, profession_ids: set[int] | None = None
     ) -> list[tuple[str, dict | None]]:
@@ -638,6 +697,7 @@ class CraftingRecipeCache(db.BASE):
         return cls._dedup_category_rows(rows)
 
     @classmethod
+    @_cache_recipe_query
     def get_raid_prep_items(cls, recipe_type, category_name, session, profession_ids: set[int] | None = None):
         """Return recipe rows for a specific raid prep category."""
         q = session.query(cls).filter(
@@ -650,6 +710,7 @@ class CraftingRecipeCache(db.BASE):
         return q.order_by(asc(cls.ItemName)).all()
 
     @classmethod
+    @_cache_recipe_query
     def get_other_categories(
         cls, recipe_type, session, profession_ids: set[int] | None = None
     ) -> list[tuple[str, dict | None]]:
@@ -672,6 +733,7 @@ class CraftingRecipeCache(db.BASE):
         return cls._dedup_category_rows(rows)
 
     @classmethod
+    @_cache_recipe_query
     def get_other_items(cls, recipe_type, category_name, session, profession_ids: set[int] | None = None):
         """Return recipe rows for a specific 'Other' category."""
         q = session.query(cls).filter(
@@ -688,6 +750,7 @@ class CraftingRecipeCache(db.BASE):
         return q.order_by(asc(cls.ItemName)).all()
 
     @classmethod
+    @_cache_recipe_query
     def get_professions_with_recipes(cls, recipe_type, session, profession_ids: set[int] | None = None):
         """Return distinct (ProfessionId, ProfessionName) pairs that have cached recipes of the given type."""
         q = session.query(cls.ProfessionId, cls.ProfessionName).filter(cls.RecipeType == recipe_type)

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -39,9 +39,10 @@ def _cache_recipe_query(method):
     Builds a key from the method name + all arguments except ``cls`` and ``session``.
     ``set`` arguments are converted to ``frozenset`` for hashability.
 
-    Warning: cached results are session-detached ORM instances. Callers must not
-    access lazy-loaded relationships on returned objects — only eagerly-loaded columns
-    are safe. Accessing a lazy attribute raises ``DetachedInstanceError``.
+    Warning: methods that return ``list[CraftingRecipeCache]`` yield session-detached
+    ORM instances. Callers must not access lazy-loaded relationships on those objects —
+    only eagerly-loaded columns are safe. Methods returning scalars or plain tuples are
+    unaffected.
     """
     sig = inspect.signature(method)
 
@@ -59,7 +60,21 @@ def _cache_recipe_query(method):
         key = tuple(key_parts)
         if key in _recipe_cache:
             return _recipe_cache[key]
-        result = method(*args, **kwargs)
+        try:
+            result = method(*args, **kwargs)
+        except Exception:
+            import logging
+
+            logging.getLogger(__name__).exception("_cache_recipe_query: %s raised an error", method.__name__)
+            raise
+        # Detach ORM instances from the session so they remain accessible after the
+        # session closes. Only column-level data is safe; lazy relationships raise
+        # DetachedInstanceError if accessed after expunge.
+        session = bound.arguments.get("session")
+        if session is not None and isinstance(result, list):
+            for item in result:
+                if isinstance(item, db.BASE):
+                    session.expunge(item)
         _recipe_cache[key] = result
         return result
 

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -46,7 +46,7 @@ def _cache_recipe_query(method):
     Warning: methods that return ``list[CraftingRecipeCache]`` yield session-detached
     ORM instances. Callers must not access lazy-loaded relationships on those objects —
     only eagerly-loaded columns are safe. Methods returning scalars or plain tuples are
-    unaffected.
+    cached normally but are not subject to session expunge, since they carry no ORM identity.
     """
     sig = inspect.signature(method)
 

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -5,6 +5,7 @@ import functools
 import inspect
 import logging
 from datetime import UTC, datetime
+from threading import RLock
 
 from cachetools import TTLCache
 from sqlalchemy.exc import SQLAlchemyError
@@ -35,6 +36,7 @@ _log = logging.getLogger(__name__)
 # TTL of 1 hour prevents stale data without ever needing a bot restart.
 
 _recipe_cache: TTLCache = TTLCache(maxsize=256, ttl=3600)
+_recipe_cache_lock = RLock()
 
 
 def _cache_recipe_query(method):
@@ -68,8 +70,11 @@ def _cache_recipe_query(method):
                 if name not in ("cls", "session")
             ),
         )
-        if key in _recipe_cache:
-            return _recipe_cache[key]
+        with _recipe_cache_lock:
+            try:
+                return _recipe_cache[key]
+            except KeyError:
+                pass
         try:
             result = method(*args, **kwargs)
         except Exception:
@@ -87,7 +92,8 @@ def _cache_recipe_query(method):
                     method.__name__,
                 )
                 return result  # safe to return detached-ish; just won't be served from cache
-        _recipe_cache[key] = result
+        with _recipe_cache_lock:
+            _recipe_cache[key] = result
         return result
 
     return wrapper
@@ -98,7 +104,8 @@ def invalidate_recipe_cache() -> None:
 
     Call this after a recipe sync completes to ensure fresh data on next access.
     """
-    _recipe_cache.clear()
+    with _recipe_cache_lock:
+        _recipe_cache.clear()
 
 
 class WoW(db.BASE):

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -45,8 +45,14 @@ def _cache_recipe_query(method):
 
     Warning: methods that return ``list[CraftingRecipeCache]`` yield session-detached
     ORM instances. Callers must not access lazy-loaded relationships on those objects —
-    only eagerly-loaded columns are safe. Methods returning scalars or plain tuples are
-    cached normally but are not subject to session expunge, since they carry no ORM identity.
+    only eagerly-loaded columns are safe.
+
+    Return-type behaviour:
+    - ``list[ORM]``: each item is expunged from the session before caching.
+    - ``list[tuple]``: the expunge loop runs but the ``isinstance(item, db.BASE)``
+      guard makes each iteration a no-op — the tuples are cached without expunge.
+    - scalar (bool, int, …): the ``isinstance(result, list)`` guard skips the loop
+      entirely.
     """
     sig = inspect.signature(method)
 
@@ -76,8 +82,11 @@ def _cache_recipe_query(method):
                     if isinstance(item, db.BASE):
                         session.expunge(item)
             except SQLAlchemyError:
-                _log.exception("_cache_recipe_query: %s — expunge failed", method.__name__)
-                raise
+                _log.exception(
+                    "_cache_recipe_query: %s — expunge failed; returning result uncached",
+                    method.__name__,
+                )
+                return result  # safe to return detached-ish; just won't be served from cache
         _recipe_cache[key] = result
         return result
 

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -7,6 +7,7 @@ import logging
 from datetime import UTC, datetime
 
 from cachetools import TTLCache
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import (
     BigInteger,
     Boolean,
@@ -56,7 +57,7 @@ def _cache_recipe_query(method):
         key = (
             method.__name__,
             *(
-                None if (isinstance(val, set) and not val) else (frozenset(val) if isinstance(val, set) else val)
+                frozenset(val) if isinstance(val, set) else val
                 for name, val in bound.arguments.items()
                 if name not in ("cls", "session")
             ),
@@ -70,9 +71,13 @@ def _cache_recipe_query(method):
             raise
         session = bound.arguments.get("session")
         if session is not None and isinstance(result, list):
-            for item in result:
-                if isinstance(item, db.BASE):
-                    session.expunge(item)
+            try:
+                for item in result:
+                    if isinstance(item, db.BASE):
+                        session.expunge(item)
+            except SQLAlchemyError:
+                _log.exception("_cache_recipe_query: %s — expunge failed", method.__name__)
+                raise
         _recipe_cache[key] = result
         return result
 

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -3,6 +3,7 @@
 
 import functools
 import inspect
+import logging
 from datetime import UTC, datetime
 
 from cachetools import TTLCache
@@ -25,6 +26,8 @@ from sqlalchemy import (
     or_,
 )
 from utils import database as db
+
+_log = logging.getLogger(__name__)
 
 # ── CraftingRecipeCache query cache ───────────────────────────────────────────
 # Recipe data changes only on operator-triggered sync (daily/weekly at most).
@@ -50,26 +53,21 @@ def _cache_recipe_query(method):
     def wrapper(*args, **kwargs):
         bound = sig.bind(*args, **kwargs)
         bound.apply_defaults()
-        key_parts = [method.__name__]
-        for name, val in bound.arguments.items():
-            if name in ("cls", "session"):
-                continue
-            if isinstance(val, set):
-                val = frozenset(val)
-            key_parts.append(val)
-        key = tuple(key_parts)
+        key = (
+            method.__name__,
+            *(
+                frozenset(val) if isinstance(val, set) else val
+                for name, val in bound.arguments.items()
+                if name not in ("cls", "session")
+            ),
+        )
         if key in _recipe_cache:
             return _recipe_cache[key]
         try:
             result = method(*args, **kwargs)
         except Exception:
-            import logging
-
-            logging.getLogger(__name__).exception("_cache_recipe_query: %s raised an error", method.__name__)
+            _log.exception("_cache_recipe_query: %s raised an error", method.__name__)
             raise
-        # Detach ORM instances from the session so they remain accessible after the
-        # session closes. Only column-level data is safe; lazy relationships raise
-        # DetachedInstanceError if accessed after expunge.
         session = bound.arguments.get("session")
         if session is not None and isinstance(result, list):
             for item in result:

--- a/NerdyPy/models/wow.py
+++ b/NerdyPy/models/wow.py
@@ -37,6 +37,7 @@ _log = logging.getLogger(__name__)
 
 _recipe_cache: TTLCache = TTLCache(maxsize=256, ttl=3600)
 _recipe_cache_lock = RLock()
+_recipe_cache_generation: int = 0
 
 
 def _cache_recipe_query(method):
@@ -44,6 +45,8 @@ def _cache_recipe_query(method):
 
     Builds a key from the method name + all arguments except ``cls`` and ``session``.
     ``set`` arguments are converted to ``frozenset`` for hashability.
+    Empty ``profession_ids`` (``None`` or ``set()``) are normalized to ``None``
+    so both forms share the same cache entry.
 
     Warning: methods that return ``list[CraftingRecipeCache]`` yield session-detached
     ORM instances. Callers must not access lazy-loaded relationships on those objects —
@@ -58,19 +61,21 @@ def _cache_recipe_query(method):
     """
     sig = inspect.signature(method)
 
+    def _normalize(name, val):
+        if name == "profession_ids" and not val:
+            return None
+        return frozenset(val) if isinstance(val, set) else val
+
     @functools.wraps(method)
     def wrapper(*args, **kwargs):
         bound = sig.bind(*args, **kwargs)
         bound.apply_defaults()
         key = (
             method.__name__,
-            *(
-                frozenset(val) if isinstance(val, set) else val
-                for name, val in bound.arguments.items()
-                if name not in ("cls", "session")
-            ),
+            *(_normalize(name, val) for name, val in bound.arguments.items() if name not in ("cls", "session")),
         )
         with _recipe_cache_lock:
+            generation = _recipe_cache_generation
             try:
                 return _recipe_cache[key]
             except KeyError:
@@ -93,7 +98,8 @@ def _cache_recipe_query(method):
                 )
                 return result  # safe to return detached-ish; just won't be served from cache
         with _recipe_cache_lock:
-            _recipe_cache[key] = result
+            if generation == _recipe_cache_generation:
+                _recipe_cache[key] = result
         return result
 
     return wrapper
@@ -104,7 +110,9 @@ def invalidate_recipe_cache() -> None:
 
     Call this after a recipe sync completes to ensure fresh data on next access.
     """
+    global _recipe_cache_generation
     with _recipe_cache_lock:
+        _recipe_cache_generation += 1
         _recipe_cache.clear()
 
 

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -43,16 +43,6 @@ def _localize_field(
     modal.add_item(discord.ui.Label(text=get_string(lang, f"{key_prefix}_label"), component=field))
 
 
-def _filter_choices(items, current: str) -> list[app_commands.Choice[str]]:
-    """Build autocomplete choices from items with a .Name attribute, filtering by current input."""
-    choices = []
-    for item in items:
-        if current and current.lower() not in item.Name.lower():
-            continue
-        choices.append(app_commands.Choice(name=item.Name[:100], value=item.Name))
-    return choices[:25]
-
-
 @app_commands.default_permissions(administrator=True)
 @app_commands.guild_only()
 class Application(NerpyBotCog, GroupCog, group_name="application"):
@@ -83,10 +73,14 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
 
         def _fetch():
             with self.bot.session_scope() as session:
-                return ApplicationForm.get_all_by_guild(guild_id, session)
+                return [f.Name for f in ApplicationForm.get_all_by_guild(guild_id, session)]
 
-        forms = cached_autocomplete(("app_forms", guild_id), _fetch)
-        return _filter_choices(forms, current)
+        form_names = cached_autocomplete(("app_forms", guild_id), _fetch)
+        return [
+            app_commands.Choice(name=n[:100], value=n)
+            for n in form_names
+            if not current or current.lower() in n.lower()
+        ][:25]
 
     async def _template_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
         lang = self._lang(interaction.guild_id)
@@ -94,28 +88,28 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
 
         def _fetch():
             with self.bot.session_scope() as session:
-                return ApplicationTemplate.get_available(guild_id, session)
+                return [(tpl.Name, tpl.IsBuiltIn) for tpl in ApplicationTemplate.get_available(guild_id, session)]
 
         templates = cached_autocomplete(("app_templates", guild_id), _fetch)
         choices = []
-        for tpl in templates:
-            if tpl.IsBuiltIn:
-                yaml_key = TEMPLATE_KEY_MAP.get(tpl.Name)
+        for name, is_built_in in templates:
+            if is_built_in:
+                yaml_key = TEMPLATE_KEY_MAP.get(name)
                 if yaml_key:
                     try:
                         localized_name = get_raw(lang, f"application.builtin_templates.{yaml_key}.name")
                     except KeyError:
-                        localized_name = tpl.Name
+                        localized_name = name
                 else:
-                    localized_name = tpl.Name
+                    localized_name = name
                 prefix = get_string(lang, "application.template.list.prefix_builtin")
                 label = f"{prefix} {localized_name}"
             else:
-                localized_name = tpl.Name
-                label = tpl.Name
+                localized_name = name
+                label = name
             if current and current.lower() not in localized_name.lower():
                 continue
-            choices.append(app_commands.Choice(name=label[:100], value=tpl.Name))
+            choices.append(app_commands.Choice(name=label[:100], value=name))
         return choices[:25]
 
     async def _guild_template_autocomplete(
@@ -125,10 +119,14 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
 
         def _fetch():
             with self.bot.session_scope() as session:
-                return ApplicationTemplate.get_guild_templates(guild_id, session)
+                return [t.Name for t in ApplicationTemplate.get_guild_templates(guild_id, session)]
 
-        templates = cached_autocomplete(("app_guild_templates", guild_id), _fetch)
-        return _filter_choices(templates, current)
+        template_names = cached_autocomplete(("app_guild_templates", guild_id), _fetch)
+        return [
+            app_commands.Choice(name=n[:100], value=n)
+            for n in template_names
+            if not current or current.lower() in n.lower()
+        ][:25]
 
     # -- Permission helper ---------------------------------------------------
 

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -75,7 +75,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
             with self.bot.session_scope() as session:
                 return [f.Name for f in ApplicationForm.get_all_by_guild(guild_id, session)]
 
-        return build_name_choices(cached_autocomplete(("app_forms", guild_id), _fetch), current)
+        return build_name_choices(await cached_autocomplete(("app_forms", guild_id), _fetch), current)
 
     async def _template_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
         lang = self._lang(interaction.guild_id)
@@ -85,7 +85,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
             with self.bot.session_scope() as session:
                 return [(tpl.Name, tpl.IsBuiltIn) for tpl in ApplicationTemplate.get_available(guild_id, session)]
 
-        templates = cached_autocomplete(("app_templates", guild_id), _fetch)
+        templates = await cached_autocomplete(("app_templates", guild_id), _fetch)
         choices = []
         for name, is_built_in in templates:
             if is_built_in:
@@ -116,7 +116,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
             with self.bot.session_scope() as session:
                 return [t.Name for t in ApplicationTemplate.get_guild_templates(guild_id, session)]
 
-        return build_name_choices(cached_autocomplete(("app_guild_templates", guild_id), _fetch), current)
+        return build_name_choices(await cached_autocomplete(("app_guild_templates", guild_id), _fetch), current)
 
     # -- Permission helper ---------------------------------------------------
 

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -28,7 +28,12 @@ from modules.conversations.application import (
 )
 from modules.views.application import check_override_permission
 from sqlalchemy.exc import SQLAlchemyError
-from utils.cache import build_name_choices, cached_autocomplete, invalidate_autocomplete
+from utils.cache import (
+    build_name_choices,
+    cached_autocomplete,
+    invalidate_autocomplete,
+    invalidate_autocomplete_app_templates,
+)
 from utils.cog import NerpyBotCog
 from utils.helpers import fetch_message_content, send_hidden_message
 from utils.strings import get_raw, get_string
@@ -849,8 +854,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
                     ApplicationTemplateQuestion(TemplateId=tpl.Id, QuestionText=q.QuestionText, SortOrder=q.SortOrder)
                 )
 
-        invalidate_autocomplete(("app_templates", interaction.guild.id))
-        invalidate_autocomplete(("app_guild_templates", interaction.guild.id))
+        invalidate_autocomplete_app_templates(interaction.guild.id)
         await interaction.response.send_message(
             get_string(lang, "application.template.save.success", template_name=template_name, form=form),
             ephemeral=True,
@@ -882,8 +886,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
                 return
             session.delete(tpl)
 
-        invalidate_autocomplete(("app_templates", interaction.guild.id))
-        invalidate_autocomplete(("app_guild_templates", interaction.guild.id))
+        invalidate_autocomplete_app_templates(interaction.guild.id)
         await interaction.response.send_message(
             get_string(lang, "application.template.delete.success", name=template_name), ephemeral=True
         )

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -28,7 +28,7 @@ from modules.conversations.application import (
 )
 from modules.views.application import check_override_permission
 from sqlalchemy.exc import SQLAlchemyError
-from utils.cache import cached_autocomplete
+from utils.cache import build_name_choices, cached_autocomplete
 from utils.cog import NerpyBotCog
 from utils.helpers import fetch_message_content, send_hidden_message
 from utils.strings import get_raw, get_string
@@ -75,12 +75,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
             with self.bot.session_scope() as session:
                 return [f.Name for f in ApplicationForm.get_all_by_guild(guild_id, session)]
 
-        form_names = cached_autocomplete(("app_forms", guild_id), _fetch)
-        return [
-            app_commands.Choice(name=n[:100], value=n)
-            for n in form_names
-            if not current or current.lower() in n.lower()
-        ][:25]
+        return build_name_choices(cached_autocomplete(("app_forms", guild_id), _fetch), current)
 
     async def _template_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
         lang = self._lang(interaction.guild_id)
@@ -121,12 +116,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
             with self.bot.session_scope() as session:
                 return [t.Name for t in ApplicationTemplate.get_guild_templates(guild_id, session)]
 
-        template_names = cached_autocomplete(("app_guild_templates", guild_id), _fetch)
-        return [
-            app_commands.Choice(name=n[:100], value=n)
-            for n in template_names
-            if not current or current.lower() in n.lower()
-        ][:25]
+        return build_name_choices(cached_autocomplete(("app_guild_templates", guild_id), _fetch), current)
 
     # -- Permission helper ---------------------------------------------------
 

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -1142,6 +1142,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
                     ApplicationQuestion(FormId=form.Id, QuestionText=q["text"].strip(), SortOrder=q.get("order", i + 1))
                 )
 
+        invalidate_autocomplete(("app_forms", interaction.guild.id))
         await interaction.user.send(
             get_string(lang, "application.import.success", name=form_name, count=len(questions))
         )

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -28,7 +28,7 @@ from modules.conversations.application import (
 )
 from modules.views.application import check_override_permission
 from sqlalchemy.exc import SQLAlchemyError
-from utils.cache import build_name_choices, cached_autocomplete
+from utils.cache import build_name_choices, cached_autocomplete, invalidate_autocomplete
 from utils.cog import NerpyBotCog
 from utils.helpers import fetch_message_content, send_hidden_message
 from utils.strings import get_raw, get_string
@@ -384,6 +384,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
             apply_message_id = form.ApplyMessageId
             session.delete(form)
 
+        invalidate_autocomplete(("app_forms", interaction.guild.id))
         await interaction.response.send_message(
             get_string(lang, "application.delete.success", name=name), ephemeral=True
         )
@@ -783,6 +784,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
                         )
                 form_id = form.Id
 
+            invalidate_autocomplete(("app_forms", guild_id))
             await modal_interaction.response.send_message(
                 get_string(lang, "application.template.use.success", name=name, template=template), ephemeral=True
             )
@@ -847,6 +849,8 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
                     ApplicationTemplateQuestion(TemplateId=tpl.Id, QuestionText=q.QuestionText, SortOrder=q.SortOrder)
                 )
 
+        invalidate_autocomplete(("app_templates", interaction.guild.id))
+        invalidate_autocomplete(("app_guild_templates", interaction.guild.id))
         await interaction.response.send_message(
             get_string(lang, "application.template.save.success", template_name=template_name, form=form),
             ephemeral=True,
@@ -878,6 +882,8 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
                 return
             session.delete(tpl)
 
+        invalidate_autocomplete(("app_templates", interaction.guild.id))
+        invalidate_autocomplete(("app_guild_templates", interaction.guild.id))
         await interaction.response.send_message(
             get_string(lang, "application.template.delete.success", name=template_name), ephemeral=True
         )

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -28,6 +28,7 @@ from modules.conversations.application import (
 )
 from modules.views.application import check_override_permission
 from sqlalchemy.exc import SQLAlchemyError
+from utils.cache import cached_autocomplete
 from utils.cog import NerpyBotCog
 from utils.helpers import fetch_message_content, send_hidden_message
 from utils.strings import get_raw, get_string
@@ -78,39 +79,56 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
     # -- Autocomplete helpers ------------------------------------------------
 
     async def _form_name_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
-        with self.bot.session_scope() as session:
-            return _filter_choices(ApplicationForm.get_all_by_guild(interaction.guild.id, session), current)
+        guild_id = interaction.guild.id
+
+        def _fetch():
+            with self.bot.session_scope() as session:
+                return ApplicationForm.get_all_by_guild(guild_id, session)
+
+        forms = cached_autocomplete(("app_forms", guild_id), _fetch)
+        return _filter_choices(forms, current)
 
     async def _template_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
         lang = self._lang(interaction.guild_id)
-        with self.bot.session_scope() as session:
-            templates = ApplicationTemplate.get_available(interaction.guild.id, session)
-            choices = []
-            for tpl in templates:
-                if tpl.IsBuiltIn:
-                    yaml_key = TEMPLATE_KEY_MAP.get(tpl.Name)
-                    if yaml_key:
-                        try:
-                            localized_name = get_raw(lang, f"application.builtin_templates.{yaml_key}.name")
-                        except KeyError:
-                            localized_name = tpl.Name
-                    else:
+        guild_id = interaction.guild.id
+
+        def _fetch():
+            with self.bot.session_scope() as session:
+                return ApplicationTemplate.get_available(guild_id, session)
+
+        templates = cached_autocomplete(("app_templates", guild_id), _fetch)
+        choices = []
+        for tpl in templates:
+            if tpl.IsBuiltIn:
+                yaml_key = TEMPLATE_KEY_MAP.get(tpl.Name)
+                if yaml_key:
+                    try:
+                        localized_name = get_raw(lang, f"application.builtin_templates.{yaml_key}.name")
+                    except KeyError:
                         localized_name = tpl.Name
-                    prefix = get_string(lang, "application.template.list.prefix_builtin")
-                    label = f"{prefix} {localized_name}"
                 else:
                     localized_name = tpl.Name
-                    label = tpl.Name
-                if current and current.lower() not in localized_name.lower():
-                    continue
-                choices.append(app_commands.Choice(name=label[:100], value=tpl.Name))
-            return choices[:25]
+                prefix = get_string(lang, "application.template.list.prefix_builtin")
+                label = f"{prefix} {localized_name}"
+            else:
+                localized_name = tpl.Name
+                label = tpl.Name
+            if current and current.lower() not in localized_name.lower():
+                continue
+            choices.append(app_commands.Choice(name=label[:100], value=tpl.Name))
+        return choices[:25]
 
     async def _guild_template_autocomplete(
         self, interaction: Interaction, current: str
     ) -> list[app_commands.Choice[str]]:
-        with self.bot.session_scope() as session:
-            return _filter_choices(ApplicationTemplate.get_guild_templates(interaction.guild.id, session), current)
+        guild_id = interaction.guild.id
+
+        def _fetch():
+            with self.bot.session_scope() as session:
+                return ApplicationTemplate.get_guild_templates(guild_id, session)
+
+        templates = cached_autocomplete(("app_guild_templates", guild_id), _fetch)
+        return _filter_choices(templates, current)
 
     # -- Permission helper ---------------------------------------------------
 

--- a/NerdyPy/modules/application.py
+++ b/NerdyPy/modules/application.py
@@ -104,7 +104,7 @@ class Application(NerpyBotCog, GroupCog, group_name="application"):
                 label = name
             if current and current.lower() not in localized_name.lower():
                 continue
-            choices.append(app_commands.Choice(name=label[:100], value=name))
+            choices.append(app_commands.Choice(name=label[:100], value=name[:100]))
         return choices[:25]
 
     async def _guild_template_autocomplete(

--- a/NerdyPy/modules/conversations/application.py
+++ b/NerdyPy/modules/conversations/application.py
@@ -25,6 +25,7 @@ from models.application import (
     SubmissionStatus,
 )
 from modules.views.application import ApplicationReviewView, build_review_embed
+from utils.cache import invalidate_autocomplete
 from utils.conversation import Conversation
 from utils.strings import get_string
 
@@ -319,6 +320,7 @@ class ApplicationCreateConversation(Conversation):
                 session.add(ApplicationQuestion(FormId=form.Id, QuestionText=q_text, SortOrder=i))
             form_id = form.Id
 
+        invalidate_autocomplete(("app_forms", self.guild.id))
         if self.apply_channel_id:
             from modules.views.application import post_apply_button_message
 
@@ -475,6 +477,8 @@ class ApplicationTemplateCreateConversation(Conversation):
             for i, q_text in enumerate(self.questions, start=1):
                 session.add(ApplicationTemplateQuestion(TemplateId=tpl.Id, QuestionText=q_text, SortOrder=i))
 
+        invalidate_autocomplete(("app_templates", self.guild.id))
+        invalidate_autocomplete(("app_guild_templates", self.guild.id))
         emb = _questions_embed(
             get_string(self.lang, f"{_c}.done_title", name=self.template_name),
             self.questions,

--- a/NerdyPy/modules/conversations/application.py
+++ b/NerdyPy/modules/conversations/application.py
@@ -25,7 +25,7 @@ from models.application import (
     SubmissionStatus,
 )
 from modules.views.application import ApplicationReviewView, build_review_embed
-from utils.cache import invalidate_autocomplete
+from utils.cache import invalidate_autocomplete, invalidate_autocomplete_app_templates
 from utils.conversation import Conversation
 from utils.strings import get_string
 
@@ -477,8 +477,7 @@ class ApplicationTemplateCreateConversation(Conversation):
             for i, q_text in enumerate(self.questions, start=1):
                 session.add(ApplicationTemplateQuestion(TemplateId=tpl.Id, QuestionText=q_text, SortOrder=i))
 
-        invalidate_autocomplete(("app_templates", self.guild.id))
-        invalidate_autocomplete(("app_guild_templates", self.guild.id))
+        invalidate_autocomplete_app_templates(self.guild.id)
         emb = _questions_embed(
             get_string(self.lang, f"{_c}.done_title", name=self.template_name),
             self.questions,

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -15,6 +15,7 @@ from pytimeparse2 import parse
 from models.leavemsg import LeaveMessage
 from models.moderation import AutoDelete, AutoKicker
 
+from utils.cache import LEAVE_CONFIG_DB_ERROR
 from utils.cog import NerpyBotCog
 from utils.errors import NerpyValidationError
 from utils.helpers import fetch_message_content, notify_error, register_before_loop, send_hidden_message, send_paginated
@@ -619,26 +620,26 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         if member.bot:
             return
 
+        self.bot.guild_cache.try_rewarm_leave_messages(self.bot.SESSION)
+
         if not self.bot.guild_cache.is_leave_message_guild(member.guild.id):
             return
 
         try:
             leave_config = self.bot.guild_cache.get_leave_config(member.guild.id, self.bot.SESSION)
+            if leave_config is LEAVE_CONFIG_DB_ERROR:
+                self.bot.log.warning(
+                    "[%s (%d)]: on_member_remove: DB error reading leave config — skipping",
+                    member.guild.name,
+                    member.guild.id,
+                )
+                return
             if leave_config is None:
-                # Warmed cache + None means the guild was in the evicted set (prior DB error or reload);
-                # log at warning so a DB failure isn't indistinguishable from normal "no config" operation.
-                if self.bot.guild_cache.leave_warmed:
-                    self.bot.log.warning(
-                        "[%s (%d)]: on_member_remove: leave config missing after cache eviction — DB error likely",
-                        member.guild.name,
-                        member.guild.id,
-                    )
-                else:
-                    self.bot.log.debug(
-                        "[%s (%d)]: on_member_remove: no leave config — skipping",
-                        member.guild.name,
-                        member.guild.id,
-                    )
+                self.bot.log.debug(
+                    "[%s (%d)]: on_member_remove: no leave config — skipping",
+                    member.guild.name,
+                    member.guild.id,
+                )
                 return
 
             channel_id, message_text = leave_config

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -620,7 +620,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         if member.bot:
             return
 
-        self.bot.guild_cache.try_rewarm_leave_messages(self.bot.SESSION)
+        await self.bot.guild_cache.try_rewarm_leave_messages(self.bot.SESSION)
 
         if not self.bot.guild_cache.is_leave_message_guild(member.guild.id):
             return

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -719,9 +719,10 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
                 raise NerpyValidationError(get_string(lang, "leavemsg.message.not_enabled"))
             leave_config.Message = message
             channel_id = leave_config.ChannelId  # read inside scope before session closes
+            enabled = leave_config.Enabled  # read inside scope before session closes
 
-        # Update cached message text unconditionally — channel_id sourced from DB
-        self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, True, channel_id, message)
+        # Update cached message text — preserve actual Enabled state from DB
+        self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, enabled, channel_id, message)
         await send_hidden_message(interaction, get_string(lang, "leavemsg.message.success", message=message))
 
     @leavemsg.command(name="message")

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -14,6 +14,7 @@ from pytimeparse2 import parse
 
 from models.leavemsg import LeaveMessage
 from models.moderation import AutoDelete, AutoKicker
+from sqlalchemy.exc import SQLAlchemyError
 
 from utils.cog import NerpyBotCog
 from utils.errors import NerpyValidationError
@@ -622,7 +623,13 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         if not self.bot.guild_cache.is_leave_message_guild(member.guild.id):
             return
 
-        leave_config = self.bot.guild_cache.get_leave_config(member.guild.id, self.bot.SESSION)
+        try:
+            leave_config = self.bot.guild_cache.get_leave_config(member.guild.id, self.bot.SESSION)
+        except SQLAlchemyError as ex:
+            self.bot.log.error(
+                f"[{member.guild.name} ({member.guild.id})]: on_member_remove: DB error fetching leave config for {member}: {ex}"
+            )
+            return
         if leave_config is None:
             self.bot.log.debug(
                 "[%s (%d)]: on_member_remove: leave message guild set but config absent — cache not warmed?",

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -625,11 +625,20 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         try:
             leave_config = self.bot.guild_cache.get_leave_config(member.guild.id, self.bot.SESSION)
             if leave_config is None:
-                self.bot.log.debug(
-                    "[%s (%d)]: on_member_remove: no leave config — skipping",
-                    member.guild.name,
-                    member.guild.id,
-                )
+                # Warmed cache + None means the guild was in the evicted set (prior DB error or reload);
+                # log at warning so a DB failure isn't indistinguishable from normal "no config" operation.
+                if self.bot.guild_cache.leave_warmed:
+                    self.bot.log.warning(
+                        "[%s (%d)]: on_member_remove: leave config missing after cache eviction — DB error likely",
+                        member.guild.name,
+                        member.guild.id,
+                    )
+                else:
+                    self.bot.log.debug(
+                        "[%s (%d)]: on_member_remove: no leave config — skipping",
+                        member.guild.name,
+                        member.guild.id,
+                    )
                 return
 
             channel_id, message_text = leave_config

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -14,7 +14,6 @@ from pytimeparse2 import parse
 
 from models.leavemsg import LeaveMessage
 from models.moderation import AutoDelete, AutoKicker
-from sqlalchemy.exc import SQLAlchemyError
 
 from utils.cog import NerpyBotCog
 from utils.errors import NerpyValidationError
@@ -625,45 +624,43 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
 
         try:
             leave_config = self.bot.guild_cache.get_leave_config(member.guild.id, self.bot.SESSION)
-        except SQLAlchemyError as ex:
-            self.bot.log.error(
-                f"[{member.guild.name} ({member.guild.id})]: on_member_remove: DB error fetching leave config for {member}: {ex}"
+            if leave_config is None:
+                self.bot.log.debug(
+                    "[%s (%d)]: on_member_remove: leave message guild set but config absent — cache not warmed?",
+                    member.guild.name,
+                    member.guild.id,
+                )
+                return
+
+            channel_id, message_text = leave_config
+            channel = member.guild.get_channel(channel_id)
+            if channel is None:
+                try:
+                    channel = await member.guild.fetch_channel(channel_id)
+                except (discord.NotFound, discord.Forbidden):
+                    channel = None
+            if channel is None or not isinstance(channel, TextChannel):
+                self.bot.log.warning(
+                    f"[{member.guild.name} ({member.guild.id})]: leave channel {channel_id} not found or not a text channel"
+                )
+                return
+
+            self.bot.log.debug(f"[{member.guild.name} ({member.guild.id})]: sending leave message for {member}")
+
+            message = message_text or DEFAULT_LEAVE_MESSAGE
+            member_str = f"**{member.display_name}** ({member.name})"
+            formatted_message = (
+                message.replace("{member}", member_str) if "{member}" in message else f"{message} — {member_str}"
             )
-            return
-        if leave_config is None:
-            self.bot.log.debug(
-                "[%s (%d)]: on_member_remove: leave message guild set but config absent — cache not warmed?",
-                member.guild.name,
-                member.guild.id,
-            )
-            return
 
-        channel_id, message_text = leave_config
-        channel = member.guild.get_channel(channel_id)
-        if channel is None:
-            try:
-                channel = await member.guild.fetch_channel(channel_id)
-            except (discord.NotFound, discord.Forbidden):
-                channel = None
-        if channel is None or not isinstance(channel, TextChannel):
-            self.bot.log.warning(
-                f"[{member.guild.name} ({member.guild.id})]: leave channel {channel_id} not found or not a text channel"
-            )
-            return
-
-        self.bot.log.debug(f"[{member.guild.name} ({member.guild.id})]: sending leave message for {member}")
-
-        message = message_text or DEFAULT_LEAVE_MESSAGE
-        member_str = f"**{member.display_name}** ({member.name})"
-        formatted_message = (
-            message.replace("{member}", member_str) if "{member}" in message else f"{message} — {member_str}"
-        )
-
-        try:
             await channel.send(formatted_message)
         except discord.HTTPException as ex:
             self.bot.log.error(
                 f"[{member.guild.name} ({member.guild.id})]: failed to send leave message for {member}: {ex}"
+            )
+        except Exception:
+            self.bot.log.exception(
+                "[%s (%d)]: on_member_remove: unexpected error for %s", member.guild.name, member.guild.id, member
             )
 
     # ── /moderation leavemsg commands ────────────────────────────────────────
@@ -699,7 +696,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
                     leave_config.Message = DEFAULT_LEAVE_MESSAGE
             final_message = leave_config.Message  # always set in all branches above
 
-        self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, True, channel.id, final_message)
+        self.bot.guild_cache.set_leave_config(interaction.guild.id, channel.id, final_message)
         await send_hidden_message(interaction, get_string(lang, "leavemsg.enable.success", channel=channel.mention))
 
     @leavemsg.command(name="disable")
@@ -713,7 +710,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
                 raise NerpyValidationError(get_string(lang, "leavemsg.disable.not_configured"))
             leave_config.Enabled = False
 
-        self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, False)
+        self.bot.guild_cache.evict_leave_config(interaction.guild.id)
         await send_hidden_message(interaction, get_string(lang, "leavemsg.disable.success"))
 
     async def save_leave_message(self, interaction: Interaction, message: str, lang: str) -> None:
@@ -730,7 +727,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
 
         # Only update cache when enabled — disabled state is already reflected (evicted by /leavemsg disable)
         if enabled:
-            self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, True, channel_id, message)
+            self.bot.guild_cache.set_leave_config(interaction.guild.id, channel_id, message)
         await send_hidden_message(interaction, get_string(lang, "leavemsg.message.success", message=message))
 
     @leavemsg.command(name="message")

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -622,7 +622,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         if not self.bot.guild_cache.is_leave_message_guild(member.guild.id):
             return
 
-        leave_config = self.bot.guild_cache.get_leave_config(member.guild.id)
+        leave_config = self.bot.guild_cache.get_leave_config(member.guild.id, self.bot.SESSION)
         if leave_config is None:
             self.bot.log.debug(
                 "[%s (%d)]: on_member_remove: leave message guild set but config absent — cache not warmed?",

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -622,28 +622,31 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         if not self.bot.guild_cache.is_leave_message_guild(member.guild.id):
             return
 
-        with self.bot.session_scope() as session:
-            leave_config = LeaveMessage.get(member.guild.id, session)
-
-        if leave_config is None or not leave_config.Enabled:
+        leave_config = self.bot.guild_cache.get_leave_config(member.guild.id)
+        if leave_config is None:
+            self.bot.log.debug(
+                "[%s (%d)]: on_member_remove: leave message guild set but config absent — cache not warmed?",
+                member.guild.name,
+                member.guild.id,
+            )
             return
 
-        channel = member.guild.get_channel(leave_config.ChannelId)
+        channel_id, message_text = leave_config
+        channel = member.guild.get_channel(channel_id)
         if channel is None:
             try:
-                channel = await member.guild.fetch_channel(leave_config.ChannelId)
+                channel = await member.guild.fetch_channel(channel_id)
             except (discord.NotFound, discord.Forbidden):
                 channel = None
         if channel is None or not isinstance(channel, TextChannel):
             self.bot.log.warning(
-                f"[{member.guild.name} ({member.guild.id})]: "
-                f"leave channel {leave_config.ChannelId} not found or not a text channel"
+                f"[{member.guild.name} ({member.guild.id})]: leave channel {channel_id} not found or not a text channel"
             )
             return
 
         self.bot.log.debug(f"[{member.guild.name} ({member.guild.id})]: sending leave message for {member}")
 
-        message = leave_config.Message or DEFAULT_LEAVE_MESSAGE
+        message = message_text or DEFAULT_LEAVE_MESSAGE
         member_str = f"**{member.display_name}** ({member.name})"
         formatted_message = (
             message.replace("{member}", member_str) if "{member}" in message else f"{message} — {member_str}"
@@ -687,11 +690,10 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
                 leave_config.Enabled = True
                 if leave_config.Message is None:
                     leave_config.Message = DEFAULT_LEAVE_MESSAGE
+            final_message = leave_config.Message  # always set in all branches above
 
-        self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, True)
-        await interaction.response.send_message(
-            get_string(lang, "leavemsg.enable.success", channel=channel.mention), ephemeral=True
-        )
+        self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, True, channel.id, final_message)
+        await send_hidden_message(interaction, get_string(lang, "leavemsg.enable.success", channel=channel.mention))
 
     @leavemsg.command(name="disable")
     @checks.has_permissions(administrator=True)
@@ -705,7 +707,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
             leave_config.Enabled = False
 
         self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, False)
-        await interaction.response.send_message(get_string(lang, "leavemsg.disable.success"), ephemeral=True)
+        await send_hidden_message(interaction, get_string(lang, "leavemsg.disable.success"))
 
     async def save_leave_message(self, interaction: Interaction, message: str, lang: str) -> None:
         """Validate and persist a leave message, then confirm to the user."""
@@ -716,15 +718,11 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
             if leave_config is None:
                 raise NerpyValidationError(get_string(lang, "leavemsg.message.not_enabled"))
             leave_config.Message = message
+            channel_id = leave_config.ChannelId  # read inside scope before session closes
 
-        if not interaction.response.is_done():
-            await interaction.response.send_message(
-                get_string(lang, "leavemsg.message.success", message=message), ephemeral=True
-            )
-        else:
-            await interaction.followup.send(
-                get_string(lang, "leavemsg.message.success", message=message), ephemeral=True
-            )
+        # Update cached message text unconditionally — channel_id sourced from DB
+        self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, True, channel_id, message)
+        await send_hidden_message(interaction, get_string(lang, "leavemsg.message.success", message=message))
 
     @leavemsg.command(name="message")
     @checks.has_permissions(administrator=True)
@@ -748,7 +746,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
                 self.bot, message_source, None, interaction, lang, key_prefix="leavemsg.fetch_message"
             )
             if error:
-                await interaction.response.send_message(error, ephemeral=True)
+                await send_hidden_message(interaction, error)
                 return
             message = content
 
@@ -770,15 +768,15 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
             leave_config = LeaveMessage.get(interaction.guild.id, session)
 
         if leave_config is None or not leave_config.Enabled:
-            await interaction.response.send_message(get_string(lang, "leavemsg.status.not_enabled"), ephemeral=True)
+            await send_hidden_message(interaction, get_string(lang, "leavemsg.status.not_enabled"))
             return
 
         channel = interaction.guild.get_channel(leave_config.ChannelId)
         channel_mention = channel.mention if channel else "Unknown channel"
         message = leave_config.Message or DEFAULT_LEAVE_MESSAGE
 
-        await interaction.response.send_message(
-            get_string(lang, "leavemsg.status.enabled", channel=channel_mention, message=message), ephemeral=True
+        await send_hidden_message(
+            interaction, get_string(lang, "leavemsg.status.enabled", channel=channel_mention, message=message)
         )
 
 
@@ -801,7 +799,7 @@ class _LeaveMessageModal(discord.ui.Modal):
     async def on_submit(self, interaction: Interaction):
         cog = self.bot.get_cog("Moderation")
         if cog is None:
-            await interaction.response.send_message("Bot is reloading, please try again.", ephemeral=True)
+            await send_hidden_message(interaction, "Bot is reloading, please try again.")
             return
         await cog.save_leave_message(interaction, self.message_input.value.strip(), self.lang)
 

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -626,7 +626,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
             leave_config = self.bot.guild_cache.get_leave_config(member.guild.id, self.bot.SESSION)
             if leave_config is None:
                 self.bot.log.debug(
-                    "[%s (%d)]: on_member_remove: leave message guild set but config absent — cache not warmed?",
+                    "[%s (%d)]: on_member_remove: no leave config — skipping",
                     member.guild.name,
                     member.guild.id,
                 )

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -728,8 +728,9 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
             channel_id = leave_config.ChannelId  # read inside scope before session closes
             enabled = leave_config.Enabled  # read inside scope before session closes
 
-        # Update cached message text — preserve actual Enabled state from DB
-        self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, enabled, channel_id, message)
+        # Only update cache when enabled — disabled state is already reflected (evicted by /leavemsg disable)
+        if enabled:
+            self.bot.guild_cache.set_leave_message_guild(interaction.guild.id, True, channel_id, message)
         await send_hidden_message(interaction, get_string(lang, "leavemsg.message.success", message=message))
 
     @leavemsg.command(name="message")

--- a/NerdyPy/modules/music.py
+++ b/NerdyPy/modules/music.py
@@ -10,7 +10,7 @@ from discord.ext.commands import Cog
 from models.music import Playlist, PlaylistEntry
 from modules.views.music import NowPlayingView, build_now_playing_embed
 from utils.audio import QueuedSong, QueueMixin
-from utils.cache import build_name_choices, cached_autocomplete
+from utils.cache import build_name_choices, cached_autocomplete, invalidate_autocomplete
 from utils.checks import is_connected_to_voice
 from utils.cog import NerpyBotCog
 from utils.download import download, fetch_yt_infos
@@ -23,7 +23,7 @@ from utils.strings import get_string
 class Music(NerpyBotCog, QueueMixin, Cog):
     """Music playback and playlist management."""
 
-    playlist = app_commands.Group(name="playlist", description="Manage your saved playlists")
+    playlist = app_commands.Group(name="playlist", description="Manage your saved playlists", guild_only=True)
 
     def __init__(self, bot):
         super().__init__(bot)
@@ -247,6 +247,7 @@ class Music(NerpyBotCog, QueueMixin, Cog):
                     Name=name,
                 )
             )
+        invalidate_autocomplete(("playlists", interaction.guild_id, interaction.user.id))
         await interaction.followup.send(get_string(lang, "music.playlist.created", name=name), ephemeral=True)
 
     @playlist.command(name="list")
@@ -358,6 +359,7 @@ class Music(NerpyBotCog, QueueMixin, Cog):
                     )
                 )
 
+        invalidate_autocomplete(("playlists", interaction.guild_id, interaction.user.id))
         await interaction.followup.send(
             get_string(lang, "music.playlist.saved", count=len(songs), name=name), ephemeral=True
         )
@@ -393,6 +395,7 @@ class Music(NerpyBotCog, QueueMixin, Cog):
                 await interaction.followup.send(get_string(lang, "music.playlist.not_found", name=name), ephemeral=True)
                 return
             session.delete(pl)
+        invalidate_autocomplete(("playlists", interaction.guild_id, interaction.user.id))
         await interaction.followup.send(get_string(lang, "music.playlist.deleted", name=name), ephemeral=True)
 
     @playlist.command(name="load")

--- a/NerdyPy/modules/music.py
+++ b/NerdyPy/modules/music.py
@@ -10,6 +10,7 @@ from discord.ext.commands import Cog
 from models.music import Playlist, PlaylistEntry
 from modules.views.music import NowPlayingView, build_now_playing_embed
 from utils.audio import QueuedSong, QueueMixin
+from utils.cache import cached_autocomplete
 from utils.checks import is_connected_to_voice
 from utils.cog import NerpyBotCog
 from utils.download import download, fetch_yt_infos
@@ -178,8 +179,14 @@ class Music(NerpyBotCog, QueueMixin, Cog):
 
     async def _ac_playlist_name(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
         """Autocomplete for playlist name from the user's saved playlists."""
-        with self.bot.session_scope() as session:
-            playlists = Playlist.get_by_user(interaction.guild_id, interaction.user.id, session)
+        guild_id = interaction.guild_id
+        user_id = interaction.user.id
+
+        def _fetch():
+            with self.bot.session_scope() as session:
+                return Playlist.get_by_user(guild_id, user_id, session)
+
+        playlists = cached_autocomplete(("playlists", guild_id, user_id), _fetch)
         return [app_commands.Choice(name=p.Name, value=p.Name) for p in playlists if current.lower() in p.Name.lower()][
             :25
         ]

--- a/NerdyPy/modules/music.py
+++ b/NerdyPy/modules/music.py
@@ -184,12 +184,10 @@ class Music(NerpyBotCog, QueueMixin, Cog):
 
         def _fetch():
             with self.bot.session_scope() as session:
-                return Playlist.get_by_user(guild_id, user_id, session)
+                return [p.Name for p in Playlist.get_by_user(guild_id, user_id, session)]
 
-        playlists = cached_autocomplete(("playlists", guild_id, user_id), _fetch)
-        return [app_commands.Choice(name=p.Name, value=p.Name) for p in playlists if current.lower() in p.Name.lower()][
-            :25
-        ]
+        playlist_names = cached_autocomplete(("playlists", guild_id, user_id), _fetch)
+        return [app_commands.Choice(name=n, value=n) for n in playlist_names if current.lower() in n.lower()][:25]
 
     async def _ac_playlist_url(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
         """Autocomplete for song URL within a named playlist (reads sibling `name` field)."""

--- a/NerdyPy/modules/music.py
+++ b/NerdyPy/modules/music.py
@@ -186,7 +186,7 @@ class Music(NerpyBotCog, QueueMixin, Cog):
             with self.bot.session_scope() as session:
                 return [p.Name for p in Playlist.get_by_user(guild_id, user_id, session)]
 
-        return build_name_choices(cached_autocomplete(("playlists", guild_id, user_id), _fetch), current)
+        return build_name_choices(await cached_autocomplete(("playlists", guild_id, user_id), _fetch), current)
 
     async def _ac_playlist_url(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
         """Autocomplete for song URL within a named playlist (reads sibling `name` field)."""

--- a/NerdyPy/modules/music.py
+++ b/NerdyPy/modules/music.py
@@ -10,7 +10,7 @@ from discord.ext.commands import Cog
 from models.music import Playlist, PlaylistEntry
 from modules.views.music import NowPlayingView, build_now_playing_embed
 from utils.audio import QueuedSong, QueueMixin
-from utils.cache import cached_autocomplete
+from utils.cache import build_name_choices, cached_autocomplete
 from utils.checks import is_connected_to_voice
 from utils.cog import NerpyBotCog
 from utils.download import download, fetch_yt_infos
@@ -186,8 +186,7 @@ class Music(NerpyBotCog, QueueMixin, Cog):
             with self.bot.session_scope() as session:
                 return [p.Name for p in Playlist.get_by_user(guild_id, user_id, session)]
 
-        playlist_names = cached_autocomplete(("playlists", guild_id, user_id), _fetch)
-        return [app_commands.Choice(name=n, value=n) for n in playlist_names if current.lower() in n.lower()][:25]
+        return build_name_choices(cached_autocomplete(("playlists", guild_id, user_id), _fetch), current)
 
     async def _ac_playlist_url(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
         """Autocomplete for song URL within a named playlist (reads sibling `name` field)."""

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -9,7 +9,7 @@ from discord.ext.commands import Cog
 
 from models.reactionrole import ReactionRoleEntry, ReactionRoleMessage
 from models.rolemanage import RoleMapping
-from utils.cache import cached_autocomplete
+from utils.cache import REACTION_ROLE_CACHE_MISS, cached_autocomplete
 from utils.checks import is_role_assignable, is_role_below_bot
 from utils.cog import NerpyBotCog
 from utils.helpers import error_context, notify_error, send_paginated
@@ -48,18 +48,34 @@ class Roles(NerpyBotCog, Cog):
 
         def _fetch():
             with self.bot.session_scope() as session:
-                return ReactionRoleMessage.get_by_guild(guild_id, session)
+                return [
+                    {"channel_id": msg.ChannelId, "message_id": msg.MessageId, "entry_count": len(msg.entries)}
+                    for msg in ReactionRoleMessage.get_by_guild(guild_id, session)
+                ]
 
         messages = await cached_autocomplete(("rr_msgs", guild_id), _fetch)
         if not messages:
             return []
+
+        # Fetch all channels not in the Discord cache in parallel to stay within the 3s autocomplete timeout.
+        missing_ids = {m["channel_id"] for m in messages if guild.get_channel(m["channel_id"]) is None}
+
+        async def _fetch_channel(cid):
+            try:
+                return await guild.fetch_channel(cid)
+            except (discord.NotFound, discord.Forbidden):
+                return None
+
+        fetched = await asyncio.gather(*(_fetch_channel(cid) for cid in missing_ids))
+        channel_lookup = dict(zip(missing_ids, fetched))
+
         choices = []
         for rr_msg in messages:
-            channel = guild.get_channel(rr_msg.ChannelId)
+            channel = guild.get_channel(rr_msg["channel_id"]) or channel_lookup.get(rr_msg["channel_id"])
             channel_name = f"#{channel.name}" if channel else "Unknown"
-            entry_count = len(rr_msg.entries) if rr_msg.entries else 0
-            label = f"{channel_name} \u00b7 {rr_msg.MessageId} ({entry_count} mappings)"
-            msg_id_str = str(rr_msg.MessageId)
+            entry_count = rr_msg["entry_count"]
+            label = f"{channel_name} \u00b7 {rr_msg['message_id']} ({entry_count} mappings)"
+            msg_id_str = str(rr_msg["message_id"])
             if current and current not in msg_id_str and current.lower() not in channel_name.lower():
                 continue
             choices.append(app_commands.Choice(name=label[:100], value=msg_id_str))
@@ -73,8 +89,8 @@ class Roles(NerpyBotCog, Cog):
         emoji_str = str(payload.emoji)
         role_id = self.bot.guild_cache.get_reaction_role(payload.message_id, emoji_str)
 
-        if role_id is None:
-            # Cache not yet warmed or entry genuinely absent — fall back to DB
+        if role_id is REACTION_ROLE_CACHE_MISS:
+            # Cache not yet warmed — fall back to DB and backfill
             with self.bot.session_scope() as session:
                 rr_msg = ReactionRoleMessage.get_by_message(payload.message_id, session)
                 if rr_msg is None:
@@ -83,8 +99,9 @@ class Roles(NerpyBotCog, Cog):
                 if entry is None:
                     return None
                 role_id = entry.RoleId
-            # Backfill so subsequent reactions for this emoji don't re-hit the DB
             self.bot.guild_cache.add_reaction_role_entry(payload.message_id, emoji_str, role_id)
+        elif role_id is None:
+            return None
 
         guild = self.bot.get_guild(payload.guild_id)
         if guild is None:

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -125,14 +125,15 @@ class Roles(NerpyBotCog, Cog):
                         self.bot.guild_cache.remove_reaction_role_message(payload.guild_id, payload.message_id)
                         return None
                     self.bot.guild_cache.add_reaction_role_message(payload.guild_id, payload.message_id)
+                    role_id = None
                     for cached_entry in rr_msg.entries:
                         self.bot.guild_cache.add_reaction_role_entry(
                             payload.message_id, cached_entry.Emoji, cached_entry.RoleId
                         )
-                    entry = next((e for e in rr_msg.entries if e.Emoji == emoji_str), None)
-                    if entry is None:
+                        if cached_entry.Emoji == emoji_str:
+                            role_id = cached_entry.RoleId
+                    if role_id is None:
                         return None
-                    role_id = entry.RoleId
             except SQLAlchemyError:
                 self.bot.log.exception(
                     "_get_role_for_reaction: DB fallback failed for message_id=%d", payload.message_id

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -7,6 +7,8 @@ from discord import Forbidden, HTTPException, Interaction, Member, NotFound, Rol
 from discord.app_commands import checks
 from discord.ext.commands import Cog
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from models.reactionrole import ReactionRoleEntry, ReactionRoleMessage
 from models.rolemanage import RoleMapping
 from utils.cache import REACTION_ROLE_CACHE_MISS, cached_autocomplete, invalidate_autocomplete
@@ -53,7 +55,7 @@ class Roles(NerpyBotCog, Cog):
                         "channel_id": msg.ChannelId,
                         "message_id": msg.MessageId,
                         "entry_count": len(msg.entries),
-                        "channel_name": None,  # resolved below; None entries are updated in-place to avoid re-fetching within TTL
+                        "channel_name": None,  # filled below; these dicts are the cached objects (aliased, not copied), so mutating channel_name here persists for the full TTL without re-fetching
                     }
                     for msg in ReactionRoleMessage.get_by_guild(guild_id, session)
                 ]
@@ -106,14 +108,20 @@ class Roles(NerpyBotCog, Cog):
         if role_id is REACTION_ROLE_CACHE_MISS:
             # Cache not yet warmed — fall back to DB and backfill.
             # ReactionRoleMessage uses lazy="joined" so rr_msg.entries is already loaded.
-            with self.bot.session_scope() as session:
-                rr_msg = ReactionRoleMessage.get_by_message(payload.message_id, session)
-                if rr_msg is None:
-                    return None
-                entry = next((e for e in rr_msg.entries if e.Emoji == emoji_str), None)
-                if entry is None:
-                    return None
-                role_id = entry.RoleId
+            try:
+                with self.bot.session_scope() as session:
+                    rr_msg = ReactionRoleMessage.get_by_message(payload.message_id, session)
+                    if rr_msg is None:
+                        return None
+                    entry = next((e for e in rr_msg.entries if e.Emoji == emoji_str), None)
+                    if entry is None:
+                        return None
+                    role_id = entry.RoleId
+            except SQLAlchemyError:
+                self.bot.log.exception(
+                    "_get_role_for_reaction: DB fallback failed for message_id=%d", payload.message_id
+                )
+                return None
             self.bot.guild_cache.add_reaction_role_entry(payload.message_id, emoji_str, role_id)
         elif role_id is None:
             return None

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -73,8 +73,8 @@ class Roles(NerpyBotCog, Cog):
 
         # For channels still unresolved, fetch in parallel. Mutate cached entries in-place so
         # subsequent calls within the 30s TTL window skip these HTTP round-trips.
-        still_missing = [m for m in messages if m["channel_name"] is None]
-        if still_missing:
+        missing_ids = list({m["channel_id"] for m in messages if m["channel_name"] is None})
+        if missing_ids:
 
             async def _fetch_channel(cid):
                 try:
@@ -82,9 +82,12 @@ class Roles(NerpyBotCog, Cog):
                 except discord.HTTPException:
                     return None
 
-            fetched = await asyncio.gather(*(_fetch_channel(m["channel_id"]) for m in still_missing))
-            for m, ch in zip(still_missing, fetched):
-                m["channel_name"] = f"#{ch.name}" if ch else "Unknown"
+            fetched = await asyncio.gather(*(_fetch_channel(cid) for cid in missing_ids))
+            channel_lookup = {cid: ch for cid, ch in zip(missing_ids, fetched)}
+            for m in messages:
+                if m["channel_name"] is None:
+                    ch = channel_lookup.get(m["channel_id"])
+                    m["channel_name"] = f"#{ch.name}" if ch else "Unknown"
 
         choices = []
         for rr_msg in messages:

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -77,7 +77,7 @@ class Roles(NerpyBotCog, Cog):
             async def _fetch_channel(cid):
                 try:
                     return await guild.fetch_channel(cid)
-                except (discord.NotFound, discord.Forbidden):
+                except discord.HTTPException:
                     return None
 
             fetched = await asyncio.gather(*(_fetch_channel(m["channel_id"]) for m in still_missing))

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -79,7 +79,13 @@ class Roles(NerpyBotCog, Cog):
             async def _fetch_channel(cid):
                 try:
                     return await guild.fetch_channel(cid)
-                except discord.HTTPException:
+                except discord.HTTPException as exc:
+                    self.bot.log.debug(
+                        "_message_id_autocomplete: fetch_channel(%d) failed — %s (%s)",
+                        cid,
+                        type(exc).__name__,
+                        exc,
+                    )
                     return None
 
             fetched = await asyncio.gather(*(_fetch_channel(cid) for cid in missing_ids))
@@ -102,6 +108,7 @@ class Roles(NerpyBotCog, Cog):
 
     def _get_role_for_reaction(self, payload):
         """Look up the role for a given reaction event payload."""
+        self.bot.guild_cache.try_rewarm_reaction_roles(self.bot.SESSION)
         if not self.bot.guild_cache.is_reaction_role_message(payload.message_id):
             return None
 

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -122,6 +122,7 @@ class Roles(NerpyBotCog, Cog):
                 with self.bot.session_scope() as session:
                     rr_msg = ReactionRoleMessage.get_by_message(payload.message_id, session)
                     if rr_msg is None:
+                        self.bot.guild_cache.remove_reaction_role_message(payload.guild_id, payload.message_id)
                         return None
                     entry = next((e for e in rr_msg.entries if e.Emoji == emoji_str), None)
                     if entry is None:
@@ -132,6 +133,7 @@ class Roles(NerpyBotCog, Cog):
                     "_get_role_for_reaction: DB fallback failed for message_id=%d", payload.message_id
                 )
                 return None
+            self.bot.guild_cache.add_reaction_role_message(payload.guild_id, payload.message_id)
             self.bot.guild_cache.add_reaction_role_entry(payload.message_id, emoji_str, role_id)
         elif role_id is None:
             return None

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -106,9 +106,9 @@ class Roles(NerpyBotCog, Cog):
             choices.append(app_commands.Choice(name=label[:100], value=msg_id_str))
         return choices[:25]
 
-    def _get_role_for_reaction(self, payload):
+    async def _get_role_for_reaction(self, payload):
         """Look up the role for a given reaction event payload."""
-        self.bot.guild_cache.try_rewarm_reaction_roles(self.bot.SESSION)
+        await self.bot.guild_cache.try_rewarm_reaction_roles(self.bot.SESSION)
         if not self.bot.guild_cache.is_reaction_role_message(payload.message_id):
             return None
 
@@ -116,7 +116,7 @@ class Roles(NerpyBotCog, Cog):
         role_id = self.bot.guild_cache.get_reaction_role(payload.message_id, emoji_str)
 
         if role_id is REACTION_ROLE_CACHE_MISS:
-            # Cache not yet warmed — fall back to DB and backfill.
+            # Cache not yet warmed — fall back to DB and backfill all entries for this message.
             # ReactionRoleMessage uses lazy="joined" so rr_msg.entries is already loaded.
             try:
                 with self.bot.session_scope() as session:
@@ -124,6 +124,11 @@ class Roles(NerpyBotCog, Cog):
                     if rr_msg is None:
                         self.bot.guild_cache.remove_reaction_role_message(payload.guild_id, payload.message_id)
                         return None
+                    self.bot.guild_cache.add_reaction_role_message(payload.guild_id, payload.message_id)
+                    for cached_entry in rr_msg.entries:
+                        self.bot.guild_cache.add_reaction_role_entry(
+                            payload.message_id, cached_entry.Emoji, cached_entry.RoleId
+                        )
                     entry = next((e for e in rr_msg.entries if e.Emoji == emoji_str), None)
                     if entry is None:
                         return None
@@ -133,8 +138,6 @@ class Roles(NerpyBotCog, Cog):
                     "_get_role_for_reaction: DB fallback failed for message_id=%d", payload.message_id
                 )
                 return None
-            self.bot.guild_cache.add_reaction_role_message(payload.guild_id, payload.message_id)
-            self.bot.guild_cache.add_reaction_role_entry(payload.message_id, emoji_str, role_id)
         elif role_id is None:
             return None
 
@@ -167,7 +170,7 @@ class Roles(NerpyBotCog, Cog):
         if payload.guild_id is None or payload.member is None or payload.member.bot:
             return
 
-        role = self._get_role_for_reaction(payload)
+        role = await self._get_role_for_reaction(payload)
         if role is None:
             return
 
@@ -189,7 +192,7 @@ class Roles(NerpyBotCog, Cog):
         if payload.guild_id is None:
             return
 
-        role = self._get_role_for_reaction(payload)
+        role = await self._get_role_for_reaction(payload)
         if role is None:
             return
 

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -9,7 +9,7 @@ from discord.ext.commands import Cog
 
 from models.reactionrole import ReactionRoleEntry, ReactionRoleMessage
 from models.rolemanage import RoleMapping
-from utils.cache import REACTION_ROLE_CACHE_MISS, cached_autocomplete
+from utils.cache import REACTION_ROLE_CACHE_MISS, cached_autocomplete, invalidate_autocomplete
 from utils.checks import is_role_assignable, is_role_below_bot
 from utils.cog import NerpyBotCog
 from utils.helpers import error_context, notify_error, send_paginated
@@ -49,7 +49,12 @@ class Roles(NerpyBotCog, Cog):
         def _fetch():
             with self.bot.session_scope() as session:
                 return [
-                    {"channel_id": msg.ChannelId, "message_id": msg.MessageId, "entry_count": len(msg.entries)}
+                    {
+                        "channel_id": msg.ChannelId,
+                        "message_id": msg.MessageId,
+                        "entry_count": len(msg.entries),
+                        "channel_name": None,  # resolved below; None entries are updated in-place to avoid re-fetching within TTL
+                    }
                     for msg in ReactionRoleMessage.get_by_guild(guild_id, session)
                 ]
 
@@ -57,22 +62,31 @@ class Roles(NerpyBotCog, Cog):
         if not messages:
             return []
 
-        # Fetch all channels not in the Discord cache in parallel to stay within the 3s autocomplete timeout.
-        missing_ids = {m["channel_id"] for m in messages if guild.get_channel(m["channel_id"]) is None}
+        # Fill channel names from Discord's internal cache (fast dict lookup).
+        for m in messages:
+            if m["channel_name"] is None:
+                ch = guild.get_channel(m["channel_id"])
+                if ch:
+                    m["channel_name"] = f"#{ch.name}"
 
-        async def _fetch_channel(cid):
-            try:
-                return await guild.fetch_channel(cid)
-            except (discord.NotFound, discord.Forbidden):
-                return None
+        # For channels still unresolved, fetch in parallel. Mutate cached entries in-place so
+        # subsequent calls within the 30s TTL window skip these HTTP round-trips.
+        still_missing = [m for m in messages if m["channel_name"] is None]
+        if still_missing:
 
-        fetched = await asyncio.gather(*(_fetch_channel(cid) for cid in missing_ids))
-        channel_lookup = dict(zip(missing_ids, fetched))
+            async def _fetch_channel(cid):
+                try:
+                    return await guild.fetch_channel(cid)
+                except (discord.NotFound, discord.Forbidden):
+                    return None
+
+            fetched = await asyncio.gather(*(_fetch_channel(m["channel_id"]) for m in still_missing))
+            for m, ch in zip(still_missing, fetched):
+                m["channel_name"] = f"#{ch.name}" if ch else "Unknown"
 
         choices = []
         for rr_msg in messages:
-            channel = guild.get_channel(rr_msg["channel_id"]) or channel_lookup.get(rr_msg["channel_id"])
-            channel_name = f"#{channel.name}" if channel else "Unknown"
+            channel_name = rr_msg["channel_name"] or "Unknown"
             entry_count = rr_msg["entry_count"]
             label = f"{channel_name} \u00b7 {rr_msg['message_id']} ({entry_count} mappings)"
             msg_id_str = str(rr_msg["message_id"])
@@ -448,6 +462,7 @@ class Roles(NerpyBotCog, Cog):
 
         self.bot.guild_cache.add_reaction_role_message(interaction.guild.id, msg_id)
         self.bot.guild_cache.add_reaction_role_entry(msg_id, emoji, role.id)
+        invalidate_autocomplete(("rr_msgs", interaction.guild.id))
 
         try:
             await discord_msg.add_reaction(emoji)
@@ -508,6 +523,7 @@ class Roles(NerpyBotCog, Cog):
             self.bot.guild_cache.remove_reaction_role_message(interaction.guild.id, msg_id)
         else:
             self.bot.guild_cache.remove_reaction_role_entry(msg_id, emoji)
+        invalidate_autocomplete(("rr_msgs", interaction.guild.id))
 
         await self._clear_reaction(interaction.guild, channel_id, msg_id, emoji)
         await interaction.response.send_message(
@@ -579,6 +595,7 @@ class Roles(NerpyBotCog, Cog):
             return
 
         self.bot.guild_cache.remove_reaction_role_message(interaction.guild.id, msg_id)
+        invalidate_autocomplete(("rr_msgs", interaction.guild.id))
 
         await asyncio.gather(
             *[self._clear_reaction(interaction.guild, channel_id, msg_id, emoji) for emoji in emojis],

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -9,6 +9,7 @@ from discord.ext.commands import Cog
 
 from models.reactionrole import ReactionRoleEntry, ReactionRoleMessage
 from models.rolemanage import RoleMapping
+from utils.cache import cached_autocomplete
 from utils.checks import is_role_assignable, is_role_below_bot
 from utils.cog import NerpyBotCog
 from utils.helpers import error_context, notify_error, send_paginated
@@ -42,38 +43,48 @@ class Roles(NerpyBotCog, Cog):
     # ── reactionrole helpers ──────────────────────────────────────────────────
 
     async def _message_id_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
-        with self.bot.session_scope() as session:
-            messages = ReactionRoleMessage.get_by_guild(interaction.guild.id, session)
-            if not messages:
-                return []
-            choices = []
-            for rr_msg in messages:
-                channel = interaction.guild.get_channel(rr_msg.ChannelId)
-                channel_name = f"#{channel.name}" if channel else "Unknown"
-                entry_count = len(rr_msg.entries) if rr_msg.entries else 0
-                label = f"{channel_name} \u00b7 {rr_msg.MessageId} ({entry_count} mappings)"
-                msg_id_str = str(rr_msg.MessageId)
-                if current and current not in msg_id_str and current.lower() not in channel_name.lower():
-                    continue
-                choices.append(app_commands.Choice(name=label[:100], value=msg_id_str))
-            return choices[:25]
+        guild = interaction.guild
+        guild_id = guild.id
+
+        def _fetch():
+            with self.bot.session_scope() as session:
+                return ReactionRoleMessage.get_by_guild(guild_id, session)
+
+        messages = cached_autocomplete(("rr_msgs", guild_id), _fetch)
+        if not messages:
+            return []
+        choices = []
+        for rr_msg in messages:
+            channel = guild.get_channel(rr_msg.ChannelId)
+            channel_name = f"#{channel.name}" if channel else "Unknown"
+            entry_count = len(rr_msg.entries) if rr_msg.entries else 0
+            label = f"{channel_name} \u00b7 {rr_msg.MessageId} ({entry_count} mappings)"
+            msg_id_str = str(rr_msg.MessageId)
+            if current and current not in msg_id_str and current.lower() not in channel_name.lower():
+                continue
+            choices.append(app_commands.Choice(name=label[:100], value=msg_id_str))
+        return choices[:25]
 
     def _get_role_for_reaction(self, payload):
         """Look up the role for a given reaction event payload."""
         if not self.bot.guild_cache.is_reaction_role_message(payload.message_id):
             return None
 
-        with self.bot.session_scope() as session:
-            rr_msg = ReactionRoleMessage.get_by_message(payload.message_id, session)
-            if rr_msg is None:
-                return None
+        emoji_str = str(payload.emoji)
+        role_id = self.bot.guild_cache.get_reaction_role(payload.message_id, emoji_str)
 
-            emoji_str = str(payload.emoji)
-            entry = ReactionRoleEntry.get_by_message_and_emoji(rr_msg.Id, emoji_str, session)
-            if entry is None:
-                return None
-
-            role_id = entry.RoleId
+        if role_id is None:
+            # Cache not yet warmed or entry genuinely absent — fall back to DB
+            with self.bot.session_scope() as session:
+                rr_msg = ReactionRoleMessage.get_by_message(payload.message_id, session)
+                if rr_msg is None:
+                    return None
+                entry = ReactionRoleEntry.get_by_message_and_emoji(rr_msg.Id, emoji_str, session)
+                if entry is None:
+                    return None
+                role_id = entry.RoleId
+            # Backfill so subsequent reactions for this emoji don't re-hit the DB
+            self.bot.guild_cache.add_reaction_role_entry(payload.message_id, emoji_str, role_id)
 
         guild = self.bot.get_guild(payload.guild_id)
         if guild is None:
@@ -419,6 +430,7 @@ class Roles(NerpyBotCog, Cog):
             return
 
         self.bot.guild_cache.add_reaction_role_message(interaction.guild.id, msg_id)
+        self.bot.guild_cache.add_reaction_role_entry(msg_id, emoji, role.id)
 
         try:
             await discord_msg.add_reaction(emoji)
@@ -477,6 +489,8 @@ class Roles(NerpyBotCog, Cog):
 
         if last_entry_removed:
             self.bot.guild_cache.remove_reaction_role_message(interaction.guild.id, msg_id)
+        else:
+            self.bot.guild_cache.remove_reaction_role_entry(msg_id, emoji)
 
         await self._clear_reaction(interaction.guild, channel_id, msg_id, emoji)
         await interaction.response.send_message(

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -50,7 +50,7 @@ class Roles(NerpyBotCog, Cog):
             with self.bot.session_scope() as session:
                 return ReactionRoleMessage.get_by_guild(guild_id, session)
 
-        messages = cached_autocomplete(("rr_msgs", guild_id), _fetch)
+        messages = await cached_autocomplete(("rr_msgs", guild_id), _fetch)
         if not messages:
             return []
         choices = []

--- a/NerdyPy/modules/roles.py
+++ b/NerdyPy/modules/roles.py
@@ -104,12 +104,13 @@ class Roles(NerpyBotCog, Cog):
         role_id = self.bot.guild_cache.get_reaction_role(payload.message_id, emoji_str)
 
         if role_id is REACTION_ROLE_CACHE_MISS:
-            # Cache not yet warmed — fall back to DB and backfill
+            # Cache not yet warmed — fall back to DB and backfill.
+            # ReactionRoleMessage uses lazy="joined" so rr_msg.entries is already loaded.
             with self.bot.session_scope() as session:
                 rr_msg = ReactionRoleMessage.get_by_message(payload.message_id, session)
                 if rr_msg is None:
                     return None
-                entry = ReactionRoleEntry.get_by_message_and_emoji(rr_msg.Id, emoji_str, session)
+                entry = next((e for e in rr_msg.entries if e.Emoji == emoji_str), None)
                 if entry is None:
                     return None
                 role_id = entry.RoleId

--- a/NerdyPy/modules/tagging.py
+++ b/NerdyPy/modules/tagging.py
@@ -14,7 +14,7 @@ from utils.checks import can_stop_playback, is_connected_to_voice
 from utils.cog import NerpyBotCog
 from utils.download import download
 from utils.errors import NerpyNotFoundError
-from utils.cache import build_name_choices, cached_autocomplete
+from utils.cache import build_name_choices, cached_autocomplete, invalidate_autocomplete
 from utils.helpers import error_context, send_paginated
 from utils.strings import get_string
 
@@ -103,6 +103,7 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
             self._add_tag_entries(session, _tag, content)
 
         self.bot.log.info(f'{error_context(interaction)}: tag "{name}" created')
+        invalidate_autocomplete(("tags", interaction.guild.id))
         await interaction.followup.send(get_string(lang, "tagging.create.success", name=name), ephemeral=True)
 
     @app_commands.command(name="add")
@@ -162,6 +163,7 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
                 return
 
             Tag.delete(name, interaction.guild.id, session)
+        invalidate_autocomplete(("tags", interaction.guild.id))
         await interaction.response.send_message(get_string(lang, "tagging.delete.success", name=name), ephemeral=True)
 
     _TAG_TYPE_EMOJI = {

--- a/NerdyPy/modules/tagging.py
+++ b/NerdyPy/modules/tagging.py
@@ -36,10 +36,10 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
 
         def _fetch():
             with self.bot.session_scope() as session:
-                return Tag.get_all_from_guild(guild_id, session)
+                return [t.Name for t in Tag.get_all_from_guild(guild_id, session)]
 
-        tags = cached_autocomplete(("tags", guild_id), _fetch)
-        return [app_commands.Choice(name=t.Name, value=t.Name) for t in tags if current.lower() in t.Name.lower()][:25]
+        tag_names = cached_autocomplete(("tags", guild_id), _fetch)
+        return [app_commands.Choice(name=n, value=n) for n in tag_names if current.lower() in n.lower()][:25]
 
     @app_commands.command(name="get")
     @app_commands.check(is_connected_to_voice)

--- a/NerdyPy/modules/tagging.py
+++ b/NerdyPy/modules/tagging.py
@@ -14,6 +14,7 @@ from utils.checks import can_stop_playback, is_connected_to_voice
 from utils.cog import NerpyBotCog
 from utils.download import download
 from utils.errors import NerpyNotFoundError
+from utils.cache import cached_autocomplete
 from utils.helpers import error_context, send_paginated
 from utils.strings import get_string
 
@@ -31,11 +32,14 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
         self.audio = self.bot.audio
 
     async def _tag_name_autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
-        with self.bot.session_scope() as session:
-            tags = Tag.get_all_from_guild(interaction.guild.id, session)
-            return [app_commands.Choice(name=t.Name, value=t.Name) for t in tags if current.lower() in t.Name.lower()][
-                :25
-            ]
+        guild_id = interaction.guild.id
+
+        def _fetch():
+            with self.bot.session_scope() as session:
+                return Tag.get_all_from_guild(guild_id, session)
+
+        tags = cached_autocomplete(("tags", guild_id), _fetch)
+        return [app_commands.Choice(name=t.Name, value=t.Name) for t in tags if current.lower() in t.Name.lower()][:25]
 
     @app_commands.command(name="get")
     @app_commands.check(is_connected_to_voice)

--- a/NerdyPy/modules/tagging.py
+++ b/NerdyPy/modules/tagging.py
@@ -14,7 +14,7 @@ from utils.checks import can_stop_playback, is_connected_to_voice
 from utils.cog import NerpyBotCog
 from utils.download import download
 from utils.errors import NerpyNotFoundError
-from utils.cache import cached_autocomplete
+from utils.cache import build_name_choices, cached_autocomplete
 from utils.helpers import error_context, send_paginated
 from utils.strings import get_string
 
@@ -38,8 +38,7 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
             with self.bot.session_scope() as session:
                 return [t.Name for t in Tag.get_all_from_guild(guild_id, session)]
 
-        tag_names = cached_autocomplete(("tags", guild_id), _fetch)
-        return [app_commands.Choice(name=n, value=n) for n in tag_names if current.lower() in n.lower()][:25]
+        return build_name_choices(cached_autocomplete(("tags", guild_id), _fetch), current)
 
     @app_commands.command(name="get")
     @app_commands.check(is_connected_to_voice)

--- a/NerdyPy/modules/tagging.py
+++ b/NerdyPy/modules/tagging.py
@@ -38,7 +38,7 @@ class Tagging(NerpyBotCog, QueueMixin, GroupCog, group_name="tag"):
             with self.bot.session_scope() as session:
                 return [t.Name for t in Tag.get_all_from_guild(guild_id, session)]
 
-        return build_name_choices(cached_autocomplete(("tags", guild_id), _fetch), current)
+        return build_name_choices(await cached_autocomplete(("tags", guild_id), _fetch), current)
 
     @app_commands.command(name="get")
     @app_commands.check(is_connected_to_voice)

--- a/NerdyPy/utils/blizzard.py
+++ b/NerdyPy/utils/blizzard.py
@@ -511,6 +511,10 @@ async def sync_crafting_recipes(
             return True
 
     cache_updated = await asyncio.to_thread(_upsert)
+    if cache_updated:
+        from models.wow import invalidate_recipe_cache
+
+        invalidate_recipe_cache()
 
     crafted_count = sum(1 for r in all_rows if r["RecipeType"] == RECIPE_TYPE_CRAFTED)
     housing_count = sum(1 for r in all_rows if r["RecipeType"] == RECIPE_TYPE_HOUSING)

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -54,9 +54,9 @@ class GuildConfigCache:
     def _run_warm(session_factory, loader_fn, error_label: str):
         """Run a bulk DB load inside a session.
 
-        Logs and re-raises ``SQLAlchemyError`` so callers stay in degraded mode
-        with a clear error entry. Non-SQLAlchemy exceptions (e.g. programming
-        errors in ``loader_fn``) propagate uncaught so the real exception type
+        Re-raises ``SQLAlchemyError`` so callers stay in degraded mode. Logging
+        is left to the caller, which has richer context (cache name, strategy).
+        Non-SQLAlchemy exceptions propagate uncaught so the real exception type
         is visible.
 
         Args:
@@ -71,7 +71,6 @@ class GuildConfigCache:
             try:
                 return loader_fn(session)
             except SQLAlchemyError:
-                _log.exception("%s: failed to load from DB — staying in degraded mode", error_label)
                 raise
 
     # ── Language ──────────────────────────────────────────────────────────────

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -240,24 +240,29 @@ class GuildConfigCache:
         self._rr_warmed = True
         self._rr_evicted_msgs.clear()
 
-    def try_rewarm_reaction_roles(self, session_factory) -> None:
-        """Attempt a reaction-role re-warm if the cache is unwarmed and the backoff window has elapsed.
+    def _try_rewarm(self, warmed_attr: str, last_attempt_attr: str, warm_fn, label: str, session_factory) -> None:
+        """Shared backoff-guarded re-warm logic for any sub-cache.
 
-        Called from the on_raw_reaction_add hot path when ``_rr_warmed`` is still ``False``
-        after a failed startup warm-up. Limits re-warm frequency to ``_REWARM_COOLDOWN`` seconds
-        so a persistently down DB does not cause a flood of queries per reaction event.
+        Only triggers a warm when ``warmed_attr`` is False and ``_REWARM_COOLDOWN`` seconds have
+        elapsed since the last attempt, preventing DB floods when the DB is persistently down.
         """
-        if self._rr_warmed:
+        if getattr(self, warmed_attr):
             return
         now = time.monotonic()
-        if now - self._rr_last_rewarm_attempt < _REWARM_COOLDOWN:
+        if now - getattr(self, last_attempt_attr) < _REWARM_COOLDOWN:
             return
-        self._rr_last_rewarm_attempt = now
+        setattr(self, last_attempt_attr, now)
         try:
-            self.warm_reaction_roles(session_factory)
-            _log.info("GuildConfigCache: reaction-role cache lazily re-warmed")
+            warm_fn(session_factory)
+            _log.info("GuildConfigCache: %s cache lazily re-warmed", label)
         except Exception:
-            _log.exception("GuildConfigCache: lazy reaction-role re-warm failed")
+            _log.exception("GuildConfigCache: lazy %s re-warm failed", label)
+
+    def try_rewarm_reaction_roles(self, session_factory) -> None:
+        """Called from the on_raw_reaction_add hot path after a failed startup warm-up."""
+        self._try_rewarm(
+            "_rr_warmed", "_rr_last_rewarm_attempt", self.warm_reaction_roles, "reaction-role", session_factory
+        )
 
     # ── Leave messages ────────────────────────────────────────────────────────
 
@@ -401,23 +406,10 @@ class GuildConfigCache:
         self._leave_evicted.clear()
 
     def try_rewarm_leave_messages(self, session_factory) -> None:
-        """Attempt a leave-message re-warm if the cache is unwarmed and the backoff window has elapsed.
-
-        Called from the on_member_remove hot path when ``_leave_warmed`` is still ``False``
-        after a failed startup warm-up. Limits re-warm frequency to ``_REWARM_COOLDOWN`` seconds
-        so a persistently down DB does not cause a flood of queries per member-leave event.
-        """
-        if self._leave_warmed:
-            return
-        now = time.monotonic()
-        if now - self._leave_last_rewarm_attempt < _REWARM_COOLDOWN:
-            return
-        self._leave_last_rewarm_attempt = now
-        try:
-            self.warm_leave_messages(session_factory)
-            _log.info("GuildConfigCache: leave-message cache lazily re-warmed")
-        except Exception:
-            _log.exception("GuildConfigCache: lazy leave-message re-warm failed")
+        """Called from the on_member_remove hot path after a failed startup warm-up."""
+        self._try_rewarm(
+            "_leave_warmed", "_leave_last_rewarm_attempt", self.warm_leave_messages, "leave-message", session_factory
+        )
 
     # ── Eviction ──────────────────────────────────────────────────────────────
 

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -321,7 +321,7 @@ class GuildConfigCache:
         if self._leave_warmed:
             self._leave_evicted.add(guild_id)
 
-    def get_leave_config(self, guild_id: int, session_factory) -> tuple[int, str | None] | None:
+    def get_leave_config(self, guild_id: int, session_factory) -> tuple[int, str | None] | None | object:
         """Return ``(channel_id, message_text)`` for the guild's enabled leave message.
 
         Returns ``None`` when the guild has no enabled leave message.

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """In-memory guild configuration cache to reduce redundant DB queries."""
 
+import asyncio
 import logging
 from contextlib import contextmanager
 
@@ -269,19 +270,20 @@ class GuildConfigCache:
 _autocomplete_cache: TTLCache = TTLCache(maxsize=500, ttl=30)
 
 
-def cached_autocomplete(key: tuple, fetcher):
+async def cached_autocomplete(key: tuple, fetcher):
     """Return cached autocomplete results, calling fetcher() on miss.
 
     Args:
         key: A hashable tuple uniquely identifying the query (e.g. ("tags", guild_id)).
         fetcher: Zero-argument callable that opens a DB session and returns a list.
+            Run in a thread pool on cache miss to avoid blocking the event loop.
 
     Returns:
         The cached or freshly fetched list.
     """
     if key in _autocomplete_cache:
         return _autocomplete_cache[key]
-    result = fetcher()
+    result = await asyncio.to_thread(fetcher)
     _autocomplete_cache[key] = result
     return result
 

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -48,6 +48,7 @@ class GuildConfigCache:
         self._rr_warmed: bool = False
         self._leave_configs: dict[int, tuple[int, str | None] | None] = {}
         self._leave_warmed: bool = False
+        self._leave_evicted: set[int] = set()  # guilds evicted after warm-up; need DB re-read on next access
 
     @staticmethod
     def _run_warm(session_factory, loader_fn, error_label: str):
@@ -221,10 +222,14 @@ class GuildConfigCache:
         """Return True if the guild has leave messages enabled.
 
         Returns True unconditionally before warm-up completes (conservative).
+        Also returns True for guilds evicted via ``evict_guild`` after warm-up —
+        they are re-checked via ``get_leave_config`` rather than treated as absent.
         """
         if not self._leave_warmed:
             return True
-        return guild_id in self._leave_configs
+        if guild_id in self._leave_evicted:
+            return True
+        return self._leave_configs.get(guild_id) is not None
 
     @staticmethod
     def _query_leave_row(guild_id: int, session):
@@ -252,8 +257,9 @@ class GuildConfigCache:
         non-fatal; callers must not treat ``None`` as a definitive "no config" when the cache
         is cold.
         """
-        if self._leave_warmed or guild_id in self._leave_configs:
-            return self._leave_configs.get(guild_id)
+        if guild_id not in self._leave_evicted:
+            if self._leave_warmed or guild_id in self._leave_configs:
+                return self._leave_configs.get(guild_id)
 
         try:
             with _open_session(session_factory) as session:
@@ -264,6 +270,7 @@ class GuildConfigCache:
             return None
 
         self._leave_configs[guild_id] = config
+        self._leave_evicted.discard(guild_id)
         return config
 
     def set_leave_config(self, guild_id: int, channel_id: int, message: str | None) -> None:
@@ -271,8 +278,9 @@ class GuildConfigCache:
         self._leave_configs[guild_id] = (channel_id, message)
 
     def evict_leave_config(self, guild_id: int) -> None:
-        """Remove the leave message config for a guild."""
+        """Remove the leave message config for a guild (definitively disabled)."""
         self._leave_configs.pop(guild_id, None)
+        self._leave_evicted.discard(guild_id)  # cancel any pending re-read
 
     def reload_leave_config(self, guild_id: int, session_factory) -> None:
         """Force a fresh DB read for a guild's leave config and update the cache.
@@ -294,13 +302,16 @@ class GuildConfigCache:
                 "reload_leave_config: DB read failed for guild_id=%d — evicting so cold-miss retries on next member-remove",
                 guild_id,
             )
-            self.evict_leave_config(guild_id)
+            self._leave_configs.pop(guild_id, None)
+            if self._leave_warmed:
+                self._leave_evicted.add(guild_id)
             return
 
         if row is not None:
             self._leave_configs[guild_id] = (row.ChannelId, row.Message)
         else:
-            self.evict_leave_config(guild_id)
+            self._leave_configs.pop(guild_id, None)
+        self._leave_evicted.discard(guild_id)
 
     def warm_leave_messages(self, session_factory) -> None:
         """Bulk-load full leave message configs (channel_id, message) for all enabled guilds.
@@ -317,6 +328,7 @@ class GuildConfigCache:
 
         self._leave_configs = self._run_warm(session_factory, _load, "warm_leave_messages")
         self._leave_warmed = True
+        self._leave_evicted.clear()
 
     # ── Eviction ──────────────────────────────────────────────────────────────
 
@@ -324,7 +336,9 @@ class GuildConfigCache:
         """Remove all cached entries for a guild (called when bot leaves a guild)."""
         self._lang.pop(guild_id, None)
         self._modrole.pop(guild_id, None)
-        self.evict_leave_config(guild_id)
+        self._leave_configs.pop(guild_id, None)
+        if self._leave_warmed:
+            self._leave_evicted.add(guild_id)  # guild may rejoin with existing config — re-check on next access
         guild_rr = self._rr_by_guild.pop(guild_id, None)
         if guild_rr:
             self._rr_message_ids -= guild_rr

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -51,7 +51,7 @@ class GuildConfigCache:
         self._leave_evicted: set[int] = set()  # guilds evicted after warm-up; need DB re-read on next access
 
     @staticmethod
-    def _run_warm(session_factory, loader_fn, error_label: str):
+    def _run_warm(session_factory, loader_fn):
         """Run a bulk DB load inside a session.
 
         Re-raises ``SQLAlchemyError`` so callers stay in degraded mode. Logging
@@ -62,7 +62,6 @@ class GuildConfigCache:
         Args:
             session_factory: Callable that returns a new SQLAlchemy session.
             loader_fn: ``(session) -> T`` — performs the query and returns data.
-            error_label: Prefix used in the error log message.
 
         Returns:
             Whatever ``loader_fn`` returns.
@@ -210,9 +209,7 @@ class GuildConfigCache:
                     mappings[msg_id][emoji] = role_id
             return by_guild, all_ids, mappings
 
-        self._rr_by_guild, self._rr_message_ids, self._rr_mappings = self._run_warm(
-            session_factory, _load, "warm_reaction_roles"
-        )
+        self._rr_by_guild, self._rr_message_ids, self._rr_mappings = self._run_warm(session_factory, _load)
         self._rr_warmed = True
 
     # ── Leave messages ────────────────────────────────────────────────────────
@@ -325,7 +322,7 @@ class GuildConfigCache:
             rows = session.execute(select(LeaveMessage).where(LeaveMessage.Enabled.is_(True))).scalars().all()
             return {row.GuildId: (row.ChannelId, row.Message) for row in rows}
 
-        self._leave_configs = self._run_warm(session_factory, _load, "warm_leave_messages")
+        self._leave_configs = self._run_warm(session_factory, _load)
         self._leave_warmed = True
         self._leave_evicted.clear()
 

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -46,6 +46,7 @@ class GuildConfigCache:
         self._rr_by_guild: dict[int, set[int]] = {}  # guild_id -> set[message_id] for eviction
         self._rr_mappings: dict[int, dict[str, int]] = {}
         self._rr_warmed: bool = False
+        self._rr_evicted_msgs: set[int] = set()  # evicted after warm; return CACHE_MISS until re-warmed
         self._leave_configs: dict[int, tuple[int, str | None] | None] = {}
         self._leave_warmed: bool = False
         self._leave_evicted: set[int] = set()  # guilds evicted after warm-up; need DB re-read on next access
@@ -131,8 +132,12 @@ class GuildConfigCache:
 
         Returns True unconditionally before warm-up completes (conservative: always
         falls through to the DB query so no reactions are missed).
+        Also returns True for messages evicted via ``evict_guild`` after warm-up —
+        they are re-checked via ``get_reaction_role`` rather than treated as absent.
         """
         if not self._rr_warmed:
+            return True
+        if message_id in self._rr_evicted_msgs:
             return True
         return message_id in self._rr_message_ids
 
@@ -142,11 +147,15 @@ class GuildConfigCache:
         Returns:
             ``REACTION_ROLE_CACHE_MISS`` if the cache has not been warmed yet
                 (caller must fall back to DB).
+            ``REACTION_ROLE_CACHE_MISS`` if the message was evicted after warm-up
+                (caller must fall back to DB — data may have changed since eviction).
             ``None`` if the cache is warmed but the emoji has no mapping
                 (caller should skip the DB query).
             ``int`` role ID if a mapping exists.
         """
         if not self._rr_warmed:
+            return REACTION_ROLE_CACHE_MISS
+        if message_id in self._rr_evicted_msgs:
             return REACTION_ROLE_CACHE_MISS
         return self._rr_mappings.get(message_id, {}).get(emoji)
 
@@ -211,6 +220,7 @@ class GuildConfigCache:
 
         self._rr_by_guild, self._rr_message_ids, self._rr_mappings = self._run_warm(session_factory, _load)
         self._rr_warmed = True
+        self._rr_evicted_msgs.clear()
 
     # ── Leave messages ────────────────────────────────────────────────────────
 
@@ -341,6 +351,8 @@ class GuildConfigCache:
             self._rr_message_ids -= guild_rr
             for msg_id in guild_rr:
                 self._rr_mappings.pop(msg_id, None)
+            if self._rr_warmed:
+                self._rr_evicted_msgs.update(guild_rr)  # guild may rejoin — re-check on next reaction
 
 
 # ── Autocomplete TTL cache ─────────────────────────────────────────────────────

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -247,11 +247,13 @@ class GuildConfigCache:
         self._rr_warmed = True
         self._rr_evicted_msgs.clear()
 
-    def _try_rewarm(self, warmed_attr: str, last_attempt_attr: str, warm_fn, label: str, session_factory) -> None:
+    async def _try_rewarm(self, warmed_attr: str, last_attempt_attr: str, warm_fn, label: str, session_factory) -> None:
         """Shared backoff-guarded re-warm logic for any sub-cache.
 
         Only triggers a warm when ``warmed_attr`` is False and ``_REWARM_COOLDOWN`` seconds have
         elapsed since the last attempt, preventing DB floods when the DB is persistently down.
+        The blocking ``warm_fn`` call is offloaded via ``asyncio.to_thread`` so the event loop
+        is not blocked during the DB table scan.
         """
         if getattr(self, warmed_attr):
             return
@@ -260,14 +262,14 @@ class GuildConfigCache:
             return
         setattr(self, last_attempt_attr, now)
         try:
-            warm_fn(session_factory)
+            await asyncio.to_thread(warm_fn, session_factory)
             _log.info("GuildConfigCache: %s cache lazily re-warmed", label)
         except Exception:
             _log.exception("GuildConfigCache: lazy %s re-warm failed", label)
 
-    def try_rewarm_reaction_roles(self, session_factory) -> None:
+    async def try_rewarm_reaction_roles(self, session_factory) -> None:
         """Called from the on_raw_reaction_add hot path after a failed startup warm-up."""
-        self._try_rewarm(
+        await self._try_rewarm(
             "_rr_warmed", "_rr_last_rewarm_attempt", self.warm_reaction_roles, "reaction-role", session_factory
         )
 
@@ -412,9 +414,9 @@ class GuildConfigCache:
         self._leave_warmed = True
         self._leave_evicted.clear()
 
-    def try_rewarm_leave_messages(self, session_factory) -> None:
+    async def try_rewarm_leave_messages(self, session_factory) -> None:
         """Called from the on_member_remove hot path after a failed startup warm-up."""
-        self._try_rewarm(
+        await self._try_rewarm(
             "_leave_warmed", "_leave_last_rewarm_attempt", self.warm_leave_messages, "leave-message", session_factory
         )
 

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -51,7 +51,12 @@ class GuildConfigCache:
 
     @staticmethod
     def _run_warm(session_factory, loader_fn, error_label: str):
-        """Run a bulk DB load inside a session, logging and re-raising on failure.
+        """Run a bulk DB load inside a session.
+
+        Logs and re-raises ``SQLAlchemyError`` so callers stay in degraded mode
+        with a clear error entry. Non-SQLAlchemy exceptions (e.g. programming
+        errors in ``loader_fn``) propagate uncaught so the real exception type
+        is visible.
 
         Args:
             session_factory: Callable that returns a new SQLAlchemy session.
@@ -64,7 +69,7 @@ class GuildConfigCache:
         with _open_session(session_factory) as session:
             try:
                 return loader_fn(session)
-            except Exception:
+            except SQLAlchemyError:
                 _log.exception("%s: failed to load from DB — staying in degraded mode", error_label)
                 raise
 
@@ -189,18 +194,19 @@ class GuildConfigCache:
             by_guild: dict[int, set[int]] = {}
             all_ids: set[int] = set()
             mappings: dict[int, dict[str, int]] = {}
-            for guild_id, msg_id in session.execute(
-                select(ReactionRoleMessage.GuildId, ReactionRoleMessage.MessageId)
+            for guild_id, msg_id, emoji, role_id in session.execute(
+                select(
+                    ReactionRoleMessage.GuildId,
+                    ReactionRoleMessage.MessageId,
+                    ReactionRoleEntry.Emoji,
+                    ReactionRoleEntry.RoleId,
+                ).outerjoin(ReactionRoleEntry, ReactionRoleEntry.ReactionRoleMessageId == ReactionRoleMessage.Id)
             ).all():
-                by_guild.setdefault(guild_id, set()).add(msg_id)
-                all_ids.add(msg_id)
-                mappings[msg_id] = {}
-            for msg_id, emoji, role_id in session.execute(
-                select(ReactionRoleMessage.MessageId, ReactionRoleEntry.Emoji, ReactionRoleEntry.RoleId).join(
-                    ReactionRoleEntry, ReactionRoleEntry.ReactionRoleMessageId == ReactionRoleMessage.Id
-                )
-            ).all():
-                if msg_id in mappings:
+                if msg_id not in all_ids:
+                    by_guild.setdefault(guild_id, set()).add(msg_id)
+                    all_ids.add(msg_id)
+                    mappings[msg_id] = {}
+                if emoji is not None:
                     mappings[msg_id][emoji] = role_id
             return by_guild, all_ids, mappings
 
@@ -226,6 +232,12 @@ class GuildConfigCache:
         Returns ``None`` when the guild has no enabled leave message.
         Falls back to a direct DB read when the cache has not been warmed yet and populates
         the per-guild entry so subsequent calls are served from memory.
+
+        On ``SQLAlchemyError``, logs the error and returns ``None`` without caching — the
+        entry stays absent so the next call retries the DB. Unlike ``get_guild_language``
+        and ``get_modrole``, this intentionally swallows the error to keep ``on_member_remove``
+        non-fatal; callers must not treat ``None`` as a definitive "no config" when the cache
+        is cold.
         """
         if self._leave_warmed or guild_id in self._leave_configs:
             return self._leave_configs.get(guild_id)
@@ -233,15 +245,14 @@ class GuildConfigCache:
         try:
             with _open_session(session_factory) as session:
                 from models.leavemsg import LeaveMessage
+                from sqlalchemy import select
 
-                row = (
-                    session.query(LeaveMessage)
-                    .filter(
+                row = session.execute(
+                    select(LeaveMessage).where(
                         LeaveMessage.GuildId == guild_id,
                         LeaveMessage.Enabled.is_(True),
                     )
-                    .first()
-                )
+                ).scalar_one_or_none()
                 config = (row.ChannelId, row.Message) if row is not None else None
         except SQLAlchemyError:
             _log.exception("get_leave_config: DB read failed for guild_id=%d — returning None", guild_id)
@@ -266,7 +277,9 @@ class GuildConfigCache:
         from models.leavemsg import LeaveMessage
 
         def _load(session):
-            rows = session.query(LeaveMessage).filter(LeaveMessage.Enabled.is_(True)).all()
+            from sqlalchemy import select
+
+            rows = session.execute(select(LeaveMessage).where(LeaveMessage.Enabled.is_(True))).scalars().all()
             return {row.GuildId: (row.ChannelId, row.Message) for row in rows}
 
         self._leave_configs = self._run_warm(session_factory, _load, "warm_leave_messages")
@@ -303,6 +316,12 @@ async def cached_autocomplete(key: tuple, fetcher):
 
     Returns:
         The cached or freshly fetched list.
+
+    Error handling:
+        ``SQLAlchemyError`` is caught, logged, and returns ``[]`` without caching
+        so the next keystroke retries. Non-DB exceptions (programming errors,
+        unexpected import failures) propagate uncaught so they surface immediately
+        rather than silently returning empty results on every keystroke.
     """
     if key in _autocomplete_cache:
         return _autocomplete_cache[key]
@@ -311,7 +330,7 @@ async def cached_autocomplete(key: tuple, fetcher):
     # window makes true simultaneity rare, and the TTL window suppresses all subsequent hits.
     try:
         result = await asyncio.to_thread(fetcher)
-    except Exception:
+    except SQLAlchemyError:
         _log.exception("cached_autocomplete: fetcher for key %r raised an error", key)
         return []
     _autocomplete_cache[key] = result

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -272,6 +272,7 @@ class GuildConfigCache:
     def set_leave_config(self, guild_id: int, channel_id: int, message: str | None) -> None:
         """Upsert the leave message config for a guild."""
         self._leave_configs[guild_id] = (channel_id, message)
+        self._leave_evicted.discard(guild_id)
 
     def evict_leave_config(self, guild_id: int) -> None:
         """Remove the leave message config for a guild (definitively disabled)."""

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 """In-memory guild configuration cache to reduce redundant DB queries."""
 
+import logging
+
+from cachetools import TTLCache
+
+_log = logging.getLogger(__name__)
+
 
 class GuildConfigCache:
     """Lightweight in-memory cache for per-guild configuration that rarely changes.
@@ -9,7 +15,9 @@ class GuildConfigCache:
     - Guild language: lazy (DB on miss), invalidated by ``guild_language_changed`` event
     - Bot moderator role: lazy (DB on miss), invalidated by ``modrole_changed`` event
     - Reaction role message IDs: bulk-loaded on startup, updated on add/remove
+    - Reaction role mappings: bulk-loaded on startup, updated on add/remove entry
     - Leave message guild IDs: bulk-loaded on startup, updated on enable/disable
+    - Leave message configs: bulk-loaded on startup, updated on enable/disable/edit
     """
 
     def __init__(self):
@@ -17,8 +25,9 @@ class GuildConfigCache:
         self._modrole: dict[int, int | None] = {}
         self._rr_message_ids: set[int] = set()  # flat set for O(1) hot-path lookup
         self._rr_by_guild: dict[int, set[int]] = {}  # guild_id -> set[message_id] for eviction
+        self._rr_mappings: dict[int, dict[str, int]] = {}
         self._rr_warmed: bool = False
-        self._leave_guild_ids: set[int] = set()
+        self._leave_configs: dict[int, tuple[int, str | None]] = {}
         self._leave_warmed: bool = False
 
     # ── Language ──────────────────────────────────────────────────────────────
@@ -83,39 +92,68 @@ class GuildConfigCache:
             return True
         return message_id in self._rr_message_ids
 
+    def get_reaction_role(self, message_id: int, emoji: str) -> int | None:
+        """Return the role ID for the given message + emoji, or None if not mapped.
+
+        Returns None before warm-up completes (callers must fall back to DB).
+        """
+        if not self._rr_warmed:
+            return None
+        return self._rr_mappings.get(message_id, {}).get(emoji)
+
     def add_reaction_role_message(self, guild_id: int, message_id: int) -> None:
         """Register a new reaction role message ID in the cache."""
         self._rr_message_ids.add(message_id)
         self._rr_by_guild.setdefault(guild_id, set()).add(message_id)
 
+    def add_reaction_role_entry(self, message_id: int, emoji: str, role_id: int) -> None:
+        """Add an emoji-to-role mapping for a tracked message.
+
+        No-op before warm-up — the full mapping is loaded by warm_reaction_roles().
+        """
+        if not self._rr_warmed:
+            return
+        self._rr_mappings.setdefault(message_id, {})[emoji] = role_id
+
+    def remove_reaction_role_entry(self, message_id: int, emoji: str) -> None:
+        """Remove a single emoji-to-role mapping from a tracked message."""
+        if message_id in self._rr_mappings:
+            self._rr_mappings[message_id].pop(emoji, None)
+
     def remove_reaction_role_message(self, guild_id: int, message_id: int) -> None:
-        """Remove a reaction role message ID from the cache."""
+        """Remove a reaction role message and all its mappings from the cache."""
         self._rr_message_ids.discard(message_id)
+        self._rr_mappings.pop(message_id, None)
         if guild_id in self._rr_by_guild:
             self._rr_by_guild[guild_id].discard(message_id)
 
     def warm_reaction_roles(self, session_factory) -> None:
-        """Bulk-load all reaction role message IDs from the database.
+        """Bulk-load all reaction role message IDs and emoji mappings from the database.
 
         Idempotent — safe to call again on reconnect.
         """
         session = session_factory()
         try:
-            from sqlalchemy import select
-
             from models.reactionrole import ReactionRoleMessage
 
             by_guild: dict[int, set[int]] = {}
             all_ids: set[int] = set()
-            rows = session.execute(select(ReactionRoleMessage.GuildId, ReactionRoleMessage.MessageId)).all()
-            for guild_id, message_id in rows:
-                by_guild.setdefault(guild_id, set()).add(message_id)
-                all_ids.add(message_id)
+            mappings: dict[int, dict[str, int]] = {}
+            # entries uses lazy="joined", so this single query fetches everything
+            messages = session.query(ReactionRoleMessage).all()
+            for msg in messages:
+                by_guild.setdefault(msg.GuildId, set()).add(msg.MessageId)
+                all_ids.add(msg.MessageId)
+                mappings[msg.MessageId] = {entry.Emoji: entry.RoleId for entry in msg.entries}
+        except Exception:
+            _log.exception("warm_reaction_roles: failed to load from DB — staying in degraded mode")
+            raise
         finally:
             session.close()
 
         self._rr_by_guild = by_guild
         self._rr_message_ids = all_ids
+        self._rr_mappings = mappings
         self._rr_warmed = True
 
     # ── Leave messages ────────────────────────────────────────────────────────
@@ -127,14 +165,25 @@ class GuildConfigCache:
         """
         if not self._leave_warmed:
             return True
-        return guild_id in self._leave_guild_ids
+        return guild_id in self._leave_configs
 
-    def set_leave_message_guild(self, guild_id: int, enabled: bool) -> None:
-        """Add or remove a guild from the leave-message set."""
+    def get_leave_config(self, guild_id: int) -> tuple[int, str | None] | None:
+        """Return (channel_id, message_text) for the guild's enabled leave message, or None."""
+        return self._leave_configs.get(guild_id)
+
+    def set_leave_message_guild(
+        self,
+        guild_id: int,
+        enabled: bool,
+        channel_id: int | None = None,
+        message: str | None = None,
+    ) -> None:
+        """Add or remove a guild from the leave-message config cache."""
         if enabled:
-            self._leave_guild_ids.add(guild_id)
+            if channel_id is not None:
+                self._leave_configs[guild_id] = (channel_id, message)
         else:
-            self._leave_guild_ids.discard(guild_id)
+            self._leave_configs.pop(guild_id, None)
 
     def warm_leave_messages(self, session_factory) -> None:
         """Bulk-load all guild IDs with enabled leave messages from the database.
@@ -143,15 +192,17 @@ class GuildConfigCache:
         """
         session = session_factory()
         try:
-            from sqlalchemy import select
-
             from models.leavemsg import LeaveMessage
 
-            ids = set(session.scalars(select(LeaveMessage.GuildId).where(LeaveMessage.Enabled.is_(True))))
+            rows = session.query(LeaveMessage).filter(LeaveMessage.Enabled.is_(True)).all()
+            configs = {row.GuildId: (row.ChannelId, row.Message) for row in rows}
+        except Exception:
+            _log.exception("warm_leave_messages: failed to load from DB — staying in degraded mode")
+            raise
         finally:
             session.close()
 
-        self._leave_guild_ids = ids
+        self._leave_configs = configs
         self._leave_warmed = True
 
     # ── Eviction ──────────────────────────────────────────────────────────────
@@ -160,7 +211,33 @@ class GuildConfigCache:
         """Remove all cached entries for a guild (called when bot leaves a guild)."""
         self._lang.pop(guild_id, None)
         self._modrole.pop(guild_id, None)
-        self._leave_guild_ids.discard(guild_id)
+        self._leave_configs.pop(guild_id, None)
         guild_rr = self._rr_by_guild.pop(guild_id, None)
         if guild_rr:
             self._rr_message_ids -= guild_rr
+            for msg_id in guild_rr:
+                self._rr_mappings.pop(msg_id, None)
+
+
+# ── Autocomplete TTL cache ─────────────────────────────────────────────────────
+
+# Shared cache for autocomplete handlers. Key: (cache_key_prefix, entity_id).
+# Short TTL (30s) reduces DB hits during rapid typing while keeping results fresh.
+_autocomplete_cache: TTLCache = TTLCache(maxsize=500, ttl=30)
+
+
+def cached_autocomplete(key: tuple, fetcher):
+    """Return cached autocomplete results, calling fetcher() on miss.
+
+    Args:
+        key: A hashable tuple uniquely identifying the query (e.g. ("tags", guild_id)).
+        fetcher: Zero-argument callable that opens a DB session and returns a list.
+
+    Returns:
+        The cached or freshly fetched list.
+    """
+    if key in _autocomplete_cache:
+        return _autocomplete_cache[key]
+    result = fetcher()
+    _autocomplete_cache[key] = result
+    return result

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -5,6 +5,8 @@ import asyncio
 import logging
 from contextlib import contextmanager
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from cachetools import TTLCache
 from discord import app_commands
 
@@ -34,7 +36,7 @@ class GuildConfigCache:
     - Bot moderator role: lazy (DB on miss), invalidated by ``modrole_changed`` event
     - Reaction role message IDs: bulk-loaded on startup, updated on add/remove
     - Reaction role mappings: bulk-loaded on startup, updated on add/remove entry
-    - Leave message configs: bulk-loaded on startup, updated on enable/disable/edit
+    - Leave message configs: bulk-loaded on startup, lazy-loaded on cold miss, updated on enable/disable/edit
     """
 
     def __init__(self):
@@ -233,34 +235,20 @@ class GuildConfigCache:
                     .first()
                 )
                 config = (row.ChannelId, row.Message) if row is not None else None
-        except Exception:
+        except SQLAlchemyError:
             _log.exception("get_leave_config: DB read failed for guild_id=%d — returning None", guild_id)
             return None
 
         self._leave_configs[guild_id] = config
         return config
 
-    def set_leave_message_guild(
-        self,
-        guild_id: int,
-        enabled: bool,
-        channel_id: int | None = None,
-        message: str | None = None,
-    ) -> None:
-        """Add or remove a guild from the leave-message config cache.
+    def set_leave_config(self, guild_id: int, channel_id: int, message: str | None) -> None:
+        """Upsert the leave message config for a guild."""
+        self._leave_configs[guild_id] = (channel_id, message)
 
-        When ``enabled=True``, ``channel_id`` must be provided; passing ``None`` raises
-        ``ValueError`` to surface caller bugs early.
-        When ``enabled=False``, the guild is evicted regardless of channel_id.
-        """
-        if enabled:
-            if channel_id is None:
-                raise ValueError(
-                    f"set_leave_message_guild: channel_id is required when enabled=True (guild_id={guild_id})"
-                )
-            self._leave_configs[guild_id] = (channel_id, message)
-        else:
-            self._leave_configs.pop(guild_id, None)
+    def evict_leave_config(self, guild_id: int) -> None:
+        """Remove the leave message config for a guild."""
+        self._leave_configs.pop(guild_id, None)
 
     def warm_leave_messages(self, session_factory) -> None:
         """Bulk-load full leave message configs (channel_id, message) for all enabled guilds.
@@ -282,7 +270,7 @@ class GuildConfigCache:
         """Remove all cached entries for a guild (called when bot leaves a guild)."""
         self._lang.pop(guild_id, None)
         self._modrole.pop(guild_id, None)
-        self._leave_configs.pop(guild_id, None)
+        self.evict_leave_config(guild_id)
         guild_rr = self._rr_by_guild.pop(guild_id, None)
         if guild_rr:
             self._rr_message_ids -= guild_rr

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -34,7 +34,6 @@ class GuildConfigCache:
     - Bot moderator role: lazy (DB on miss), invalidated by ``modrole_changed`` event
     - Reaction role message IDs: bulk-loaded on startup, updated on add/remove
     - Reaction role mappings: bulk-loaded on startup, updated on add/remove entry
-    - Leave message guild IDs: bulk-loaded on startup, updated on enable/disable
     - Leave message configs: bulk-loaded on startup, updated on enable/disable/edit
     """
 
@@ -152,7 +151,10 @@ class GuildConfigCache:
         self._rr_mappings.setdefault(message_id, {})[emoji] = role_id
 
     def remove_reaction_role_entry(self, message_id: int, emoji: str) -> None:
-        """Remove a single emoji-to-role mapping from a tracked message."""
+        """Remove a single emoji-to-role mapping from a tracked message.
+
+        No-op before warm-up — pre-warm the cache has no mappings to remove.
+        """
         if message_id in self._rr_mappings:
             self._rr_mappings[message_id].pop(emoji, None)
 
@@ -209,26 +211,31 @@ class GuildConfigCache:
         return guild_id in self._leave_configs
 
     def get_leave_config(self, guild_id: int, session_factory) -> tuple[int, str | None] | None:
-        """Return (channel_id, message_text) for the guild's enabled leave message, or None.
+        """Return ``(channel_id, message_text)`` for the guild's enabled leave message.
 
+        Returns ``None`` when the guild has no enabled leave message.
         Falls back to a direct DB read when the cache has not been warmed yet and populates
         the per-guild entry so subsequent calls are served from memory.
         """
         if self._leave_warmed or guild_id in self._leave_configs:
             return self._leave_configs.get(guild_id)
 
-        with _open_session(session_factory) as session:
-            from models.leavemsg import LeaveMessage
+        try:
+            with _open_session(session_factory) as session:
+                from models.leavemsg import LeaveMessage
 
-            row = (
-                session.query(LeaveMessage)
-                .filter(
-                    LeaveMessage.GuildId == guild_id,
-                    LeaveMessage.Enabled.is_(True),
+                row = (
+                    session.query(LeaveMessage)
+                    .filter(
+                        LeaveMessage.GuildId == guild_id,
+                        LeaveMessage.Enabled.is_(True),
+                    )
+                    .first()
                 )
-                .first()
-            )
-            config = (row.ChannelId, row.Message) if row is not None else None
+                config = (row.ChannelId, row.Message) if row is not None else None
+        except Exception:
+            _log.exception("get_leave_config: DB read failed for guild_id=%d — returning None", guild_id)
+            return None
 
         self._leave_configs[guild_id] = config
         return config
@@ -256,7 +263,7 @@ class GuildConfigCache:
             self._leave_configs.pop(guild_id, None)
 
     def warm_leave_messages(self, session_factory) -> None:
-        """Bulk-load all guild IDs with enabled leave messages from the database.
+        """Bulk-load full leave message configs (channel_id, message) for all enabled guilds.
 
         Idempotent — safe to call again on reconnect.
         """
@@ -306,7 +313,11 @@ async def cached_autocomplete(key: tuple, fetcher):
     # No lock: two concurrent keystrokes for the same key can both miss and fire parallel DB
     # fetches. Both write the same result, so this is benign — Discord's 3s autocomplete
     # window makes true simultaneity rare, and the TTL window suppresses all subsequent hits.
-    result = await asyncio.to_thread(fetcher)
+    try:
+        result = await asyncio.to_thread(fetcher)
+    except Exception:
+        _log.exception("cached_autocomplete: fetcher for key %r raised an error", key)
+        return []
     _autocomplete_cache[key] = result
     return result
 

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -2,11 +2,22 @@
 """In-memory guild configuration cache to reduce redundant DB queries."""
 
 import logging
+from contextlib import contextmanager
 
 from cachetools import TTLCache
 from discord import app_commands
 
 _log = logging.getLogger(__name__)
+
+
+@contextmanager
+def _open_session(session_factory):
+    """Open a SQLAlchemy session and ensure it is closed on exit."""
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
 
 
 class GuildConfigCache:
@@ -31,6 +42,25 @@ class GuildConfigCache:
         self._leave_configs: dict[int, tuple[int, str | None]] = {}
         self._leave_warmed: bool = False
 
+    @staticmethod
+    def _run_warm(session_factory, loader_fn, error_label: str):
+        """Run a bulk DB load inside a session, logging and re-raising on failure.
+
+        Args:
+            session_factory: Callable that returns a new SQLAlchemy session.
+            loader_fn: ``(session) -> T`` — performs the query and returns data.
+            error_label: Prefix used in the error log message.
+
+        Returns:
+            Whatever ``loader_fn`` returns.
+        """
+        with _open_session(session_factory) as session:
+            try:
+                return loader_fn(session)
+            except Exception:
+                _log.exception("%s: failed to load from DB — staying in degraded mode", error_label)
+                raise
+
     # ── Language ──────────────────────────────────────────────────────────────
 
     def get_guild_language(self, guild_id: int, session_factory) -> str:
@@ -38,14 +68,11 @@ class GuildConfigCache:
         if guild_id in self._lang:
             return self._lang[guild_id]
 
-        session = session_factory()
-        try:
+        with _open_session(session_factory) as session:
             from models.admin import GuildLanguageConfig
 
             config = GuildLanguageConfig.get(guild_id, session)
             lang = config.Language if config is not None else "en"
-        finally:
-            session.close()
 
         self._lang[guild_id] = lang
         return lang
@@ -61,14 +88,11 @@ class GuildConfigCache:
         if guild_id in self._modrole:
             return self._modrole[guild_id]
 
-        session = session_factory()
-        try:
+        with _open_session(session_factory) as session:
             from models.admin import BotModeratorRole
 
             entry = BotModeratorRole.get(guild_id, session)
             role_id = entry.RoleId if entry is not None else None
-        finally:
-            session.close()
 
         self._modrole[guild_id] = role_id
         return role_id
@@ -133,28 +157,22 @@ class GuildConfigCache:
 
         Idempotent — safe to call again on reconnect.
         """
-        session = session_factory()
-        try:
-            from models.reactionrole import ReactionRoleMessage
+        from models.reactionrole import ReactionRoleMessage
 
+        def _load(session):
             by_guild: dict[int, set[int]] = {}
             all_ids: set[int] = set()
             mappings: dict[int, dict[str, int]] = {}
             # entries uses lazy="joined", so this single query fetches everything
-            messages = session.query(ReactionRoleMessage).all()
-            for msg in messages:
+            for msg in session.query(ReactionRoleMessage).all():
                 by_guild.setdefault(msg.GuildId, set()).add(msg.MessageId)
                 all_ids.add(msg.MessageId)
                 mappings[msg.MessageId] = {entry.Emoji: entry.RoleId for entry in msg.entries}
-        except Exception:
-            _log.exception("warm_reaction_roles: failed to load from DB — staying in degraded mode")
-            raise
-        finally:
-            session.close()
+            return by_guild, all_ids, mappings
 
-        self._rr_by_guild = by_guild
-        self._rr_message_ids = all_ids
-        self._rr_mappings = mappings
+        self._rr_by_guild, self._rr_message_ids, self._rr_mappings = self._run_warm(
+            session_factory, _load, "warm_reaction_roles"
+        )
         self._rr_warmed = True
 
     # ── Leave messages ────────────────────────────────────────────────────────
@@ -178,8 +196,7 @@ class GuildConfigCache:
         if self._leave_warmed or guild_id in self._leave_configs:
             return self._leave_configs.get(guild_id)
 
-        session = session_factory()
-        try:
+        with _open_session(session_factory) as session:
             from models.leavemsg import LeaveMessage
 
             row = (
@@ -191,8 +208,6 @@ class GuildConfigCache:
                 .first()
             )
             config = (row.ChannelId, row.Message) if row is not None else None
-        finally:
-            session.close()
 
         self._leave_configs[guild_id] = config
         return config
@@ -224,19 +239,13 @@ class GuildConfigCache:
 
         Idempotent — safe to call again on reconnect.
         """
-        session = session_factory()
-        try:
-            from models.leavemsg import LeaveMessage
+        from models.leavemsg import LeaveMessage
 
+        def _load(session):
             rows = session.query(LeaveMessage).filter(LeaveMessage.Enabled.is_(True)).all()
-            configs = {row.GuildId: (row.ChannelId, row.Message) for row in rows}
-        except Exception:
-            _log.exception("warm_leave_messages: failed to load from DB — staying in degraded mode")
-            raise
-        finally:
-            session.close()
+            return {row.GuildId: (row.ChannelId, row.Message) for row in rows}
 
-        self._leave_configs = configs
+        self._leave_configs = self._run_warm(session_factory, _load, "warm_leave_messages")
         self._leave_warmed = True
 
     # ── Eviction ──────────────────────────────────────────────────────────────

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -21,6 +21,11 @@ def _open_session(session_factory):
         session.close()
 
 
+# Sentinel returned by GuildConfigCache.get_reaction_role() when the cache has not been
+# warmed yet. Distinguishes "not warmed — fall back to DB" from None ("warmed, no mapping").
+REACTION_ROLE_CACHE_MISS = object()
+
+
 class GuildConfigCache:
     """Lightweight in-memory cache for per-guild configuration that rarely changes.
 
@@ -118,13 +123,18 @@ class GuildConfigCache:
             return True
         return message_id in self._rr_message_ids
 
-    def get_reaction_role(self, message_id: int, emoji: str) -> int | None:
-        """Return the role ID for the given message + emoji, or None if not mapped.
+    def get_reaction_role(self, message_id: int, emoji: str):
+        """Return the role ID for the given message + emoji.
 
-        Returns None before warm-up completes (callers must fall back to DB).
+        Returns:
+            ``REACTION_ROLE_CACHE_MISS`` if the cache has not been warmed yet
+                (caller must fall back to DB).
+            ``None`` if the cache is warmed but the emoji has no mapping
+                (caller should skip the DB query).
+            ``int`` role ID if a mapping exists.
         """
         if not self._rr_warmed:
-            return None
+            return REACTION_ROLE_CACHE_MISS
         return self._rr_mappings.get(message_id, {}).get(emoji)
 
     def add_reaction_role_message(self, guild_id: int, message_id: int) -> None:

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -4,6 +4,7 @@
 import logging
 
 from cachetools import TTLCache
+from discord import app_commands
 
 _log = logging.getLogger(__name__)
 
@@ -241,3 +242,12 @@ def cached_autocomplete(key: tuple, fetcher):
     result = fetcher()
     _autocomplete_cache[key] = result
     return result
+
+
+def build_name_choices(names: list[str], current: str) -> list[app_commands.Choice[str]]:
+    """Filter a list of names by the current autocomplete input and return up to 25 choices.
+
+    Companion to ``cached_autocomplete`` for the common case where the cache stores
+    plain name strings and Discord choices have name == value.
+    """
+    return [app_commands.Choice(name=n[:100], value=n) for n in names if current.lower() in n.lower()][:25]

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 import time
 from contextlib import contextmanager
-from typing import Literal
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -30,9 +29,16 @@ def _open_session(session_factory):
 # to DB" (not yet warmed, or evicted after warm-up) from None ("warmed, emoji has no mapping").
 REACTION_ROLE_CACHE_MISS = object()
 
-# Sentinel returned by GuildConfigCache.get_leave_config() when a DB read failed.
-# Callers must treat this as distinct from None ("no leave config") and log at warning level.
-LEAVE_CONFIG_DB_ERROR = object()
+
+class _LeaveConfigDbError:
+    """Typed sentinel returned by GuildConfigCache.get_leave_config() on DB failure.
+
+    Distinct from ``None`` ("no leave config found") so callers can narrow the
+    return type statically. Use ``result is LEAVE_CONFIG_DB_ERROR`` for identity checks.
+    """
+
+
+LEAVE_CONFIG_DB_ERROR = _LeaveConfigDbError()
 
 # Minimum seconds between lazy re-warm attempts after a failed startup warm-up.
 _REWARM_COOLDOWN = 60.0
@@ -322,9 +328,7 @@ class GuildConfigCache:
         if self._leave_warmed:
             self._leave_evicted.add(guild_id)
 
-    def get_leave_config(
-        self, guild_id: int, session_factory
-    ) -> tuple[int, str | None] | None | Literal[LEAVE_CONFIG_DB_ERROR]:
+    def get_leave_config(self, guild_id: int, session_factory) -> tuple[int, str | None] | None | _LeaveConfigDbError:
         """Return ``(channel_id, message_text)`` for the guild's enabled leave message.
 
         Returns ``None`` when the guild has no enabled leave message.

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -290,7 +290,10 @@ class GuildConfigCache:
             with _open_session(session_factory) as session:
                 row = self._query_leave_row(guild_id, session)
         except SQLAlchemyError:
-            _log.exception("reload_leave_config: DB read failed for guild_id=%d — evicting instead", guild_id)
+            _log.exception(
+                "reload_leave_config: DB read failed for guild_id=%d — evicting so cold-miss retries on next member-remove",
+                guild_id,
+            )
             self.evict_leave_config(guild_id)
             return
 

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -55,10 +55,8 @@ class GuildConfigCache:
     def _run_warm(session_factory, loader_fn):
         """Run a bulk DB load inside a session.
 
-        Re-raises ``SQLAlchemyError`` so callers stay in degraded mode. Logging
-        is left to the caller, which has richer context (cache name, strategy).
-        Non-SQLAlchemy exceptions propagate uncaught so the real exception type
-        is visible.
+        Any exception from ``loader_fn`` propagates to the caller. Logging is
+        left to the caller, which has richer context (cache name, strategy).
 
         Args:
             session_factory: Callable that returns a new SQLAlchemy session.
@@ -68,10 +66,7 @@ class GuildConfigCache:
             Whatever ``loader_fn`` returns.
         """
         with _open_session(session_factory) as session:
-            try:
-                return loader_fn(session)
-            except SQLAlchemyError:
-                raise
+            return loader_fn(session)
 
     # ── Language ──────────────────────────────────────────────────────────────
 
@@ -163,6 +158,7 @@ class GuildConfigCache:
         """Register a new reaction role message ID in the cache."""
         self._rr_message_ids.add(message_id)
         self._rr_by_guild.setdefault(guild_id, set()).add(message_id)
+        self._rr_evicted_msgs.discard(message_id)  # heal eviction sentinel if guild rejoined
 
     def add_reaction_role_entry(self, message_id: int, emoji: str, role_id: int) -> None:
         """Add an emoji-to-role mapping for a tracked message.
@@ -185,6 +181,7 @@ class GuildConfigCache:
         """Remove a reaction role message and all its mappings from the cache."""
         self._rr_message_ids.discard(message_id)
         self._rr_mappings.pop(message_id, None)
+        self._rr_evicted_msgs.discard(message_id)  # cancel re-check sentinel: message is definitively removed
         if guild_id in self._rr_by_guild:
             self._rr_by_guild[guild_id].discard(message_id)
 

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -175,7 +175,7 @@ class GuildConfigCache:
         the per-guild entry, matching the lazy-load pattern of ``get_guild_language`` and
         ``get_modrole``.
         """
-        if self._leave_warmed:
+        if self._leave_warmed or guild_id in self._leave_configs:
             return self._leave_configs.get(guild_id)
 
         session = session_factory()
@@ -194,8 +194,7 @@ class GuildConfigCache:
         finally:
             session.close()
 
-        if config is not None:
-            self._leave_configs[guild_id] = config
+        self._leave_configs[guild_id] = config
         return config
 
     def set_leave_message_guild(

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -185,6 +185,16 @@ class GuildConfigCache:
         if guild_id in self._rr_by_guild:
             self._rr_by_guild[guild_id].discard(message_id)
 
+    @property
+    def rr_warmed(self) -> bool:
+        """Return True once the reaction-role cache has been successfully warmed."""
+        return self._rr_warmed
+
+    @property
+    def leave_warmed(self) -> bool:
+        """Return True once the leave-message cache has been successfully warmed."""
+        return self._leave_warmed
+
     def warm_reaction_roles(self, session_factory) -> None:
         """Bulk-load all reaction role message IDs and emoji mappings from the database.
 

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -292,4 +292,4 @@ def build_name_choices(names: list[str], current: str) -> list[app_commands.Choi
     Companion to ``cached_autocomplete`` for the common case where the cache stores
     plain name strings and Discord choices have name == value.
     """
-    return [app_commands.Choice(name=n[:100], value=n) for n in names if current.lower() in n.lower()][:25]
+    return [app_commands.Choice(name=n[:100], value=n[:100]) for n in names if current.lower() in n.lower()][:25]

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -168,9 +168,30 @@ class GuildConfigCache:
             return True
         return guild_id in self._leave_configs
 
-    def get_leave_config(self, guild_id: int) -> tuple[int, str | None] | None:
-        """Return (channel_id, message_text) for the guild's enabled leave message, or None."""
-        return self._leave_configs.get(guild_id)
+    def get_leave_config(self, guild_id: int, session_factory) -> tuple[int, str | None] | None:
+        """Return (channel_id, message_text) for the guild's enabled leave message, or None.
+
+        Falls back to a direct DB read when the cache has not been warmed yet, matching
+        the lazy-load pattern used by ``get_guild_language`` and ``get_modrole``.
+        """
+        if self._leave_warmed:
+            return self._leave_configs.get(guild_id)
+
+        session = session_factory()
+        try:
+            from models.leavemsg import LeaveMessage
+
+            row = (
+                session.query(LeaveMessage)
+                .filter(
+                    LeaveMessage.GuildId == guild_id,
+                    LeaveMessage.Enabled.is_(True),
+                )
+                .first()
+            )
+            return (row.ChannelId, row.Message) if row is not None else None
+        finally:
+            session.close()
 
     def set_leave_message_guild(
         self,
@@ -181,13 +202,16 @@ class GuildConfigCache:
     ) -> None:
         """Add or remove a guild from the leave-message config cache.
 
-        When ``enabled=True``, the guild is stored only if ``channel_id`` is not None;
-        passing ``enabled=True`` without a channel_id is a no-op.
+        When ``enabled=True``, ``channel_id`` must be provided; passing ``None`` raises
+        ``ValueError`` to surface caller bugs early.
         When ``enabled=False``, the guild is evicted regardless of channel_id.
         """
         if enabled:
-            if channel_id is not None:
-                self._leave_configs[guild_id] = (channel_id, message)
+            if channel_id is None:
+                raise ValueError(
+                    f"set_leave_message_guild: channel_id is required when enabled=True (guild_id={guild_id})"
+                )
+            self._leave_configs[guild_id] = (channel_id, message)
         else:
             self._leave_configs.pop(guild_id, None)
 

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -404,9 +404,10 @@ async def cached_autocomplete(key: tuple, fetcher):
 
     Error handling:
         ``SQLAlchemyError`` is caught, logged, and returns ``[]`` without caching
-        so the next keystroke retries. Non-DB exceptions (programming errors,
-        unexpected import failures) propagate uncaught so they surface immediately
-        rather than silently returning empty results on every keystroke.
+        so the next keystroke retries. Any other exception (programming errors,
+        unexpected import failures) is also caught, logged at error level, and
+        returns ``[]`` so discord.py's autocomplete handler gets a clean empty list
+        rather than propagating to the root exception handler with no module log entry.
     """
     try:
         return _autocomplete_cache[key]
@@ -419,6 +420,9 @@ async def cached_autocomplete(key: tuple, fetcher):
         result = await asyncio.to_thread(fetcher)
     except SQLAlchemyError:
         _log.exception("cached_autocomplete: fetcher for key %r raised an error", key)
+        return []
+    except Exception:
+        _log.error("cached_autocomplete: unexpected error for key %r", key, exc_info=True)
         return []
     _autocomplete_cache[key] = result
     return result

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -171,8 +171,9 @@ class GuildConfigCache:
     def get_leave_config(self, guild_id: int, session_factory) -> tuple[int, str | None] | None:
         """Return (channel_id, message_text) for the guild's enabled leave message, or None.
 
-        Falls back to a direct DB read when the cache has not been warmed yet, matching
-        the lazy-load pattern used by ``get_guild_language`` and ``get_modrole``.
+        Falls back to a direct DB read when the cache has not been warmed yet and populates
+        the per-guild entry, matching the lazy-load pattern of ``get_guild_language`` and
+        ``get_modrole``.
         """
         if self._leave_warmed:
             return self._leave_configs.get(guild_id)
@@ -189,9 +190,13 @@ class GuildConfigCache:
                 )
                 .first()
             )
-            return (row.ChannelId, row.Message) if row is not None else None
+            config = (row.ChannelId, row.Message) if row is not None else None
         finally:
             session.close()
+
+        if config is not None:
+            self._leave_configs[guild_id] = config
+        return config
 
     def set_leave_message_guild(
         self,

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -7,6 +7,8 @@ from contextlib import contextmanager
 
 from sqlalchemy.exc import SQLAlchemyError
 
+from utils.errors import NerpyInfraException
+
 from cachetools import TTLCache
 from discord import app_commands
 
@@ -418,7 +420,7 @@ async def cached_autocomplete(key: tuple, fetcher):
     # window makes true simultaneity rare, and the TTL window suppresses all subsequent hits.
     try:
         result = await asyncio.to_thread(fetcher)
-    except SQLAlchemyError:
+    except (SQLAlchemyError, NerpyInfraException):
         _log.exception("cached_autocomplete: fetcher for key %r raised an error", key)
         return []
     except Exception:

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -394,6 +394,16 @@ def invalidate_autocomplete(key: tuple) -> None:
     _autocomplete_cache.pop(key, None)
 
 
+def invalidate_autocomplete_app_templates(guild_id: int) -> None:
+    """Evict both app template autocomplete caches for a guild.
+
+    ``app_templates`` and ``app_guild_templates`` share the same mutation sites
+    (save, delete, create-from-template), so they are always invalidated together.
+    """
+    invalidate_autocomplete(("app_templates", guild_id))
+    invalidate_autocomplete(("app_guild_templates", guild_id))
+
+
 def build_name_choices(names: list[str], current: str) -> list[app_commands.Choice[str]]:
     """Filter a list of names by the current autocomplete input and return up to 25 choices.
 

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -46,7 +46,7 @@ class GuildConfigCache:
         self._rr_by_guild: dict[int, set[int]] = {}  # guild_id -> set[message_id] for eviction
         self._rr_mappings: dict[int, dict[str, int]] = {}
         self._rr_warmed: bool = False
-        self._leave_configs: dict[int, tuple[int, str | None]] = {}
+        self._leave_configs: dict[int, tuple[int, str | None] | None] = {}
         self._leave_warmed: bool = False
 
     @staticmethod
@@ -226,6 +226,19 @@ class GuildConfigCache:
             return True
         return guild_id in self._leave_configs
 
+    @staticmethod
+    def _query_leave_row(guild_id: int, session):
+        """Return the enabled LeaveMessage row for a guild, or None if not found."""
+        from models.leavemsg import LeaveMessage
+        from sqlalchemy import select
+
+        return session.execute(
+            select(LeaveMessage).where(
+                LeaveMessage.GuildId == guild_id,
+                LeaveMessage.Enabled.is_(True),
+            )
+        ).scalar_one_or_none()
+
     def get_leave_config(self, guild_id: int, session_factory) -> tuple[int, str | None] | None:
         """Return ``(channel_id, message_text)`` for the guild's enabled leave message.
 
@@ -244,15 +257,7 @@ class GuildConfigCache:
 
         try:
             with _open_session(session_factory) as session:
-                from models.leavemsg import LeaveMessage
-                from sqlalchemy import select
-
-                row = session.execute(
-                    select(LeaveMessage).where(
-                        LeaveMessage.GuildId == guild_id,
-                        LeaveMessage.Enabled.is_(True),
-                    )
-                ).scalar_one_or_none()
+                row = self._query_leave_row(guild_id, session)
                 config = (row.ChannelId, row.Message) if row is not None else None
         except SQLAlchemyError:
             _log.exception("get_leave_config: DB read failed for guild_id=%d — returning None", guild_id)
@@ -268,6 +273,31 @@ class GuildConfigCache:
     def evict_leave_config(self, guild_id: int) -> None:
         """Remove the leave message config for a guild."""
         self._leave_configs.pop(guild_id, None)
+
+    def reload_leave_config(self, guild_id: int, session_factory) -> None:
+        """Force a fresh DB read for a guild's leave config and update the cache.
+
+        Unlike ``get_leave_config``, this bypasses the ``_leave_warmed`` short-circuit
+        and always hits the DB. Use after an external mutation (e.g. web dashboard
+        enable/disable) so ``is_leave_message_guild`` reflects the new state immediately
+        rather than waiting for an eviction-triggered cold miss that would never arrive
+        when ``_leave_warmed=True``.
+
+        On ``SQLAlchemyError``, logs the error and falls back to eviction so the next
+        ``on_member_remove`` retries the DB read via the cold-miss path.
+        """
+        try:
+            with _open_session(session_factory) as session:
+                row = self._query_leave_row(guild_id, session)
+        except SQLAlchemyError:
+            _log.exception("reload_leave_config: DB read failed for guild_id=%d — evicting instead", guild_id)
+            self.evict_leave_config(guild_id)
+            return
+
+        if row is not None:
+            self._leave_configs[guild_id] = (row.ChannelId, row.Message)
+        else:
+            self.evict_leave_config(guild_id)
 
     def warm_leave_messages(self, session_factory) -> None:
         """Bulk-load full leave message configs (channel_id, message) for all enabled guilds.

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -257,6 +257,35 @@ class GuildConfigCache:
             )
         ).scalar_one_or_none()
 
+    def _load_leave_config_from_db(self, guild_id: int, session_factory) -> tuple[int, str | None] | None:
+        """Read the leave config for *guild_id* from the DB.
+
+        Returns ``(channel_id, message)`` or ``None`` (no enabled leave message).
+        Pure I/O — does **not** mutate any cache state. Safe to call from a worker thread.
+        Raises ``SQLAlchemyError`` on DB failure.
+        """
+        with _open_session(session_factory) as session:
+            row = self._query_leave_row(guild_id, session)
+        return (row.ChannelId, row.Message) if row is not None else None
+
+    def apply_leave_config(self, guild_id: int, config: tuple[int, str | None] | None) -> None:
+        """Write a freshly loaded leave config into the in-memory cache.
+
+        Must be called from the event-loop thread.
+        ``config`` is ``(channel_id, message)`` or ``None`` (no enabled leave message).
+        """
+        if config is not None:
+            self._leave_configs[guild_id] = config
+        else:
+            self._leave_configs.pop(guild_id, None)
+        self._leave_evicted.discard(guild_id)
+
+    def mark_leave_config_for_recheck(self, guild_id: int) -> None:
+        """On DB error: evict stale data and flag the guild for re-read on the next member-remove."""
+        self._leave_configs.pop(guild_id, None)
+        if self._leave_warmed:
+            self._leave_evicted.add(guild_id)
+
     def get_leave_config(self, guild_id: int, session_factory) -> tuple[int, str | None] | None:
         """Return ``(channel_id, message_text)`` for the guild's enabled leave message.
 
@@ -275,13 +304,14 @@ class GuildConfigCache:
                 return self._leave_configs.get(guild_id)
 
         try:
-            with _open_session(session_factory) as session:
-                row = self._query_leave_row(guild_id, session)
-                config = (row.ChannelId, row.Message) if row is not None else None
+            config = self._load_leave_config_from_db(guild_id, session_factory)
         except SQLAlchemyError:
             _log.exception("get_leave_config: DB read failed for guild_id=%d — returning None", guild_id)
             return None
 
+        # Store None explicitly as a sentinel so repeated cold-cache misses for the same guild
+        # don't each re-hit the DB.  (apply_leave_config pops on None, which is the right
+        # behaviour for the reload/eviction path but not here.)
         self._leave_configs[guild_id] = config
         self._leave_evicted.discard(guild_id)
         return config
@@ -309,23 +339,15 @@ class GuildConfigCache:
         ``on_member_remove`` retries the DB read via the cold-miss path.
         """
         try:
-            with _open_session(session_factory) as session:
-                row = self._query_leave_row(guild_id, session)
+            config = self._load_leave_config_from_db(guild_id, session_factory)
         except SQLAlchemyError:
             _log.exception(
                 "reload_leave_config: DB read failed for guild_id=%d — evicting so cold-miss retries on next member-remove",
                 guild_id,
             )
-            self._leave_configs.pop(guild_id, None)
-            if self._leave_warmed:
-                self._leave_evicted.add(guild_id)
+            self.mark_leave_config_for_recheck(guild_id)
             return
-
-        if row is not None:
-            self._leave_configs[guild_id] = (row.ChannelId, row.Message)
-        else:
-            self._leave_configs.pop(guild_id, None)
-        self._leave_evicted.discard(guild_id)
+        self.apply_leave_config(guild_id, config)
 
     def warm_leave_messages(self, session_factory) -> None:
         """Bulk-load full leave message configs (channel_id, message) for all enabled guilds.

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import time
 from contextlib import contextmanager
+from typing import Literal
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -321,7 +322,9 @@ class GuildConfigCache:
         if self._leave_warmed:
             self._leave_evicted.add(guild_id)
 
-    def get_leave_config(self, guild_id: int, session_factory) -> tuple[int, str | None] | None | object:
+    def get_leave_config(
+        self, guild_id: int, session_factory
+    ) -> tuple[int, str | None] | None | Literal[LEAVE_CONFIG_DB_ERROR]:
         """Return ``(channel_id, message_text)`` for the guild's enabled leave message.
 
         Returns ``None`` when the guild has no enabled leave message.

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -75,11 +75,15 @@ class GuildConfigCache:
         if guild_id in self._lang:
             return self._lang[guild_id]
 
-        with _open_session(session_factory) as session:
-            from models.admin import GuildLanguageConfig
+        try:
+            with _open_session(session_factory) as session:
+                from models.admin import GuildLanguageConfig
 
-            config = GuildLanguageConfig.get(guild_id, session)
-            lang = config.Language if config is not None else "en"
+                config = GuildLanguageConfig.get(guild_id, session)
+                lang = config.Language if config is not None else "en"
+        except SQLAlchemyError:
+            _log.exception("get_guild_language: DB read failed for guild_id=%d", guild_id)
+            raise
 
         self._lang[guild_id] = lang
         return lang
@@ -95,11 +99,15 @@ class GuildConfigCache:
         if guild_id in self._modrole:
             return self._modrole[guild_id]
 
-        with _open_session(session_factory) as session:
-            from models.admin import BotModeratorRole
+        try:
+            with _open_session(session_factory) as session:
+                from models.admin import BotModeratorRole
 
-            entry = BotModeratorRole.get(guild_id, session)
-            role_id = entry.RoleId if entry is not None else None
+                entry = BotModeratorRole.get(guild_id, session)
+                role_id = entry.RoleId if entry is not None else None
+        except SQLAlchemyError:
+            _log.exception("get_modrole: DB read failed for guild_id=%d", guild_id)
+            raise
 
         self._modrole[guild_id] = role_id
         return role_id

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -370,8 +370,10 @@ async def cached_autocomplete(key: tuple, fetcher):
         unexpected import failures) propagate uncaught so they surface immediately
         rather than silently returning empty results on every keystroke.
     """
-    if key in _autocomplete_cache:
+    try:
         return _autocomplete_cache[key]
+    except KeyError:
+        pass
     # No lock: two concurrent keystrokes for the same key can both miss and fire parallel DB
     # fetches. Both write the same result, so this is benign — Discord's 3s autocomplete
     # window makes true simultaneity rare, and the TTL window suppresses all subsequent hits.

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
-"""In-memory guild configuration cache to reduce redundant DB queries."""
+"""In-memory guild configuration and autocomplete TTL cache."""
 
 import asyncio
 import logging
+import time
 from contextlib import contextmanager
 
 from sqlalchemy.exc import SQLAlchemyError
-
-from utils.errors import NerpyInfraException
 
 from cachetools import TTLCache
 from discord import app_commands
@@ -26,8 +25,16 @@ def _open_session(session_factory):
 
 
 # Sentinel returned by GuildConfigCache.get_reaction_role() when the cache has not been
-# warmed yet. Distinguishes "not warmed — fall back to DB" from None ("warmed, no mapping").
+# warmed yet or when the message was evicted after warm-up. Distinguishes "must fall back
+# to DB" (not yet warmed, or evicted after warm-up) from None ("warmed, emoji has no mapping").
 REACTION_ROLE_CACHE_MISS = object()
+
+# Sentinel returned by GuildConfigCache.get_leave_config() when a DB read failed.
+# Callers must treat this as distinct from None ("no leave config") and log at warning level.
+LEAVE_CONFIG_DB_ERROR = object()
+
+# Minimum seconds between lazy re-warm attempts after a failed startup warm-up.
+_REWARM_COOLDOWN = 60.0
 
 
 class GuildConfigCache:
@@ -49,9 +56,11 @@ class GuildConfigCache:
         self._rr_mappings: dict[int, dict[str, int]] = {}
         self._rr_warmed: bool = False
         self._rr_evicted_msgs: set[int] = set()  # evicted after warm; return CACHE_MISS until re-warmed
+        self._rr_last_rewarm_attempt: float = 0.0
         self._leave_configs: dict[int, tuple[int, str | None] | None] = {}
         self._leave_warmed: bool = False
         self._leave_evicted: set[int] = set()  # guilds evicted after warm-up; need DB re-read on next access
+        self._leave_last_rewarm_attempt: float = 0.0
 
     @staticmethod
     def _run_warm(session_factory, loader_fn):
@@ -231,6 +240,25 @@ class GuildConfigCache:
         self._rr_warmed = True
         self._rr_evicted_msgs.clear()
 
+    def try_rewarm_reaction_roles(self, session_factory) -> None:
+        """Attempt a reaction-role re-warm if the cache is unwarmed and the backoff window has elapsed.
+
+        Called from the on_raw_reaction_add hot path when ``_rr_warmed`` is still ``False``
+        after a failed startup warm-up. Limits re-warm frequency to ``_REWARM_COOLDOWN`` seconds
+        so a persistently down DB does not cause a flood of queries per reaction event.
+        """
+        if self._rr_warmed:
+            return
+        now = time.monotonic()
+        if now - self._rr_last_rewarm_attempt < _REWARM_COOLDOWN:
+            return
+        self._rr_last_rewarm_attempt = now
+        try:
+            self.warm_reaction_roles(session_factory)
+            _log.info("GuildConfigCache: reaction-role cache lazily re-warmed")
+        except Exception:
+            _log.exception("GuildConfigCache: lazy reaction-role re-warm failed")
+
     # ── Leave messages ────────────────────────────────────────────────────────
 
     def is_leave_message_guild(self, guild_id: int) -> bool:
@@ -292,14 +320,18 @@ class GuildConfigCache:
         """Return ``(channel_id, message_text)`` for the guild's enabled leave message.
 
         Returns ``None`` when the guild has no enabled leave message.
-        Falls back to a direct DB read when the cache has not been warmed yet and populates
-        the per-guild entry so subsequent calls are served from memory.
+        Returns :data:`LEAVE_CONFIG_DB_ERROR` when a DB read failed — callers must log at
+        warning level to distinguish this from a legitimately absent config.
+        Falls back to a direct DB read when the cache has not been warmed yet or when
+        ``guild_id in self._leave_evicted`` (guild evicted after warm-up, e.g. via
+        ``evict_guild`` or a prior DB error flagged by ``mark_leave_config_for_recheck``).
+        On success the per-guild entry is populated and the eviction sentinel cleared so
+        subsequent calls are served from memory.
 
-        On ``SQLAlchemyError``, logs the error and returns ``None`` without caching — the
-        entry stays absent so the next call retries the DB. Unlike ``get_guild_language``
-        and ``get_modrole``, this intentionally swallows the error to keep ``on_member_remove``
-        non-fatal; callers must not treat ``None`` as a definitive "no config" when the cache
-        is cold.
+        On ``SQLAlchemyError``, logs the error and returns :data:`LEAVE_CONFIG_DB_ERROR`
+        without caching — the entry stays absent so the next call retries the DB. Unlike
+        ``get_guild_language`` and ``get_modrole``, this intentionally swallows the error
+        to keep ``on_member_remove`` non-fatal.
         """
         if guild_id not in self._leave_evicted:
             if self._leave_warmed or guild_id in self._leave_configs:
@@ -308,8 +340,8 @@ class GuildConfigCache:
         try:
             config = self._load_leave_config_from_db(guild_id, session_factory)
         except SQLAlchemyError:
-            _log.exception("get_leave_config: DB read failed for guild_id=%d — returning None", guild_id)
-            return None
+            _log.exception("get_leave_config: DB read failed for guild_id=%d", guild_id)
+            return LEAVE_CONFIG_DB_ERROR
 
         # Store None explicitly as a sentinel so repeated cold-cache misses for the same guild
         # don't each re-hit the DB.  (apply_leave_config pops on None, which is the right
@@ -368,6 +400,25 @@ class GuildConfigCache:
         self._leave_warmed = True
         self._leave_evicted.clear()
 
+    def try_rewarm_leave_messages(self, session_factory) -> None:
+        """Attempt a leave-message re-warm if the cache is unwarmed and the backoff window has elapsed.
+
+        Called from the on_member_remove hot path when ``_leave_warmed`` is still ``False``
+        after a failed startup warm-up. Limits re-warm frequency to ``_REWARM_COOLDOWN`` seconds
+        so a persistently down DB does not cause a flood of queries per member-leave event.
+        """
+        if self._leave_warmed:
+            return
+        now = time.monotonic()
+        if now - self._leave_last_rewarm_attempt < _REWARM_COOLDOWN:
+            return
+        self._leave_last_rewarm_attempt = now
+        try:
+            self.warm_leave_messages(session_factory)
+            _log.info("GuildConfigCache: leave-message cache lazily re-warmed")
+        except Exception:
+            _log.exception("GuildConfigCache: lazy leave-message re-warm failed")
+
     # ── Eviction ──────────────────────────────────────────────────────────────
 
     def evict_guild(self, guild_id: int) -> None:
@@ -405,11 +456,13 @@ async def cached_autocomplete(key: tuple, fetcher):
         The cached or freshly fetched list.
 
     Error handling:
-        ``SQLAlchemyError`` is caught, logged, and returns ``[]`` without caching
-        so the next keystroke retries. Any other exception (programming errors,
-        unexpected import failures) is also caught, logged at error level, and
-        returns ``[]`` so discord.py's autocomplete handler gets a clean empty list
-        rather than propagating to the root exception handler with no module log entry.
+        ``SQLAlchemyError`` is caught, logged at ``exception`` level, and returns ``[]``
+        without caching so the next keystroke retries. Any other exception (programming
+        errors, unexpected import failures, ``NerpyInfraException`` from fetchers that use
+        ``session_scope``) falls through to the broad ``except Exception`` clause, which
+        also logs at error level and returns ``[]``. ``NerpyInfraException`` is intentionally
+        not caught here so future fetchers that raise it are only silently swallowed by the
+        generic handler — not given a false impression of being "handled" like a DB error.
     """
     try:
         return _autocomplete_cache[key]
@@ -420,7 +473,7 @@ async def cached_autocomplete(key: tuple, fetcher):
     # window makes true simultaneity rare, and the TTL window suppresses all subsequent hits.
     try:
         result = await asyncio.to_thread(fetcher)
-    except (SQLAlchemyError, NerpyInfraException):
+    except SQLAlchemyError:
         _log.exception("cached_autocomplete: fetcher for key %r raised an error", key)
         return []
     except Exception:

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -171,14 +171,25 @@ class GuildConfigCache:
         from models.reactionrole import ReactionRoleMessage
 
         def _load(session):
+            from models.reactionrole import ReactionRoleEntry
+            from sqlalchemy import select
+
             by_guild: dict[int, set[int]] = {}
             all_ids: set[int] = set()
             mappings: dict[int, dict[str, int]] = {}
-            # entries uses lazy="joined", so this single query fetches everything
-            for msg in session.query(ReactionRoleMessage).all():
-                by_guild.setdefault(msg.GuildId, set()).add(msg.MessageId)
-                all_ids.add(msg.MessageId)
-                mappings[msg.MessageId] = {entry.Emoji: entry.RoleId for entry in msg.entries}
+            for guild_id, msg_id in session.execute(
+                select(ReactionRoleMessage.GuildId, ReactionRoleMessage.MessageId)
+            ).all():
+                by_guild.setdefault(guild_id, set()).add(msg_id)
+                all_ids.add(msg_id)
+                mappings[msg_id] = {}
+            for msg_id, emoji, role_id in session.execute(
+                select(ReactionRoleMessage.MessageId, ReactionRoleEntry.Emoji, ReactionRoleEntry.RoleId).join(
+                    ReactionRoleEntry, ReactionRoleEntry.ReactionRoleMessageId == ReactionRoleMessage.Id
+                )
+            ).all():
+                if msg_id in mappings:
+                    mappings[msg_id][emoji] = role_id
             return by_guild, all_ids, mappings
 
         self._rr_by_guild, self._rr_message_ids, self._rr_mappings = self._run_warm(
@@ -201,8 +212,7 @@ class GuildConfigCache:
         """Return (channel_id, message_text) for the guild's enabled leave message, or None.
 
         Falls back to a direct DB read when the cache has not been warmed yet and populates
-        the per-guild entry, matching the lazy-load pattern of ``get_guild_language`` and
-        ``get_modrole``.
+        the per-guild entry so subsequent calls are served from memory.
         """
         if self._leave_warmed or guild_id in self._leave_configs:
             return self._leave_configs.get(guild_id)
@@ -293,9 +303,22 @@ async def cached_autocomplete(key: tuple, fetcher):
     """
     if key in _autocomplete_cache:
         return _autocomplete_cache[key]
+    # No lock: two concurrent keystrokes for the same key can both miss and fire parallel DB
+    # fetches. Both write the same result, so this is benign — Discord's 3s autocomplete
+    # window makes true simultaneity rare, and the TTL window suppresses all subsequent hits.
     result = await asyncio.to_thread(fetcher)
     _autocomplete_cache[key] = result
     return result
+
+
+def invalidate_autocomplete(key: tuple) -> None:
+    """Evict a single key from the autocomplete cache.
+
+    Call after mutations that change the result set (e.g. adding/removing a reaction role
+    message), so the next autocomplete call fetches fresh data rather than serving stale
+    labels for up to 30 seconds.
+    """
+    _autocomplete_cache.pop(key, None)
 
 
 def build_name_choices(names: list[str], current: str) -> list[app_commands.Choice[str]]:

--- a/NerdyPy/utils/cache.py
+++ b/NerdyPy/utils/cache.py
@@ -179,7 +179,12 @@ class GuildConfigCache:
         channel_id: int | None = None,
         message: str | None = None,
     ) -> None:
-        """Add or remove a guild from the leave-message config cache."""
+        """Add or remove a guild from the leave-message config cache.
+
+        When ``enabled=True``, the guild is stored only if ``channel_id`` is not None;
+        passing ``enabled=True`` without a channel_id is a no-op.
+        When ``enabled=False``, the guild is evicted regardless of channel_id.
+        """
         if enabled:
             if channel_id is not None:
                 self._leave_configs[guild_id] = (channel_id, message)

--- a/NerdyPy/utils/strings.py
+++ b/NerdyPy/utils/strings.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Localized string lookup — loads YAML templates and resolves per-guild language."""
+"""Localized string lookup — loads YAML templates and formats per-language strings."""
 
 from pathlib import Path
 
 import yaml
-from models.admin import GuildLanguageConfig
 
 # Module-level state, populated by load_strings()
 _strings: dict[str, dict] = {}
@@ -109,15 +108,3 @@ def get_raw(lang: str, key: str):
             return result
 
     raise KeyError(f"Missing localization key: {key}")
-
-
-def get_guild_language(guild_id: int, session) -> str:
-    """Get the configured language for a guild, defaulting to 'en'."""
-    config = GuildLanguageConfig.get(guild_id, session)
-    return config.Language if config is not None else "en"
-
-
-def get_localized_string(guild_id: int, key: str, session, **kwargs) -> str:
-    """Convenience: resolve guild language, then look up and format a string."""
-    lang = get_guild_language(guild_id, session)
-    return get_string(lang, key, **kwargs)

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -38,7 +38,12 @@ def _discover_available_modules(loaded_names: set[str]) -> list[str]:
 
 
 def _parse_guild_id(payload: dict) -> int:
-    """Safely extract guild_id from a payload dict. Returns 0 on missing or non-numeric input."""
+    """Safely extract guild_id from a payload dict.
+
+    Returns 0 on missing, explicit ``None``, or non-numeric input.
+    The ``or 0`` handles the case where the key is present but set to ``None``
+    (``payload.get("guild_id", 0)`` returns ``None`` in that case, not the default).
+    """
     try:
         return int(payload.get("guild_id", 0) or 0)
     except (TypeError, ValueError):
@@ -46,8 +51,18 @@ def _parse_guild_id(payload: dict) -> int:
 
 
 def _get_guild(bot, payload: dict):
-    """Extract guild_id from payload and return the Guild, or None if not found."""
-    return bot.get_guild(_parse_guild_id(payload))
+    """Extract guild_id from payload and return the Guild, or None if not found.
+
+    Returns None both when the guild is not in the bot's cache and when the payload
+    carries an invalid guild_id. Callers are responsible for handling the None case;
+    this function emits a debug log when guild_id parses to 0 so malformed payloads
+    leave a trace.
+    """
+    guild_id = _parse_guild_id(payload)
+    if not guild_id:
+        bot.log.debug("_get_guild: payload missing or invalid guild_id=%r", payload.get("guild_id"))
+        return None
+    return bot.get_guild(guild_id)
 
 
 def _build_voice_details(bot) -> tuple[list, list]:

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -263,7 +263,10 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
             bot.log.warning("validate_wow_guild failed: %s", e)
             return {"valid": False, "display_name": None, "error": str(e)}
     elif command == "invalidate_leave_config":
-        guild_id = int(payload.get("guild_id", 0))
+        try:
+            guild_id = int(payload.get("guild_id", 0) or 0)
+        except (TypeError, ValueError):
+            guild_id = 0
         if not guild_id:
             bot.log.warning("invalidate_leave_config: received invalid guild_id=%r", payload.get("guild_id"))
             return {"ok": False, "error": "invalid guild_id"}
@@ -274,7 +277,10 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
             return {"ok": False, "error": "cache reload failed — see bot logs"}
         return {"ok": True}
     elif command == "invalidate_modrole":
-        guild_id = int(payload.get("guild_id", 0))
+        try:
+            guild_id = int(payload.get("guild_id", 0) or 0)
+        except (TypeError, ValueError):
+            guild_id = 0
         if not guild_id:
             bot.log.warning("invalidate_modrole: received invalid guild_id=%r", payload.get("guild_id"))
             return {"ok": False, "error": "invalid guild_id"}
@@ -283,7 +289,10 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
         bot.guild_cache.delete_modrole(guild_id)
         return {"ok": True}
     elif command == "set_guild_language":
-        guild_id = int(payload.get("guild_id", 0))
+        try:
+            guild_id = int(payload.get("guild_id", 0) or 0)
+        except (TypeError, ValueError):
+            guild_id = 0
         language = payload.get("language", "")
         if not guild_id:
             bot.log.warning("set_guild_language: received invalid guild_id=%r", payload.get("guild_id"))

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -310,7 +310,7 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
         if not guild_id:
             bot.log.warning("set_guild_language: received invalid guild_id=%r", payload.get("guild_id"))
             return {"ok": False, "error": "invalid guild_id"}
-        if not isinstance(language, str):
+        if not isinstance(language, str) or not language.strip():
             bot.log.warning("set_guild_language: received invalid language=%r for guild_id=%d", language, guild_id)
             return {"ok": False, "error": "invalid language"}
         bot.guild_cache.set_guild_language(guild_id, language)

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -282,6 +282,15 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
         # value under concurrent updates and stays consistent with the leave-config pattern.
         bot.guild_cache.delete_modrole(guild_id)
         return {"ok": True}
+    elif command == "set_guild_language":
+        guild_id = int(payload.get("guild_id", 0))
+        language = payload.get("language", "")
+        if not guild_id:
+            bot.log.warning("set_guild_language: received invalid guild_id=%r", payload.get("guild_id"))
+            return {"ok": False, "error": "invalid guild_id"}
+        bot.guild_cache.set_guild_language(guild_id, language)
+        bot.dispatch("guild_language_changed", guild_id, language)
+        return {"ok": True}
     elif command == "list_guilds":
         return {
             "guilds": [

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -37,10 +37,17 @@ def _discover_available_modules(loaded_names: set[str]) -> list[str]:
     return sorted(discovered - loaded_names - PROTECTED_MODULES)
 
 
+def _parse_guild_id(payload: dict) -> int:
+    """Safely extract guild_id from a payload dict. Returns 0 on missing or non-numeric input."""
+    try:
+        return int(payload.get("guild_id", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _get_guild(bot, payload: dict):
     """Extract guild_id from payload and return the Guild, or None if not found."""
-    guild_id = int(payload.get("guild_id", 0))
-    return bot.get_guild(guild_id)
+    return bot.get_guild(_parse_guild_id(payload))
 
 
 def _build_voice_details(bot) -> tuple[list, list]:
@@ -263,10 +270,7 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
             bot.log.warning("validate_wow_guild failed: %s", e)
             return {"valid": False, "display_name": None, "error": str(e)}
     elif command == "invalidate_leave_config":
-        try:
-            guild_id = int(payload.get("guild_id", 0) or 0)
-        except (TypeError, ValueError):
-            guild_id = 0
+        guild_id = _parse_guild_id(payload)
         if not guild_id:
             bot.log.warning("invalidate_leave_config: received invalid guild_id=%r", payload.get("guild_id"))
             return {"ok": False, "error": "invalid guild_id"}
@@ -277,10 +281,7 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
             return {"ok": False, "error": "cache reload failed — see bot logs"}
         return {"ok": True}
     elif command == "invalidate_modrole":
-        try:
-            guild_id = int(payload.get("guild_id", 0) or 0)
-        except (TypeError, ValueError):
-            guild_id = 0
+        guild_id = _parse_guild_id(payload)
         if not guild_id:
             bot.log.warning("invalidate_modrole: received invalid guild_id=%r", payload.get("guild_id"))
             return {"ok": False, "error": "invalid guild_id"}
@@ -289,10 +290,7 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
         bot.guild_cache.delete_modrole(guild_id)
         return {"ok": True}
     elif command == "set_guild_language":
-        try:
-            guild_id = int(payload.get("guild_id", 0) or 0)
-        except (TypeError, ValueError):
-            guild_id = 0
+        guild_id = _parse_guild_id(payload)
         language = payload.get("language", "")
         if not guild_id:
             bot.log.warning("set_guild_language: received invalid guild_id=%r", payload.get("guild_id"))

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -262,6 +262,10 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
         except Exception as e:
             bot.log.warning("validate_wow_guild failed: %s", e)
             return {"valid": False, "display_name": None, "error": str(e)}
+    elif command == "invalidate_leave_config":
+        guild_id = int(payload.get("guild_id", 0))
+        bot.guild_cache._leave_configs.pop(guild_id, None)
+        return {"ok": True}
     elif command == "list_guilds":
         return {
             "guilds": [

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -264,7 +264,10 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
             return {"valid": False, "display_name": None, "error": str(e)}
     elif command == "invalidate_leave_config":
         guild_id = int(payload.get("guild_id", 0))
-        bot.guild_cache._leave_configs.pop(guild_id, None)
+        if not guild_id:
+            bot.log.warning("invalidate_leave_config: received invalid guild_id=%r", payload.get("guild_id"))
+            return {"ok": False, "error": "invalid guild_id"}
+        bot.guild_cache.evict_leave_config(guild_id)
         return {"ok": True}
     elif command == "list_guilds":
         return {

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -267,7 +267,16 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
         if not guild_id:
             bot.log.warning("invalidate_leave_config: received invalid guild_id=%r", payload.get("guild_id"))
             return {"ok": False, "error": "invalid guild_id"}
-        bot.guild_cache.evict_leave_config(guild_id)
+        await to_thread(bot.guild_cache.reload_leave_config, guild_id, bot.SESSION)
+        return {"ok": True}
+    elif command == "invalidate_modrole":
+        guild_id = int(payload.get("guild_id", 0))
+        if not guild_id:
+            bot.log.warning("invalidate_modrole: received invalid guild_id=%r", payload.get("guild_id"))
+            return {"ok": False, "error": "invalid guild_id"}
+        # Evict so the next get_modrole re-reads from DB — avoids trusting the web-tier
+        # value under concurrent updates and stays consistent with the leave-config pattern.
+        bot.guild_cache.delete_modrole(guild_id)
         return {"ok": True}
     elif command == "list_guilds":
         return {

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -313,6 +313,7 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
         if not isinstance(language, str) or not language.strip():
             bot.log.warning("set_guild_language: received invalid language=%r for guild_id=%d", language, guild_id)
             return {"ok": False, "error": "invalid language"}
+        language = language.strip()
         bot.guild_cache.set_guild_language(guild_id, language)
         bot.dispatch("guild_language_changed", guild_id, language)
         return {"ok": True}

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -310,6 +310,9 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
         if not guild_id:
             bot.log.warning("set_guild_language: received invalid guild_id=%r", payload.get("guild_id"))
             return {"ok": False, "error": "invalid guild_id"}
+        if not isinstance(language, str):
+            bot.log.warning("set_guild_language: received invalid language=%r for guild_id=%d", language, guild_id)
+            return {"ok": False, "error": "invalid language"}
         bot.guild_cache.set_guild_language(guild_id, language)
         bot.dispatch("guild_language_changed", guild_id, language)
         return {"ok": True}

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -114,8 +114,8 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
                     return session.query(ReminderMessage).filter(ReminderMessage.Enabled == True).count()  # noqa: E712
 
             active_reminders = await to_thread(_count_reminders)
-        except Exception as e:
-            bot.log.warning("Failed to count active reminders for health response: %s", e)
+        except Exception:
+            bot.log.exception("Failed to count active reminders for health response")
         return {
             "guild_count": len(bot.guilds),
             "voice_connections": len(active_vcs),
@@ -267,7 +267,11 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
         if not guild_id:
             bot.log.warning("invalidate_leave_config: received invalid guild_id=%r", payload.get("guild_id"))
             return {"ok": False, "error": "invalid guild_id"}
-        await to_thread(bot.guild_cache.reload_leave_config, guild_id, bot.SESSION)
+        try:
+            await to_thread(bot.guild_cache.reload_leave_config, guild_id, bot.SESSION)
+        except Exception:
+            bot.log.exception("invalidate_leave_config: reload failed for guild_id=%d", guild_id)
+            return {"ok": False, "error": "cache reload failed — see bot logs"}
         return {"ok": True}
     elif command == "invalidate_modrole":
         guild_id = int(payload.get("guild_id", 0))

--- a/NerdyPy/utils/valkey.py
+++ b/NerdyPy/utils/valkey.py
@@ -10,6 +10,8 @@ The listener loop runs as an asyncio background task. It subscribes to the
 import json
 import time
 from asyncio import CancelledError, ensure_future, gather, sleep, to_thread
+
+from sqlalchemy.exc import SQLAlchemyError
 from datetime import UTC, datetime
 from importlib.metadata import version as pkg_version
 from pathlib import Path
@@ -40,14 +42,18 @@ def _discover_available_modules(loaded_names: set[str]) -> list[str]:
 def _parse_guild_id(payload: dict) -> int:
     """Safely extract guild_id from a payload dict.
 
-    Returns 0 on missing, explicit ``None``, or non-numeric input.
+    Returns 0 on missing, explicit ``None``, non-numeric input, booleans, or non-positive values.
     The ``or 0`` handles the case where the key is present but set to ``None``
     (``payload.get("guild_id", 0)`` returns ``None`` in that case, not the default).
     """
+    raw = payload.get("guild_id", 0)
+    if isinstance(raw, bool):
+        return 0
     try:
-        return int(payload.get("guild_id", 0) or 0)
+        guild_id = int(raw or 0)
     except (TypeError, ValueError):
         return 0
+    return guild_id if guild_id > 0 else 0
 
 
 def _get_guild(bot, payload: dict):
@@ -290,10 +296,12 @@ async def handle_valkey_command(bot, command: str, payload: dict) -> dict:
             bot.log.warning("invalidate_leave_config: received invalid guild_id=%r", payload.get("guild_id"))
             return {"ok": False, "error": "invalid guild_id"}
         try:
-            await to_thread(bot.guild_cache.reload_leave_config, guild_id, bot.SESSION)
-        except Exception:
+            config = await to_thread(bot.guild_cache._load_leave_config_from_db, guild_id, bot.SESSION)
+        except SQLAlchemyError:
+            bot.guild_cache.mark_leave_config_for_recheck(guild_id)
             bot.log.exception("invalidate_leave_config: reload failed for guild_id=%d", guild_id)
             return {"ok": False, "error": "cache reload failed — see bot logs"}
+        bot.guild_cache.apply_leave_config(guild_id, config)
         return {"ok": True}
     elif command == "invalidate_modrole":
         guild_id = _parse_guild_id(payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ web = [
     "uvicorn[standard]",
     "PyJWT",
     "httpx",
+    "cachetools",
     "valkey",
     "pyyaml",
     "sse-starlette",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ web = [
     "uvicorn[standard]",
     "PyJWT",
     "httpx",
-    "cachetools",
     "valkey",
     "pyyaml",
     "sse-starlette",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,24 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "NerdyPy"))
 from utils.database import BASE
 
 
+@pytest.fixture(autouse=True)
+def clear_bot_caches():
+    """Clear bot-side in-process TTL caches between tests.
+
+    Module-level TTLCache singletons live for the entire process lifetime.
+    Tests that use function-scoped DB sessions trigger rollback() on cleanup,
+    which expires SQLAlchemy ORM objects. A subsequent test that hits the warm
+    cache gets expired+detached objects, raising DetachedInstanceError or
+    "no such table" errors from lazy-load attempts on a different in-memory DB.
+    """
+    from models.wow import invalidate_recipe_cache
+    from utils.cache import _autocomplete_cache
+
+    _autocomplete_cache.clear()
+    invalidate_recipe_cache()
+    yield
+
+
 @pytest.fixture
 def db_engine():
     """Create an in-memory SQLite engine for testing."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 # Add NerdyPy to path so we can import modules
 sys.path.insert(0, str(Path(__file__).parent.parent / "NerdyPy"))
@@ -37,7 +38,12 @@ def clear_bot_caches():
 @pytest.fixture
 def db_engine():
     """Create an in-memory SQLite engine for testing."""
-    engine = create_engine("sqlite:///:memory:", echo=False)
+    engine = create_engine(
+        "sqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
 
     @event.listens_for(engine, "connect")
     def set_sqlite_pragma(dbapi_conn, _connection_record):

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -1,0 +1,19 @@
+"""Fixtures shared across model tests."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_recipe_cache():
+    """Clear the CraftingRecipeCache TTL cache before each test.
+
+    The cache is a module-level singleton that survives across tests.
+    Tests use a per-test db_session whose rollback() expires all ORM
+    objects — a subsequent test that hits the warm cache gets expired+
+    detached instances and raises DetachedInstanceError. Clearing before
+    each test keeps each test independent.
+    """
+    from models.wow import invalidate_recipe_cache
+
+    invalidate_recipe_cache()
+    yield

--- a/tests/models/test_recipe_cache_decorator.py
+++ b/tests/models/test_recipe_cache_decorator.py
@@ -88,18 +88,18 @@ class TestCacheRecipeQueryDecorator:
         )
         assert r1 is r2
 
-    def test_none_and_empty_set_produce_different_cache_keys(self, db_session):
+    def test_none_and_empty_set_produce_same_cache_key(self, db_session):
         db_session.add(_recipe(RecipeId=1, ProfessionId=164))
         db_session.commit()
 
         from models.wow import RECIPE_TYPE_CRAFTED, CraftingRecipeCache, invalidate_recipe_cache
 
         invalidate_recipe_cache()
-        # None and set() are distinct argument values and must produce separate cache entries.
+        # Both mean "no filter" — the decorator normalizes empty set() to None so both
+        # produce the same cache key and the second call is a cache hit.
         r1 = CraftingRecipeCache.get_by_type_and_subclass(RECIPE_TYPE_CRAFTED, 4, 4, db_session, profession_ids=None)
         r2 = CraftingRecipeCache.get_by_type_and_subclass(RECIPE_TYPE_CRAFTED, 4, 4, db_session, profession_ids=set())
-        # r1 is r2 would mean same object (cache hit) — we want different entries.
-        assert r1 is not r2
+        assert r1 is r2
 
     def test_bool_returning_method_is_cached(self, db_session):
         db_session.add(_recipe(RecipeId=1, ProfessionId=164))

--- a/tests/models/test_recipe_cache_decorator.py
+++ b/tests/models/test_recipe_cache_decorator.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Tests for the _cache_recipe_query decorator on CraftingRecipeCache."""
+
+from models.wow import BIND_ON_ACQUIRE, RECIPE_TYPE_CRAFTED, CraftingRecipeCache, invalidate_recipe_cache
+
+
+def _recipe(**kwargs) -> CraftingRecipeCache:
+    defaults = {
+        "ProfessionId": 164,
+        "ProfessionName": "Blacksmithing",
+        "ItemName": "Test Item",
+        "RecipeType": RECIPE_TYPE_CRAFTED,
+        "ItemClassName": "Armor",
+        "ItemClassId": 4,
+        "ItemSubClassName": "Plate",
+        "ItemSubClassId": 4,
+        "BindType": BIND_ON_ACQUIRE,
+        "CategoryName": "Plate Armor",
+    }
+    defaults.update(kwargs)
+    return CraftingRecipeCache(**defaults)
+
+
+class TestCacheRecipeQueryDecorator:
+    def test_second_call_returns_cached_result(self, db_session):
+        db_session.add(_recipe(RecipeId=1, ProfessionId=164))
+        db_session.commit()
+
+        r1 = CraftingRecipeCache.get_by_profession(164, RECIPE_TYPE_CRAFTED, db_session)
+        r2 = CraftingRecipeCache.get_by_profession(164, RECIPE_TYPE_CRAFTED, db_session)
+
+        assert r1 is r2
+
+    def test_different_args_produce_separate_entries(self, db_session):
+        db_session.add(_recipe(RecipeId=1, ProfessionId=164, ProfessionName="Blacksmithing"))
+        db_session.add(_recipe(RecipeId=2, ProfessionId=333, ProfessionName="Engineering"))
+        db_session.commit()
+
+        r1 = CraftingRecipeCache.get_by_profession(164, RECIPE_TYPE_CRAFTED, db_session)
+        r2 = CraftingRecipeCache.get_by_profession(333, RECIPE_TYPE_CRAFTED, db_session)
+
+        assert len(r1) == 1
+        assert r1[0].ProfessionId == 164
+        assert len(r2) == 1
+        assert r2[0].ProfessionId == 333
+
+    def test_invalidate_forces_fresh_db_query(self, db_session):
+        db_session.add(_recipe(RecipeId=1, ProfessionId=164))
+        db_session.commit()
+
+        r1 = CraftingRecipeCache.get_by_profession(164, RECIPE_TYPE_CRAFTED, db_session)
+        assert len(r1) == 1
+
+        invalidate_recipe_cache()
+
+        db_session.add(_recipe(RecipeId=2, ProfessionId=164))
+        db_session.commit()
+
+        r2 = CraftingRecipeCache.get_by_profession(164, RECIPE_TYPE_CRAFTED, db_session)
+        assert len(r2) == 2
+        assert r1 is not r2

--- a/tests/models/test_recipe_cache_decorator.py
+++ b/tests/models/test_recipe_cache_decorator.py
@@ -59,3 +59,29 @@ class TestCacheRecipeQueryDecorator:
         r2 = CraftingRecipeCache.get_by_profession(164, RECIPE_TYPE_CRAFTED, db_session)
         assert len(r2) == 2
         assert r1 is not r2
+
+    def test_set_args_are_coerced_to_frozenset_for_cache_key(self, db_session):
+        db_session.add(_recipe(RecipeId=1, ProfessionId=164))
+        db_session.add(_recipe(RecipeId=2, ProfessionId=333))
+        db_session.commit()
+
+        # Passing same profession IDs as a set vs frozenset should produce the same cache entry.
+        from models.wow import RECIPE_TYPE_CRAFTED, CraftingRecipeCache, invalidate_recipe_cache
+
+        invalidate_recipe_cache()
+        r1 = CraftingRecipeCache.get_by_type_and_subclass(RECIPE_TYPE_CRAFTED, 4, 4, db_session, profession_ids={164})
+        r2 = CraftingRecipeCache.get_by_type_and_subclass(RECIPE_TYPE_CRAFTED, 4, 4, db_session, profession_ids={164})
+        assert r1 is r2
+
+    def test_cached_results_are_session_detached(self, db_session):
+        from sqlalchemy import inspect as sa_inspect
+
+        db_session.add(_recipe(RecipeId=1, ProfessionId=164))
+        db_session.commit()
+
+        results = CraftingRecipeCache.get_by_profession(164, RECIPE_TYPE_CRAFTED, db_session)
+        assert len(results) == 1
+
+        # Object must be detached (not bound to the session).
+        state = sa_inspect(results[0])
+        assert state.detached

--- a/tests/models/test_recipe_cache_decorator.py
+++ b/tests/models/test_recipe_cache_decorator.py
@@ -73,6 +73,34 @@ class TestCacheRecipeQueryDecorator:
         r2 = CraftingRecipeCache.get_by_type_and_subclass(RECIPE_TYPE_CRAFTED, 4, 4, db_session, profession_ids={164})
         assert r1 is r2
 
+    def test_frozenset_and_set_produce_same_cache_key(self, db_session):
+        db_session.add(_recipe(RecipeId=1, ProfessionId=164))
+        db_session.commit()
+
+        from models.wow import RECIPE_TYPE_CRAFTED, CraftingRecipeCache, invalidate_recipe_cache
+
+        invalidate_recipe_cache()
+        # First call with a plain set populates the cache.
+        r1 = CraftingRecipeCache.get_by_type_and_subclass(RECIPE_TYPE_CRAFTED, 4, 4, db_session, profession_ids={164})
+        # Second call with a frozenset of the same values should hit the same cache entry.
+        r2 = CraftingRecipeCache.get_by_type_and_subclass(
+            RECIPE_TYPE_CRAFTED, 4, 4, db_session, profession_ids=frozenset({164})
+        )
+        assert r1 is r2
+
+    def test_none_and_empty_set_produce_same_cache_key(self, db_session):
+        db_session.add(_recipe(RecipeId=1, ProfessionId=164))
+        db_session.commit()
+
+        from models.wow import RECIPE_TYPE_CRAFTED, CraftingRecipeCache, invalidate_recipe_cache
+
+        invalidate_recipe_cache()
+        # First call with None populates the cache.
+        r1 = CraftingRecipeCache.get_by_type_and_subclass(RECIPE_TYPE_CRAFTED, 4, 4, db_session, profession_ids=None)
+        # Second call with an empty set should normalize to the same key and hit the cache.
+        r2 = CraftingRecipeCache.get_by_type_and_subclass(RECIPE_TYPE_CRAFTED, 4, 4, db_session, profession_ids=set())
+        assert r1 is r2
+
     def test_cached_results_are_session_detached(self, db_session):
         from sqlalchemy import inspect as sa_inspect
 

--- a/tests/models/test_recipe_cache_decorator.py
+++ b/tests/models/test_recipe_cache_decorator.py
@@ -127,3 +127,28 @@ class TestCacheRecipeQueryDecorator:
         # Object must be detached (not bound to the session).
         state = sa_inspect(results[0])
         assert state.detached
+
+    def test_ttl_expiry_forces_fresh_db_query(self, db_session, monkeypatch):
+        """After TTL expires, the decorator must issue a fresh DB query."""
+        import time
+
+        import models.wow as wow_module
+        from cachetools import TTLCache
+
+        short_ttl_cache = TTLCache(maxsize=256, ttl=0.01)
+        monkeypatch.setattr(wow_module, "_recipe_cache", short_ttl_cache)
+
+        db_session.add(_recipe(RecipeId=1, ProfessionId=164))
+        db_session.commit()
+
+        r1 = CraftingRecipeCache.get_by_profession(164, RECIPE_TYPE_CRAFTED, db_session)
+        assert len(r1) == 1
+
+        time.sleep(0.1)  # wait for TTL to expire
+
+        db_session.add(_recipe(RecipeId=2, ProfessionId=164))
+        db_session.commit()
+
+        r2 = CraftingRecipeCache.get_by_profession(164, RECIPE_TYPE_CRAFTED, db_session)
+        assert len(r2) == 2  # fresh DB read after TTL expiry
+        assert r1 is not r2

--- a/tests/models/test_recipe_cache_decorator.py
+++ b/tests/models/test_recipe_cache_decorator.py
@@ -88,18 +88,32 @@ class TestCacheRecipeQueryDecorator:
         )
         assert r1 is r2
 
-    def test_none_and_empty_set_produce_same_cache_key(self, db_session):
+    def test_none_and_empty_set_produce_different_cache_keys(self, db_session):
         db_session.add(_recipe(RecipeId=1, ProfessionId=164))
         db_session.commit()
 
         from models.wow import RECIPE_TYPE_CRAFTED, CraftingRecipeCache, invalidate_recipe_cache
 
         invalidate_recipe_cache()
-        # First call with None populates the cache.
+        # None and set() are distinct argument values and must produce separate cache entries.
         r1 = CraftingRecipeCache.get_by_type_and_subclass(RECIPE_TYPE_CRAFTED, 4, 4, db_session, profession_ids=None)
-        # Second call with an empty set should normalize to the same key and hit the cache.
         r2 = CraftingRecipeCache.get_by_type_and_subclass(RECIPE_TYPE_CRAFTED, 4, 4, db_session, profession_ids=set())
-        assert r1 is r2
+        # r1 is r2 would mean same object (cache hit) — we want different entries.
+        assert r1 is not r2
+
+    def test_bool_returning_method_is_cached(self, db_session):
+        db_session.add(_recipe(RecipeId=1, ProfessionId=164))
+        db_session.commit()
+
+        # First call populates the cache.
+        r1 = CraftingRecipeCache.has_prof_knowledge_items(RECIPE_TYPE_CRAFTED, db_session)
+
+        # Mutate the DB between calls — the second call must return the cached (stale) value.
+        db_session.query(CraftingRecipeCache).delete()
+        db_session.commit()
+
+        r2 = CraftingRecipeCache.has_prof_knowledge_items(RECIPE_TYPE_CRAFTED, db_session)
+        assert r1 == r2  # same cached boolean, not a fresh DB result
 
     def test_cached_results_are_session_detached(self, db_session):
         from sqlalchemy import inspect as sa_inspect

--- a/tests/models/test_recipe_cache_decorator.py
+++ b/tests/models/test_recipe_cache_decorator.py
@@ -102,18 +102,19 @@ class TestCacheRecipeQueryDecorator:
         assert r1 is r2
 
     def test_bool_returning_method_is_cached(self, db_session):
-        db_session.add(_recipe(RecipeId=1, ProfessionId=164))
+        db_session.add(_recipe(RecipeId=1, ProfessionId=164, CategoryName="Blacksmith Treatise"))
         db_session.commit()
 
         # First call populates the cache.
         r1 = CraftingRecipeCache.has_prof_knowledge_items(RECIPE_TYPE_CRAFTED, db_session)
+        assert r1 is True
 
         # Mutate the DB between calls — the second call must return the cached (stale) value.
         db_session.query(CraftingRecipeCache).delete()
         db_session.commit()
 
         r2 = CraftingRecipeCache.has_prof_knowledge_items(RECIPE_TYPE_CRAFTED, db_session)
-        assert r1 == r2  # same cached boolean, not a fresh DB result
+        assert r2 is True  # same cached boolean, not a fresh DB result
 
     def test_cached_results_are_session_detached(self, db_session):
         from sqlalchemy import inspect as sa_inspect

--- a/tests/modules/test_application.py
+++ b/tests/modules/test_application.py
@@ -20,6 +20,7 @@ from models.application import (
     seed_built_in_templates,
 )
 from modules.application import Application
+from utils.cache import _autocomplete_cache
 from utils.helpers import fetch_message_content
 from utils.strings import load_strings
 
@@ -395,12 +396,15 @@ class TestApplicationDelete:
     @pytest.mark.asyncio
     async def test_delete_happy_path(self, app_cog, admin_interaction, db_session):
         _make_form(db_session, guild_id=admin_interaction.guild.id, name="ToDelete")
+        guild_id = admin_interaction.guild.id
+        _autocomplete_cache[("app_forms", guild_id)] = ["stale"]
 
         await app_cog._delete.callback(app_cog, admin_interaction, name="ToDelete")
 
         call_args = str(admin_interaction.response.send_message.call_args)
         assert "deleted" in call_args.lower()
-        assert ApplicationForm.get("ToDelete", admin_interaction.guild.id, db_session) is None
+        assert ApplicationForm.get("ToDelete", guild_id, db_session) is None
+        assert ("app_forms", guild_id) not in _autocomplete_cache
 
     @pytest.mark.asyncio
     async def test_delete_not_found(self, app_cog, admin_interaction):

--- a/tests/modules/test_moderation_leavemsg.py
+++ b/tests/modules/test_moderation_leavemsg.py
@@ -136,6 +136,20 @@ class TestLeavemsgMessage:
         with pytest.raises(NerpyValidationError, match="enable|aktiviere"):
             await Moderation.leavemsg._children["message"].callback(cog, interaction, "Bye {member}")
 
+    async def test_set_message_disabled_does_not_update_cache(self, cog, interaction, db_session):
+        """When the leave config row has Enabled=False, /leavemsg message must NOT write to cache.
+
+        Guards the ``if enabled:`` guard in the cache-update path against accidental removal.
+        """
+        db_session.add(LeaveMessage(GuildId=987654321, ChannelId=111, Enabled=False))
+        db_session.commit()
+
+        await Moderation.leavemsg._children["message"].callback(cog, interaction, "Bye {member}!")
+
+        # Cache must still return None — disabled guilds must not appear in the cache.
+        cached = cog.bot.guild_cache.get_leave_config(987654321, cog.bot.SESSION)
+        assert cached is None
+
 
 # ---------------------------------------------------------------------------
 # /moderation leavemsg status

--- a/tests/modules/test_moderation_leavemsg.py
+++ b/tests/modules/test_moderation_leavemsg.py
@@ -55,6 +55,13 @@ class TestLeavemsgEnable:
         assert config.Enabled is True
         assert config.ChannelId == 111
 
+        # Cache must reflect the new config so on_member_remove can read it without a DB hit.
+        # enable always initialises Message to DEFAULT_LEAVE_MESSAGE when no message exists.
+        from modules.moderation import DEFAULT_LEAVE_MESSAGE
+
+        cached = cog.bot.guild_cache.get_leave_config(987654321, cog.bot.SESSION)
+        assert cached == (111, DEFAULT_LEAVE_MESSAGE)
+
     async def test_enable_updates_existing(self, cog, interaction, db_session):
         db_session.add(LeaveMessage(GuildId=987654321, ChannelId=222, Enabled=False))
         db_session.commit()
@@ -69,6 +76,11 @@ class TestLeavemsgEnable:
         config = db_session.query(LeaveMessage).filter_by(GuildId=987654321).first()
         assert config.ChannelId == 333
         assert config.Enabled is True
+
+        from modules.moderation import DEFAULT_LEAVE_MESSAGE
+
+        cached = cog.bot.guild_cache.get_leave_config(987654321, cog.bot.SESSION)
+        assert cached == (333, DEFAULT_LEAVE_MESSAGE)
 
 
 # ---------------------------------------------------------------------------
@@ -85,6 +97,10 @@ class TestLeavemsgDisable:
 
         msg = interaction.response.send_message.call_args[0][0]
         assert "disabled" in msg.lower() or "deaktiviert" in msg.lower()
+
+        # Cache entry must be removed so on_member_remove skips the leave message.
+        cached = cog.bot.guild_cache.get_leave_config(987654321, cog.bot.SESSION)
+        assert cached is None
 
     async def test_disable_not_configured(self, cog, interaction):
         with pytest.raises(NerpyValidationError, match="not configured|nicht konfiguriert"):
@@ -108,6 +124,10 @@ class TestLeavemsgMessage:
 
         config = db_session.query(LeaveMessage).filter_by(GuildId=987654321).first()
         assert config.Message == "Goodbye {member}!"
+
+        # Cache must reflect the updated message text.
+        cached = cog.bot.guild_cache.get_leave_config(987654321, cog.bot.SESSION)
+        assert cached == (111, "Goodbye {member}!")
 
     async def test_set_message_missing_placeholder(self, cog, interaction, db_session):
         db_session.add(LeaveMessage(GuildId=987654321, ChannelId=111, Enabled=True))

--- a/tests/modules/test_moderation_leavemsg.py
+++ b/tests/modules/test_moderation_leavemsg.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from models.leavemsg import LeaveMessage
-from modules.moderation import Moderation
+from modules.moderation import DEFAULT_LEAVE_MESSAGE, Moderation
 from utils.errors import NerpyValidationError
 from utils.strings import load_strings
 
@@ -57,8 +57,6 @@ class TestLeavemsgEnable:
 
         # Cache must reflect the new config so on_member_remove can read it without a DB hit.
         # enable always initialises Message to DEFAULT_LEAVE_MESSAGE when no message exists.
-        from modules.moderation import DEFAULT_LEAVE_MESSAGE
-
         cached = cog.bot.guild_cache.get_leave_config(987654321, cog.bot.SESSION)
         assert cached == (111, DEFAULT_LEAVE_MESSAGE)
 
@@ -76,8 +74,6 @@ class TestLeavemsgEnable:
         config = db_session.query(LeaveMessage).filter_by(GuildId=987654321).first()
         assert config.ChannelId == 333
         assert config.Enabled is True
-
-        from modules.moderation import DEFAULT_LEAVE_MESSAGE
 
         cached = cog.bot.guild_cache.get_leave_config(987654321, cog.bot.SESSION)
         assert cached == (333, DEFAULT_LEAVE_MESSAGE)

--- a/tests/modules/test_moderation_leavemsg_events.py
+++ b/tests/modules/test_moderation_leavemsg_events.py
@@ -106,6 +106,66 @@ class TestOnMemberRemove:
         mock_channel.send.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_cold_cache_with_config_sends_message(self, cog, db_session):
+        """Cold cache (not warmed) falls back to DB; if config exists the message is sent."""
+        guild_id = 111000111
+        channel_id = 222000222
+
+        db_session.add(
+            LeaveMessage(
+                GuildId=guild_id,
+                ChannelId=channel_id,
+                Message="See you {member}!",
+                Enabled=True,
+            )
+        )
+        db_session.commit()
+        # Intentionally do NOT warm the cache — exercises the cold-miss DB path.
+
+        mock_channel = MagicMock(spec=TextChannel)
+        mock_channel.id = channel_id
+        mock_channel.send = AsyncMock()
+
+        mock_guild = MagicMock()
+        mock_guild.id = guild_id
+        mock_guild.name = "Cold Guild"
+        mock_guild.get_channel = MagicMock(return_value=mock_channel)
+
+        member = MagicMock()
+        member.bot = False
+        member.display_name = "Bob"
+        member.name = "bob456"
+        member.guild = mock_guild
+
+        await cog.on_member_remove(member)
+
+        mock_channel.send.assert_awaited_once()
+        assert "Bob" in mock_channel.send.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_cold_cache_without_config_does_not_send(self, cog, db_session):
+        """Cold cache (not warmed), no config in DB — no message sent, no exception."""
+        guild_id = 333000333
+
+        mock_channel = MagicMock(spec=TextChannel)
+        mock_channel.send = AsyncMock()
+
+        mock_guild = MagicMock()
+        mock_guild.id = guild_id
+        mock_guild.name = "Empty Guild"
+        mock_guild.get_channel = MagicMock(return_value=mock_channel)
+
+        member = MagicMock()
+        member.bot = False
+        member.display_name = "Carol"
+        member.name = "carol789"
+        member.guild = mock_guild
+
+        await cog.on_member_remove(member)
+
+        mock_channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_channel_not_found_does_not_crash(self, cog, db_session):
         """When the channel no longer exists, on_member_remove should not raise."""
         guild_id = 987654321

--- a/tests/modules/test_moderation_leavemsg_events.py
+++ b/tests/modules/test_moderation_leavemsg_events.py
@@ -43,6 +43,8 @@ class TestOnMemberRemove:
             )
         )
         db_session.commit()
+        # Warm the guild cache — on_member_remove now reads from cache, not DB.
+        cog.bot.guild_cache.warm_leave_messages(cog.bot.SESSION)
 
         mock_channel = MagicMock(spec=TextChannel)
         mock_channel.id = channel_id

--- a/tests/modules/test_moderation_leavemsg_events.py
+++ b/tests/modules/test_moderation_leavemsg_events.py
@@ -83,6 +83,9 @@ class TestOnMemberRemove:
             )
         )
         db_session.commit()
+        # Warm the cache: Enabled=False configs are intentionally excluded, so the
+        # cache stays empty — on_member_remove correctly skips this guild.
+        cog.bot.guild_cache.warm_leave_messages(cog.bot.SESSION)
 
         mock_channel = MagicMock(spec=TextChannel)
         mock_channel.send = AsyncMock()
@@ -117,6 +120,9 @@ class TestOnMemberRemove:
             )
         )
         db_session.commit()
+        # Warm the cache so on_member_remove actually attempts the send and exercises
+        # the fetch_channel fallback path.
+        cog.bot.guild_cache.warm_leave_messages(cog.bot.SESSION)
 
         mock_guild = MagicMock()
         mock_guild.id = guild_id

--- a/tests/modules/test_music.py
+++ b/tests/modules/test_music.py
@@ -5,7 +5,9 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from models.music import Playlist, PlaylistEntry
 from modules.music import Music
+from utils.cache import _autocomplete_cache
 from utils.strings import load_strings
 
 
@@ -178,15 +180,18 @@ class TestPlayCommand:
         assert mock_interaction.followup.send.call_args[1].get("ephemeral") is True
 
 
-from models.music import Playlist  # noqa: E402
-
-
 class TestPlaylistCreate:
     @pytest.mark.asyncio
     async def test_create_stores_playlist(self, music_cog_new, mock_interaction, db_session):
+        guild_id = mock_interaction.guild_id
+        user_id = mock_interaction.user.id
+        _autocomplete_cache[("playlists", guild_id, user_id)] = ["stale"]
+
         await Music.playlist._children["create"].callback(music_cog_new, mock_interaction, name="bops")
-        p = Playlist.get_by_name(mock_interaction.guild_id, mock_interaction.user.id, "bops", db_session)
+
+        p = Playlist.get_by_name(guild_id, user_id, "bops", db_session)
         assert p is not None
+        assert ("playlists", guild_id, user_id) not in _autocomplete_cache
 
     @pytest.mark.asyncio
     async def test_create_duplicate_sends_error(self, music_cog_new, mock_interaction, db_session):
@@ -237,9 +242,6 @@ class TestPlaylistShow:
         if mock_interaction.followup.send.called:
             msg = mock_interaction.followup.send.call_args[0][0]
             assert "missing" in msg.lower() or "not found" in msg.lower()
-
-
-from models.music import PlaylistEntry  # noqa: E402
 
 
 class TestPlaylistAdd:

--- a/tests/modules/test_roles_reactionrole.py
+++ b/tests/modules/test_roles_reactionrole.py
@@ -73,6 +73,13 @@ class TestAdd:
         assert "👍" in msg
         assert "Member" in msg
 
+    async def test_add_updates_cache(self, cog, interaction, channel, role):
+        cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
+
+        await Roles.reactionrole._children["add"].callback(cog, interaction, channel, "12345", "👍", role)
+
+        assert cog.bot.guild_cache.get_reaction_role(12345, "👍") == role.id
+
     async def test_add_already_mapped(self, cog, interaction, channel, role, db_session):
         rr_msg = ReactionRoleMessage(GuildId=987654321, ChannelId=111, MessageId=12345)
         db_session.add(rr_msg)
@@ -111,6 +118,36 @@ class TestRemove:
 
         msg = interaction.response.send_message.call_args[0][0]
         assert "Removed mapping" in msg
+
+    async def test_remove_last_entry_evicts_message_from_cache(self, cog, interaction, db_session):
+        rr_msg = ReactionRoleMessage(GuildId=987654321, ChannelId=111, MessageId=12345)
+        db_session.add(rr_msg)
+        db_session.flush()
+        db_session.add(ReactionRoleEntry(ReactionRoleMessageId=rr_msg.Id, Emoji="👍", RoleId=333))
+        db_session.commit()
+
+        cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
+        cog._clear_reaction = AsyncMock()
+
+        await Roles.reactionrole._children["remove"].callback(cog, interaction, "12345", "👍")
+
+        assert cog.bot.guild_cache.is_reaction_role_message(12345) is False
+
+    async def test_remove_non_last_entry_keeps_message_tracked(self, cog, interaction, db_session):
+        rr_msg = ReactionRoleMessage(GuildId=987654321, ChannelId=111, MessageId=12345)
+        db_session.add(rr_msg)
+        db_session.flush()
+        db_session.add(ReactionRoleEntry(ReactionRoleMessageId=rr_msg.Id, Emoji="👍", RoleId=333))
+        db_session.add(ReactionRoleEntry(ReactionRoleMessageId=rr_msg.Id, Emoji="❤️", RoleId=444))
+        db_session.commit()
+
+        cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
+        cog._clear_reaction = AsyncMock()
+
+        await Roles.reactionrole._children["remove"].callback(cog, interaction, "12345", "👍")
+
+        assert cog.bot.guild_cache.is_reaction_role_message(12345) is True
+        assert cog.bot.guild_cache.get_reaction_role(12345, "👍") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/modules/test_roles_reactionrole_events.py
+++ b/tests/modules/test_roles_reactionrole_events.py
@@ -78,6 +78,51 @@ class TestOnRawReactionAdd:
     """Tests for the on_raw_reaction_add listener."""
 
     @pytest.mark.asyncio
+    async def test_reaction_add_warm_cache_assigns_role(
+        self, cog, db_with_reaction_role, guild_id, message_id, mock_role
+    ):
+        """Warm cache + correct emoji → role assigned without fallback DB hit."""
+        cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
+
+        member = MagicMock()
+        member.bot = False
+        member.add_roles = AsyncMock()
+
+        payload = _make_payload(message_id, guild_id, "👍", member=member)
+
+        mock_guild = MagicMock()
+        mock_guild.id = guild_id
+        mock_guild.name = "Test Guild"
+        mock_guild.get_role = MagicMock(return_value=mock_role)
+        cog.bot.get_guild = MagicMock(return_value=mock_guild)
+
+        await cog.on_raw_reaction_add(payload)
+
+        member.add_roles.assert_awaited_once_with(mock_role, reason="Reaction role")
+
+    @pytest.mark.asyncio
+    async def test_reaction_add_warm_cache_no_mapping_skips_role(
+        self, cog, db_with_reaction_role, guild_id, message_id
+    ):
+        """Warm cache + unmapped emoji → add_roles never called."""
+        cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
+
+        member = MagicMock()
+        member.bot = False
+        member.add_roles = AsyncMock()
+
+        payload = _make_payload(message_id, guild_id, "👎", member=member)
+
+        mock_guild = MagicMock()
+        mock_guild.id = guild_id
+        mock_guild.name = "Test Guild"
+        cog.bot.get_guild = MagicMock(return_value=mock_guild)
+
+        await cog.on_raw_reaction_add(payload)
+
+        member.add_roles.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_reaction_add_assigns_role(self, cog, db_with_reaction_role, guild_id, message_id, mock_role):
         """Adding a known reaction should assign the mapped role to the member."""
         member = MagicMock()

--- a/tests/modules/test_roles_reactionrole_events.py
+++ b/tests/modules/test_roles_reactionrole_events.py
@@ -9,6 +9,8 @@ from models.reactionrole import ReactionRoleEntry, ReactionRoleMessage
 from modules.roles import Roles
 from utils.strings import load_strings
 
+_NO_DB_MSG = "warm-cache path must not open a DB session"
+
 
 @pytest.fixture(autouse=True)
 def _load_locale_strings():
@@ -83,7 +85,7 @@ class TestOnRawReactionAdd:
     ):
         """Warm cache + correct emoji → role assigned without fallback DB hit."""
         cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
-        cog.bot.session_scope = MagicMock(side_effect=AssertionError("warm-cache path must not open a DB session"))
+        cog.bot.session_scope = MagicMock(side_effect=AssertionError(_NO_DB_MSG))
 
         member = MagicMock()
         member.bot = False
@@ -107,7 +109,7 @@ class TestOnRawReactionAdd:
     ):
         """Warm cache + unmapped emoji → add_roles never called."""
         cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
-        cog.bot.session_scope = MagicMock(side_effect=AssertionError("warm-cache path must not open a DB session"))
+        cog.bot.session_scope = MagicMock(side_effect=AssertionError(_NO_DB_MSG))
 
         member = MagicMock()
         member.bot = False
@@ -134,7 +136,7 @@ class TestOnRawReactionAdd:
         and the cold-miss DB fallback is never triggered.
         """
         cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
-        cog.bot.session_scope = MagicMock(side_effect=AssertionError("warm-cache path must not open a DB session"))
+        cog.bot.session_scope = MagicMock(side_effect=AssertionError(_NO_DB_MSG))
 
         member = MagicMock()
         member.bot = False

--- a/tests/modules/test_roles_reactionrole_events.py
+++ b/tests/modules/test_roles_reactionrole_events.py
@@ -123,6 +123,40 @@ class TestOnRawReactionAdd:
         member.add_roles.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_reaction_add_warm_cache_mismatched_emoji_no_db_hit(
+        self, cog, db_with_reaction_role, guild_id, message_id
+    ):
+        """Warm cache with message_id mapped to 👍 only; reaction for ❤ returns None without a DB call.
+
+        Pins the warm-but-mismatched-emoji path: get_reaction_role returns None in-memory,
+        and the cold-miss DB fallback is never triggered.
+        """
+        cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
+
+        # Patch session_scope so any DB access would raise and fail the test.
+        def _no_db():
+            raise AssertionError("DB should not be accessed on a warm-cache emoji miss")
+
+        member = MagicMock()
+        member.bot = False
+        member.add_roles = AsyncMock()
+
+        payload = _make_payload(message_id, guild_id, "❤", member=member)
+
+        # get_reaction_role for a known message + unknown emoji should return None without fallback.
+        result = cog.bot.guild_cache.get_reaction_role(message_id, "❤")
+        assert result is None  # None, not REACTION_ROLE_CACHE_MISS
+
+        mock_guild = MagicMock()
+        mock_guild.id = guild_id
+        mock_guild.name = "Test Guild"
+        cog.bot.get_guild = MagicMock(return_value=mock_guild)
+
+        await cog.on_raw_reaction_add(payload)
+
+        member.add_roles.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_reaction_add_assigns_role(self, cog, db_with_reaction_role, guild_id, message_id, mock_role):
         """Adding a known reaction should assign the mapped role to the member."""
         member = MagicMock()

--- a/tests/modules/test_roles_reactionrole_events.py
+++ b/tests/modules/test_roles_reactionrole_events.py
@@ -83,6 +83,7 @@ class TestOnRawReactionAdd:
     ):
         """Warm cache + correct emoji → role assigned without fallback DB hit."""
         cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
+        cog.bot.session_scope = MagicMock(side_effect=AssertionError("warm-cache path must not open a DB session"))
 
         member = MagicMock()
         member.bot = False
@@ -106,6 +107,7 @@ class TestOnRawReactionAdd:
     ):
         """Warm cache + unmapped emoji → add_roles never called."""
         cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
+        cog.bot.session_scope = MagicMock(side_effect=AssertionError("warm-cache path must not open a DB session"))
 
         member = MagicMock()
         member.bot = False
@@ -132,10 +134,7 @@ class TestOnRawReactionAdd:
         and the cold-miss DB fallback is never triggered.
         """
         cog.bot.guild_cache.warm_reaction_roles(cog.bot.SESSION)
-
-        # Patch session_scope so any DB access would raise and fail the test.
-        def _no_db():
-            raise AssertionError("DB should not be accessed on a warm-cache emoji miss")
+        cog.bot.session_scope = MagicMock(side_effect=AssertionError("warm-cache path must not open a DB session"))
 
         member = MagicMock()
         member.bot = False

--- a/tests/modules/test_tagging.py
+++ b/tests/modules/test_tagging.py
@@ -8,6 +8,7 @@ import pytest
 
 from models.tagging import Tag, TagType, TagTypeConverter
 from modules.tagging import Tagging
+from utils.cache import _autocomplete_cache
 from utils.errors import NerpyValidationError
 from utils.strings import load_strings
 
@@ -231,6 +232,19 @@ class TestTagDeleteLocale:
 
         msg = tagging_interaction.response.send_message.call_args[0][0]
         assert "doesn't exist" in msg
+
+    async def test_delete_success_invalidates_autocomplete(
+        self, _load_locale_strings, tagging_cog, tagging_interaction, monkeypatch
+    ):
+        guild_id = tagging_interaction.guild.id
+        _autocomplete_cache[("tags", guild_id)] = ["stale"]
+
+        monkeypatch.setattr("modules.tagging.Tag.exists", lambda name, gid, sess: True)
+        monkeypatch.setattr("modules.tagging.Tag.delete", lambda name, gid, sess: None)
+
+        await Tagging._tag_delete.callback(tagging_cog, tagging_interaction, "oldtag")
+
+        assert ("tags", guild_id) not in _autocomplete_cache
 
 
 class TestTagListLocale:

--- a/tests/test_valkey_subscriber.py
+++ b/tests/test_valkey_subscriber.py
@@ -476,3 +476,58 @@ class TestBotCommandHandler:
         mock_bot.guilds = []
         result = await handle_valkey_command(mock_bot, "list_guilds", {})
         assert result["guilds"] == []
+
+    # ── set_guild_language ──────────────────────────────────────────────────
+
+    async def test_set_guild_language_valid(self, mock_bot):
+        """Valid payload updates the cache and dispatches guild_language_changed."""
+        mock_bot.guild_cache = MagicMock()
+        mock_bot.dispatch = MagicMock()
+        result = await handle_valkey_command(mock_bot, "set_guild_language", {"guild_id": "42", "language": "de"})
+        assert result == {"ok": True}
+        mock_bot.guild_cache.set_guild_language.assert_called_once_with(42, "de")
+        mock_bot.dispatch.assert_called_once_with("guild_language_changed", 42, "de")
+
+    async def test_set_guild_language_missing_guild_id(self, mock_bot):
+        """Missing guild_id returns ok=False without touching the cache."""
+        mock_bot.guild_cache = MagicMock()
+        result = await handle_valkey_command(mock_bot, "set_guild_language", {"language": "fr"})
+        assert result["ok"] is False
+        mock_bot.guild_cache.set_guild_language.assert_not_called()
+
+    async def test_set_guild_language_empty_string(self, mock_bot):
+        """Empty language string returns ok=False without touching the cache."""
+        mock_bot.guild_cache = MagicMock()
+        result = await handle_valkey_command(mock_bot, "set_guild_language", {"guild_id": "42", "language": ""})
+        assert result["ok"] is False
+        mock_bot.guild_cache.set_guild_language.assert_not_called()
+
+    async def test_set_guild_language_non_string(self, mock_bot):
+        """Non-string language value returns ok=False without touching the cache."""
+        mock_bot.guild_cache = MagicMock()
+        result = await handle_valkey_command(mock_bot, "set_guild_language", {"guild_id": "42", "language": 99})
+        assert result["ok"] is False
+        mock_bot.guild_cache.set_guild_language.assert_not_called()
+
+    # ── invalidate_modrole ─────────────────────────────────────────────────
+
+    async def test_invalidate_modrole_valid(self, mock_bot):
+        """Valid guild_id evicts the modrole cache entry."""
+        mock_bot.guild_cache = MagicMock()
+        result = await handle_valkey_command(mock_bot, "invalidate_modrole", {"guild_id": "77"})
+        assert result == {"ok": True}
+        mock_bot.guild_cache.delete_modrole.assert_called_once_with(77)
+
+    async def test_invalidate_modrole_invalid_guild_id(self, mock_bot):
+        """Zero or non-numeric guild_id returns ok=False without touching the cache."""
+        mock_bot.guild_cache = MagicMock()
+        result = await handle_valkey_command(mock_bot, "invalidate_modrole", {"guild_id": "abc"})
+        assert result["ok"] is False
+        mock_bot.guild_cache.delete_modrole.assert_not_called()
+
+    async def test_invalidate_modrole_missing_guild_id(self, mock_bot):
+        """Missing guild_id returns ok=False without touching the cache."""
+        mock_bot.guild_cache = MagicMock()
+        result = await handle_valkey_command(mock_bot, "invalidate_modrole", {})
+        assert result["ok"] is False
+        mock_bot.guild_cache.delete_modrole.assert_not_called()

--- a/tests/test_valkey_subscriber.py
+++ b/tests/test_valkey_subscriber.py
@@ -535,29 +535,37 @@ class TestBotCommandHandler:
     # ── invalidate_leave_config ─────────────────────────────────────────────
 
     async def test_invalidate_leave_config_valid(self, mock_bot):
-        """Valid guild_id calls reload_leave_config on the guild cache."""
+        """Valid guild_id: DB loaded in thread, then apply_leave_config called on event-loop."""
+        from sqlalchemy.exc import SQLAlchemyError  # noqa: F401 — ensure importable
+
+        sentinel = (123, "bye")
         mock_bot.guild_cache = MagicMock()
+        mock_bot.guild_cache._load_leave_config_from_db.return_value = sentinel
         result = await handle_valkey_command(mock_bot, "invalidate_leave_config", {"guild_id": "55"})
         assert result == {"ok": True}
-        mock_bot.guild_cache.reload_leave_config.assert_called_once_with(55, mock_bot.SESSION)
+        mock_bot.guild_cache._load_leave_config_from_db.assert_called_once_with(55, mock_bot.SESSION)
+        mock_bot.guild_cache.apply_leave_config.assert_called_once_with(55, sentinel)
 
     async def test_invalidate_leave_config_missing_guild_id(self, mock_bot):
-        """Missing or non-numeric guild_id returns ok=False without calling reload."""
+        """Missing or non-numeric guild_id returns ok=False without hitting the DB."""
         mock_bot.guild_cache = MagicMock()
         result = await handle_valkey_command(mock_bot, "invalidate_leave_config", {})
         assert result["ok"] is False
-        mock_bot.guild_cache.reload_leave_config.assert_not_called()
+        mock_bot.guild_cache._load_leave_config_from_db.assert_not_called()
 
     async def test_invalidate_leave_config_invalid_guild_id(self, mock_bot):
-        """Non-numeric guild_id returns ok=False without calling reload."""
+        """Non-numeric guild_id returns ok=False without hitting the DB."""
         mock_bot.guild_cache = MagicMock()
         result = await handle_valkey_command(mock_bot, "invalidate_leave_config", {"guild_id": "bad"})
         assert result["ok"] is False
-        mock_bot.guild_cache.reload_leave_config.assert_not_called()
+        mock_bot.guild_cache._load_leave_config_from_db.assert_not_called()
 
     async def test_invalidate_leave_config_reload_failure(self, mock_bot):
-        """reload_leave_config raising an exception returns ok=False with error message."""
+        """SQLAlchemyError from DB read calls mark_leave_config_for_recheck and returns ok=False."""
+        from sqlalchemy.exc import SQLAlchemyError
+
         mock_bot.guild_cache = MagicMock()
-        mock_bot.guild_cache.reload_leave_config.side_effect = RuntimeError("DB down")
+        mock_bot.guild_cache._load_leave_config_from_db.side_effect = SQLAlchemyError("DB down")
         result = await handle_valkey_command(mock_bot, "invalidate_leave_config", {"guild_id": "55"})
         assert result == {"ok": False, "error": "cache reload failed — see bot logs"}
+        mock_bot.guild_cache.mark_leave_config_for_recheck.assert_called_once_with(55)

--- a/tests/test_valkey_subscriber.py
+++ b/tests/test_valkey_subscriber.py
@@ -531,3 +531,33 @@ class TestBotCommandHandler:
         result = await handle_valkey_command(mock_bot, "invalidate_modrole", {})
         assert result["ok"] is False
         mock_bot.guild_cache.delete_modrole.assert_not_called()
+
+    # ── invalidate_leave_config ─────────────────────────────────────────────
+
+    async def test_invalidate_leave_config_valid(self, mock_bot):
+        """Valid guild_id calls reload_leave_config on the guild cache."""
+        mock_bot.guild_cache = MagicMock()
+        result = await handle_valkey_command(mock_bot, "invalidate_leave_config", {"guild_id": "55"})
+        assert result == {"ok": True}
+        mock_bot.guild_cache.reload_leave_config.assert_called_once_with(55, mock_bot.SESSION)
+
+    async def test_invalidate_leave_config_missing_guild_id(self, mock_bot):
+        """Missing or non-numeric guild_id returns ok=False without calling reload."""
+        mock_bot.guild_cache = MagicMock()
+        result = await handle_valkey_command(mock_bot, "invalidate_leave_config", {})
+        assert result["ok"] is False
+        mock_bot.guild_cache.reload_leave_config.assert_not_called()
+
+    async def test_invalidate_leave_config_invalid_guild_id(self, mock_bot):
+        """Non-numeric guild_id returns ok=False without calling reload."""
+        mock_bot.guild_cache = MagicMock()
+        result = await handle_valkey_command(mock_bot, "invalidate_leave_config", {"guild_id": "bad"})
+        assert result["ok"] is False
+        mock_bot.guild_cache.reload_leave_config.assert_not_called()
+
+    async def test_invalidate_leave_config_reload_failure(self, mock_bot):
+        """reload_leave_config raising an exception returns ok=False with error message."""
+        mock_bot.guild_cache = MagicMock()
+        mock_bot.guild_cache.reload_leave_config.side_effect = RuntimeError("DB down")
+        result = await handle_valkey_command(mock_bot, "invalidate_leave_config", {"guild_id": "55"})
+        assert result == {"ok": False, "error": "cache reload failed — see bot logs"}

--- a/tests/test_valkey_subscriber.py
+++ b/tests/test_valkey_subscriber.py
@@ -536,8 +536,6 @@ class TestBotCommandHandler:
 
     async def test_invalidate_leave_config_valid(self, mock_bot):
         """Valid guild_id: DB loaded in thread, then apply_leave_config called on event-loop."""
-        from sqlalchemy.exc import SQLAlchemyError  # noqa: F401 — ensure importable
-
         sentinel = (123, "bye")
         mock_bot.guild_cache = MagicMock()
         mock_bot.guild_cache._load_leave_config_from_db.return_value = sentinel

--- a/tests/utils/test_blizzard.py
+++ b/tests/utils/test_blizzard.py
@@ -4,7 +4,7 @@
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
-from models.wow import CraftingRecipeCache
+from models.wow import CraftingRecipeCache, _recipe_cache
 from utils.blizzard import CRAFTING_PROFESSIONS
 
 
@@ -137,3 +137,19 @@ class TestSyncCraftingRecipesGuard:
         assert result["errors"] > 0
         assert result["cache_updated"] is True
         assert result["crafted"] > 0  # partial rows were actually written
+
+    async def test_cache_updated_true_invalidates_recipe_cache(self):
+        """When the DB swap succeeds (cache_updated=True), _recipe_cache must be cleared."""
+        bot, _ = _make_bot()
+
+        # Pre-populate the recipe cache with a sentinel so we can detect the invalidation.
+        _recipe_cache["sentinel_key"] = ["stale"]
+
+        with patch("blizzapi.RetailClient", return_value=_make_client(fail=False)):
+            with patch.object(CraftingRecipeCache, "count", return_value=5):
+                from utils.blizzard import sync_crafting_recipes
+
+                result = await sync_crafting_recipes(bot)
+
+        assert result["cache_updated"] is True
+        assert "sentinel_key" not in _recipe_cache  # sentinel must have been cleared

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -338,9 +338,8 @@ class TestLeaveMessages:
 
         assert cache.is_leave_message_guild(GUILD_ID) is False
 
-    def test_reload_leave_config_fixes_broken_eviction(self, cache, session_factory, db_session):
-        # Regression: after evict_leave_config with _leave_warmed=True, is_leave_message_guild
-        # returns False, so get_leave_config is never called to repopulate.
+    def test_reload_leave_config_restores_evicted_entry(self, cache, session_factory, db_session):
+        # After evict_leave_config (explicit disable), is_leave_message_guild returns False.
         # reload_leave_config must restore the entry so is_leave_message_guild returns True.
         from models.leavemsg import LeaveMessage
 
@@ -349,11 +348,11 @@ class TestLeaveMessages:
         cache.warm_leave_messages(session_factory)
         cache.evict_leave_config(GUILD_ID)
 
-        assert cache.is_leave_message_guild(GUILD_ID) is False  # broken state before fix
+        assert cache.is_leave_message_guild(GUILD_ID) is False
 
         cache.reload_leave_config(GUILD_ID, session_factory)
 
-        assert cache.is_leave_message_guild(GUILD_ID) is True  # restored
+        assert cache.is_leave_message_guild(GUILD_ID) is True
 
 
 # ── Eviction ──────────────────────────────────────────────────────────────────
@@ -372,10 +371,15 @@ class TestEviction:
         cache.get_modrole(GUILD_ID, session_factory)
         session_factory.assert_called_once()
 
-    def test_evict_removes_from_leave_guild_set(self, cache, session_factory):
+    def test_evict_marks_guild_for_recheck(self, cache, session_factory):
+        # After eviction from a warmed cache, is_leave_message_guild returns True
+        # (conservative — guild was evicted, state unknown until next DB re-read).
         cache.warm_leave_messages(session_factory)
         cache.set_leave_config(GUILD_ID, 111, "bye")
         cache.evict_guild(GUILD_ID)
+        assert cache.is_leave_message_guild(GUILD_ID) is True
+        # get_leave_config re-reads DB (no row in test DB) and clears the evicted marker.
+        assert cache.get_leave_config(GUILD_ID, session_factory) is None
         assert cache.is_leave_message_guild(GUILD_ID) is False
 
     def test_evict_removes_reaction_role_messages(self, cache, session_factory):

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -237,6 +237,21 @@ class TestLeaveMessages:
         result = cache.get_leave_config(GUILD_ID, session_factory)
         assert result is None
 
+    def test_get_leave_config_unwarmed_caches_none_result(self, cache, session_factory):
+        # First call hits DB (no row), stores None; second call must not hit DB again.
+        cache.get_leave_config(GUILD_ID, session_factory)
+
+        # Patch session_factory to detect a second DB call
+        db_called = []
+        original = session_factory
+
+        def spy_factory():
+            db_called.append(True)
+            return original()
+
+        cache.get_leave_config(GUILD_ID, spy_factory)
+        assert not db_called, "second call for same guild should not open a DB session"
+
     def test_get_leave_config_warmed_uses_cache(self, cache, session_factory, db_session):
         from models.leavemsg import LeaveMessage
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -4,8 +4,19 @@
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy.exc import OperationalError
 
-from utils.cache import GuildConfigCache, build_name_choices
+from models.admin import BotModeratorRole, GuildLanguageConfig
+from models.leavemsg import LeaveMessage
+from models.reactionrole import ReactionRoleEntry, ReactionRoleMessage
+from utils.cache import (
+    REACTION_ROLE_CACHE_MISS,
+    GuildConfigCache,
+    _autocomplete_cache,
+    build_name_choices,
+    cached_autocomplete,
+    invalidate_autocomplete,
+)
 
 
 GUILD_ID = 987654321
@@ -37,8 +48,6 @@ class TestGuildLanguage:
         session_factory.assert_called_once()
 
     def test_miss_loads_from_db(self, cache, session_factory, db_session):
-        from models.admin import GuildLanguageConfig
-
         db_session.add(GuildLanguageConfig(GuildId=GUILD_ID, Language="de"))
         db_session.commit()
 
@@ -59,8 +68,6 @@ class TestGuildLanguage:
         session_factory.assert_not_called()
 
     def test_second_call_uses_cache(self, cache, session_factory, db_session):
-        from models.admin import GuildLanguageConfig
-
         db_session.add(GuildLanguageConfig(GuildId=GUILD_ID, Language="de"))
         db_session.commit()
 
@@ -70,8 +77,6 @@ class TestGuildLanguage:
         assert session_factory.call_count == 1
 
     def test_different_guilds_are_independent(self, cache, session_factory, db_session):
-        from models.admin import GuildLanguageConfig
-
         db_session.add(GuildLanguageConfig(GuildId=GUILD_ID, Language="de"))
         db_session.add(GuildLanguageConfig(GuildId=GUILD_ID_2, Language="fr"))
         db_session.commit()
@@ -90,8 +95,6 @@ class TestModrole:
         session_factory.assert_called_once()
 
     def test_miss_loads_from_db(self, cache, session_factory, db_session):
-        from models.admin import BotModeratorRole
-
         db_session.add(BotModeratorRole(GuildId=GUILD_ID, RoleId=555))
         db_session.commit()
 
@@ -133,8 +136,6 @@ class TestReactionRoles:
         assert cache.is_reaction_role_message(999999) is False
 
     def test_warmed_returns_true_for_known(self, cache, session_factory, db_session):
-        from models.reactionrole import ReactionRoleMessage
-
         db_session.add(ReactionRoleMessage(GuildId=GUILD_ID, ChannelId=111, MessageId=42))
         db_session.commit()
 
@@ -147,6 +148,27 @@ class TestReactionRoles:
         cache.add_reaction_role_message(GUILD_ID, 77)
         assert cache.is_reaction_role_message(77) is True
 
+    def test_add_after_evict_heals_sentinel(self, cache, session_factory):
+        # After evict_guild, add_reaction_role_message must clear the re-check sentinel so
+        # get_reaction_role returns None (not CACHE_MISS) for the freshly registered message.
+        cache.warm_reaction_roles(session_factory)
+        cache.add_reaction_role_message(GUILD_ID, 77)
+        cache.evict_guild(GUILD_ID)
+        assert cache.get_reaction_role(77, "👍") is REACTION_ROLE_CACHE_MISS  # sentinel active
+        cache.add_reaction_role_message(GUILD_ID, 77)  # re-register after rejoin
+        assert cache.get_reaction_role(77, "👍") is None  # sentinel healed; None = warmed, no mapping
+
+    def test_remove_after_evict_clears_sentinel(self, cache, session_factory):
+        # After evict_guild, remove_reaction_role_message must clear the re-check sentinel so
+        # get_reaction_role returns None (not CACHE_MISS) — the message is definitively gone.
+        cache.warm_reaction_roles(session_factory)
+        cache.add_reaction_role_message(GUILD_ID, 77)
+        cache.evict_guild(GUILD_ID)
+        assert cache.get_reaction_role(77, "👍") is REACTION_ROLE_CACHE_MISS  # sentinel active
+        cache.remove_reaction_role_message(GUILD_ID, 77)
+        assert cache.is_reaction_role_message(77) is False  # hot-path guard: message is gone
+        assert cache.get_reaction_role(77, "👍") is None  # sentinel cleared; None = warmed, no mapping
+
     def test_remove_after_add(self, cache, session_factory):
         cache.warm_reaction_roles(session_factory)
         cache.add_reaction_role_message(GUILD_ID, 77)
@@ -157,8 +179,6 @@ class TestReactionRoles:
         cache.remove_reaction_role_message(GUILD_ID, 999)  # must not raise
 
     def test_warm_is_idempotent(self, cache, session_factory, db_session):
-        from models.reactionrole import ReactionRoleMessage
-
         db_session.add(ReactionRoleMessage(GuildId=GUILD_ID, ChannelId=111, MessageId=42))
         db_session.commit()
 
@@ -207,8 +227,6 @@ class TestLeaveMessages:
         assert cache.is_leave_message_guild(GUILD_ID) is False
 
     def test_warmed_returns_true_for_enabled_guild(self, cache, session_factory, db_session):
-        from models.leavemsg import LeaveMessage
-
         db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye", Enabled=True))
         db_session.commit()
 
@@ -216,8 +234,6 @@ class TestLeaveMessages:
         assert cache.is_leave_message_guild(GUILD_ID) is True
 
     def test_disabled_guild_not_in_cache(self, cache, session_factory, db_session):
-        from models.leavemsg import LeaveMessage
-
         db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye", Enabled=False))
         db_session.commit()
 
@@ -236,8 +252,6 @@ class TestLeaveMessages:
         assert cache.is_leave_message_guild(GUILD_ID) is False
 
     def test_warm_is_idempotent(self, cache, session_factory, db_session):
-        from models.leavemsg import LeaveMessage
-
         db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye", Enabled=True))
         db_session.commit()
 
@@ -249,8 +263,6 @@ class TestLeaveMessages:
         assert cache.is_leave_message_guild(GUILD_ID) is True
 
     def test_get_leave_config_unwarmed_hits_db(self, cache, session_factory, db_session):
-        from models.leavemsg import LeaveMessage
-
         db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye {member}", Enabled=True))
         db_session.commit()
 
@@ -278,8 +290,6 @@ class TestLeaveMessages:
         assert not db_called, "second call for same guild should not open a DB session"
 
     def test_get_leave_config_warmed_uses_cache(self, cache, session_factory, db_session):
-        from models.leavemsg import LeaveMessage
-
         db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye", Enabled=True))
         db_session.commit()
 
@@ -311,8 +321,6 @@ class TestLeaveMessages:
         assert cache._leave_warmed is True
 
     def test_reload_leave_config_populates_when_enabled(self, cache, session_factory, db_session):
-        from models.leavemsg import LeaveMessage
-
         db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye {member}", Enabled=True))
         db_session.commit()
 
@@ -325,8 +333,6 @@ class TestLeaveMessages:
         assert cache.get_leave_config(GUILD_ID, session_factory) == (111, "bye {member}")
 
     def test_reload_leave_config_evicts_when_disabled(self, cache, session_factory, db_session):
-        from models.leavemsg import LeaveMessage
-
         db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye {member}", Enabled=True))
         db_session.commit()
         cache.warm_leave_messages(session_factory)
@@ -341,8 +347,6 @@ class TestLeaveMessages:
     def test_reload_leave_config_restores_evicted_entry(self, cache, session_factory, db_session):
         # After evict_leave_config (explicit disable), is_leave_message_guild returns False.
         # reload_leave_config must restore the entry so is_leave_message_guild returns True.
-        from models.leavemsg import LeaveMessage
-
         db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye {member}", Enabled=True))
         db_session.commit()
         cache.warm_leave_messages(session_factory)
@@ -393,8 +397,6 @@ class TestEviction:
         assert cache.is_reaction_role_message(42) is True  # evicted but treated as possible
         assert cache.is_reaction_role_message(99) is True  # other guild unaffected
         # get_reaction_role must return CACHE_MISS (not None) so callers fall back to DB.
-        from utils.cache import REACTION_ROLE_CACHE_MISS
-
         assert cache.get_reaction_role(42, "👍") is REACTION_ROLE_CACHE_MISS
 
     def test_evict_reaction_role_messages_cleared_on_re_warm(self, cache, session_factory):
@@ -418,22 +420,14 @@ class TestEviction:
         session_factory.assert_not_called()
 
 
-# ── build_name_choices ────────────────────────────────────────────────────────
-
-
 # ── get_reaction_role ─────────────────────────────────────────────────────────
 
 
 class TestGetReactionRole:
     def test_returns_cache_miss_before_warm(self, cache):
-        from utils.cache import REACTION_ROLE_CACHE_MISS
-
         assert cache.get_reaction_role(99, "👍") is REACTION_ROLE_CACHE_MISS
 
     def test_returns_role_id_after_warm(self, cache, session_factory, db_session):
-        from models.reactionrole import ReactionRoleEntry, ReactionRoleMessage
-        from utils.cache import REACTION_ROLE_CACHE_MISS
-
         msg = ReactionRoleMessage(GuildId=GUILD_ID, ChannelId=111, MessageId=42)
         db_session.add(msg)
         db_session.flush()
@@ -447,9 +441,6 @@ class TestGetReactionRole:
         assert result == 777
 
     def test_returns_none_for_unknown_emoji_after_warm(self, cache, session_factory, db_session):
-        from models.reactionrole import ReactionRoleMessage
-        from utils.cache import REACTION_ROLE_CACHE_MISS
-
         db_session.add(ReactionRoleMessage(GuildId=GUILD_ID, ChannelId=111, MessageId=42))
         db_session.commit()
 
@@ -466,16 +457,12 @@ class TestGetReactionRole:
 class TestCachedAutocomplete:
     @pytest.fixture(autouse=True)
     def _clear_cache(self):
-        from utils.cache import _autocomplete_cache
-
         _autocomplete_cache.clear()
         yield
         _autocomplete_cache.clear()
 
     @pytest.mark.asyncio
     async def test_hit_returns_cached_result(self):
-        from utils.cache import cached_autocomplete
-
         calls = []
 
         def fetcher():
@@ -491,8 +478,6 @@ class TestCachedAutocomplete:
 
     @pytest.mark.asyncio
     async def test_different_keys_produce_separate_entries(self):
-        from utils.cache import cached_autocomplete
-
         r1 = await cached_autocomplete(("test", 1), lambda: ["x"])
         r2 = await cached_autocomplete(("test", 2), lambda: ["y"])
 
@@ -501,10 +486,6 @@ class TestCachedAutocomplete:
 
     @pytest.mark.asyncio
     async def test_fetcher_error_returns_empty_list(self):
-        from sqlalchemy.exc import OperationalError
-
-        from utils.cache import cached_autocomplete
-
         def bad_fetcher():
             raise OperationalError("DB down", None, None)
 
@@ -513,10 +494,6 @@ class TestCachedAutocomplete:
 
     @pytest.mark.asyncio
     async def test_fetcher_error_does_not_cache(self):
-        from sqlalchemy.exc import OperationalError
-
-        from utils.cache import cached_autocomplete
-
         calls = []
 
         def flaky_fetcher():
@@ -535,8 +512,6 @@ class TestCachedAutocomplete:
     async def test_non_db_fetcher_error_propagates(self):
         # Non-SQLAlchemyError must propagate so programming bugs surface immediately
         # rather than silently returning [] on every keystroke.
-        from utils.cache import cached_autocomplete
-
         def buggy_fetcher():
             raise RuntimeError("unexpected bug")
 
@@ -544,16 +519,12 @@ class TestCachedAutocomplete:
             await cached_autocomplete(("test", 77), buggy_fetcher)
 
     def test_invalidate_evicts_key(self):
-        from utils.cache import _autocomplete_cache, invalidate_autocomplete
-
         _autocomplete_cache[("test", 5)] = ["cached"]
         invalidate_autocomplete(("test", 5))
 
         assert ("test", 5) not in _autocomplete_cache
 
     def test_invalidate_nonexistent_is_safe(self):
-        from utils.cache import invalidate_autocomplete
-
         invalidate_autocomplete(("test", 999))  # must not raise
 
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -436,16 +436,20 @@ class TestCachedAutocomplete:
 
     @pytest.mark.asyncio
     async def test_fetcher_error_returns_empty_list(self):
+        from sqlalchemy.exc import OperationalError
+
         from utils.cache import cached_autocomplete
 
         def bad_fetcher():
-            raise RuntimeError("DB down")
+            raise OperationalError("DB down", None, None)
 
         result = await cached_autocomplete(("test", 99), bad_fetcher)
         assert result == []
 
     @pytest.mark.asyncio
     async def test_fetcher_error_does_not_cache(self):
+        from sqlalchemy.exc import OperationalError
+
         from utils.cache import cached_autocomplete
 
         calls = []
@@ -453,7 +457,7 @@ class TestCachedAutocomplete:
         def flaky_fetcher():
             calls.append(1)
             if len(calls) == 1:
-                raise RuntimeError("first call fails")
+                raise OperationalError("first call fails", None, None)
             return ["ok"]
 
         await cached_autocomplete(("test", 42), flaky_fetcher)  # miss + error
@@ -461,6 +465,18 @@ class TestCachedAutocomplete:
 
         assert result == ["ok"]
         assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_db_fetcher_error_propagates(self):
+        # Non-SQLAlchemyError must propagate so programming bugs surface immediately
+        # rather than silently returning [] on every keystroke.
+        from utils.cache import cached_autocomplete
+
+        def buggy_fetcher():
+            raise RuntimeError("unexpected bug")
+
+        with pytest.raises(RuntimeError, match="unexpected bug"):
+            await cached_autocomplete(("test", 77), buggy_fetcher)
 
     def test_invalidate_evicts_key(self):
         from utils.cache import _autocomplete_cache, invalidate_autocomplete

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -201,12 +201,12 @@ class TestLeaveMessages:
 
     def test_set_enabled(self, cache, session_factory):
         cache.warm_leave_messages(session_factory)
-        cache.set_leave_message_guild(GUILD_ID, True)
+        cache.set_leave_message_guild(GUILD_ID, True, channel_id=111, message="bye")
         assert cache.is_leave_message_guild(GUILD_ID) is True
 
     def test_set_disabled(self, cache, session_factory):
         cache.warm_leave_messages(session_factory)
-        cache.set_leave_message_guild(GUILD_ID, True)
+        cache.set_leave_message_guild(GUILD_ID, True, channel_id=111, message="bye")
         cache.set_leave_message_guild(GUILD_ID, False)
         assert cache.is_leave_message_guild(GUILD_ID) is False
 
@@ -217,7 +217,7 @@ class TestLeaveMessages:
         db_session.commit()
 
         cache.warm_leave_messages(session_factory)
-        cache.set_leave_message_guild(GUILD_ID_2, True)  # local addition
+        cache.set_leave_message_guild(GUILD_ID_2, True, channel_id=222, message="cya")  # local addition
 
         cache.warm_leave_messages(session_factory)  # re-warm clears local addition
         assert cache.is_leave_message_guild(GUILD_ID_2) is False
@@ -242,7 +242,7 @@ class TestEviction:
 
     def test_evict_removes_from_leave_guild_set(self, cache, session_factory):
         cache.warm_leave_messages(session_factory)
-        cache.set_leave_message_guild(GUILD_ID, True)
+        cache.set_leave_message_guild(GUILD_ID, True, channel_id=111, message="bye")
         cache.evict_guild(GUILD_ID)
         assert cache.is_leave_message_guild(GUILD_ID) is False
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -385,10 +385,26 @@ class TestEviction:
     def test_evict_removes_reaction_role_messages(self, cache, session_factory):
         cache.warm_reaction_roles(session_factory)
         cache.add_reaction_role_message(GUILD_ID, 42)
+        cache.add_reaction_role_entry(42, "👍", 111)
         cache.add_reaction_role_message(GUILD_ID_2, 99)
         cache.evict_guild(GUILD_ID)
-        assert cache.is_reaction_role_message(42) is False  # evicted
+        # After eviction, is_reaction_role_message returns True (conservative: fall back to DB).
+        # This matches the _leave_evicted pattern — guild may rejoin with existing config.
+        assert cache.is_reaction_role_message(42) is True  # evicted but treated as possible
         assert cache.is_reaction_role_message(99) is True  # other guild unaffected
+        # get_reaction_role must return CACHE_MISS (not None) so callers fall back to DB.
+        from utils.cache import REACTION_ROLE_CACHE_MISS
+
+        assert cache.get_reaction_role(42, "👍") is REACTION_ROLE_CACHE_MISS
+
+    def test_evict_reaction_role_messages_cleared_on_re_warm(self, cache, session_factory):
+        cache.warm_reaction_roles(session_factory)
+        cache.add_reaction_role_message(GUILD_ID, 42)
+        cache.evict_guild(GUILD_ID)
+        assert cache.is_reaction_role_message(42) is True  # evicted sentinel
+        cache.warm_reaction_roles(session_factory)  # re-warm clears sentinel
+        # msg 42 was not in the DB, so after re-warm it is truly absent
+        assert cache.is_reaction_role_message(42) is False
 
     def test_evict_nonexistent_is_safe(self, cache):
         cache.evict_guild(GUILD_ID)  # must not raise

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -539,14 +539,20 @@ class TestCachedAutocomplete:
         assert len(calls) == 2
 
     @pytest.mark.asyncio
-    async def test_non_db_fetcher_error_propagates(self):
-        # Non-SQLAlchemyError must propagate so programming bugs surface immediately
-        # rather than silently returning [] on every keystroke.
+    async def test_non_db_fetcher_error_returns_empty_and_logs(self, caplog):
+        # Non-SQLAlchemyError must be caught, logged at error level, and return []
+        # so discord.py's autocomplete handler gets a clean empty list rather than
+        # propagating to the root exception handler with no module log entry.
+        import logging
+
         def buggy_fetcher():
             raise RuntimeError("unexpected bug")
 
-        with pytest.raises(RuntimeError, match="unexpected bug"):
-            await cached_autocomplete(("test", 77), buggy_fetcher)
+        with caplog.at_level(logging.ERROR, logger="utils.cache"):
+            result = await cached_autocomplete(("test", 77), buggy_fetcher)
+
+        assert result == []
+        assert any("unexpected error" in r.message for r in caplog.records)
 
     def test_invalidate_evicts_key(self):
         _autocomplete_cache[("test", 5)] = ["cached"]

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -189,6 +189,11 @@ class TestReactionRoles:
         cache.warm_reaction_roles(session_factory)
         assert cache._rr_warmed is True
 
+    def test_add_reaction_role_entry_before_warm_is_noop(self, cache):
+        # Before warm-up, add_reaction_role_entry must not raise and must not populate mappings.
+        cache.add_reaction_role_entry(42, "👍", 777)
+        assert 42 not in cache._rr_mappings
+
 
 # ── Leave messages ────────────────────────────────────────────────────────────
 
@@ -347,6 +352,129 @@ class TestEviction:
         lang = cache.get_guild_language(GUILD_ID_2, session_factory)
         assert lang == "fr"
         session_factory.assert_not_called()
+
+
+# ── build_name_choices ────────────────────────────────────────────────────────
+
+
+# ── get_reaction_role ─────────────────────────────────────────────────────────
+
+
+class TestGetReactionRole:
+    def test_returns_cache_miss_before_warm(self, cache):
+        from utils.cache import REACTION_ROLE_CACHE_MISS
+
+        assert cache.get_reaction_role(99, "👍") is REACTION_ROLE_CACHE_MISS
+
+    def test_returns_role_id_after_warm(self, cache, session_factory, db_session):
+        from models.reactionrole import ReactionRoleEntry, ReactionRoleMessage
+        from utils.cache import REACTION_ROLE_CACHE_MISS
+
+        msg = ReactionRoleMessage(GuildId=GUILD_ID, ChannelId=111, MessageId=42)
+        db_session.add(msg)
+        db_session.flush()
+        db_session.add(ReactionRoleEntry(ReactionRoleMessageId=msg.Id, Emoji="👍", RoleId=777))
+        db_session.commit()
+
+        cache.warm_reaction_roles(session_factory)
+
+        result = cache.get_reaction_role(42, "👍")
+        assert result is not REACTION_ROLE_CACHE_MISS
+        assert result == 777
+
+    def test_returns_none_for_unknown_emoji_after_warm(self, cache, session_factory, db_session):
+        from models.reactionrole import ReactionRoleMessage
+        from utils.cache import REACTION_ROLE_CACHE_MISS
+
+        db_session.add(ReactionRoleMessage(GuildId=GUILD_ID, ChannelId=111, MessageId=42))
+        db_session.commit()
+
+        cache.warm_reaction_roles(session_factory)
+
+        result = cache.get_reaction_role(42, "🔥")
+        assert result is not REACTION_ROLE_CACHE_MISS
+        assert result is None
+
+
+# ── cached_autocomplete ────────────────────────────────────────────────────────
+
+
+class TestCachedAutocomplete:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        from utils.cache import _autocomplete_cache
+
+        _autocomplete_cache.clear()
+        yield
+        _autocomplete_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_hit_returns_cached_result(self):
+        from utils.cache import cached_autocomplete
+
+        calls = []
+
+        def fetcher():
+            calls.append(1)
+            return ["a", "b"]
+
+        r1 = await cached_autocomplete(("test", 1), fetcher)
+        r2 = await cached_autocomplete(("test", 1), fetcher)
+
+        assert r1 == ["a", "b"]
+        assert r2 == ["a", "b"]
+        assert len(calls) == 1  # fetcher called only once
+
+    @pytest.mark.asyncio
+    async def test_different_keys_produce_separate_entries(self):
+        from utils.cache import cached_autocomplete
+
+        r1 = await cached_autocomplete(("test", 1), lambda: ["x"])
+        r2 = await cached_autocomplete(("test", 2), lambda: ["y"])
+
+        assert r1 == ["x"]
+        assert r2 == ["y"]
+
+    @pytest.mark.asyncio
+    async def test_fetcher_error_returns_empty_list(self):
+        from utils.cache import cached_autocomplete
+
+        def bad_fetcher():
+            raise RuntimeError("DB down")
+
+        result = await cached_autocomplete(("test", 99), bad_fetcher)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_fetcher_error_does_not_cache(self):
+        from utils.cache import cached_autocomplete
+
+        calls = []
+
+        def flaky_fetcher():
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("first call fails")
+            return ["ok"]
+
+        await cached_autocomplete(("test", 42), flaky_fetcher)  # miss + error
+        result = await cached_autocomplete(("test", 42), flaky_fetcher)  # should retry
+
+        assert result == ["ok"]
+        assert len(calls) == 2
+
+    def test_invalidate_evicts_key(self):
+        from utils.cache import _autocomplete_cache, invalidate_autocomplete
+
+        _autocomplete_cache[("test", 5)] = ["cached"]
+        invalidate_autocomplete(("test", 5))
+
+        assert ("test", 5) not in _autocomplete_cache
+
+    def test_invalidate_nonexistent_is_safe(self):
+        from utils.cache import invalidate_autocomplete
+
+        invalidate_autocomplete(("test", 999))  # must not raise
 
 
 # ── build_name_choices ────────────────────────────────────────────────────────

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -297,6 +297,18 @@ class TestLeaveMessages:
         result = cache.get_leave_config(GUILD_ID, session_factory)
         assert result == (111, "bye")
 
+    def test_get_leave_config_sqlalchemy_error_returns_none_and_does_not_cache(self, cache, session_factory):
+        # Evict so the cache is forced to hit the DB path.
+        cache._leave_evicted.add(GUILD_ID)
+
+        def failing_factory():
+            raise OperationalError("DB down", None, None)
+
+        result = cache.get_leave_config(GUILD_ID, failing_factory)
+
+        assert result is None
+        assert GUILD_ID not in cache._leave_configs  # must NOT be cached
+
     def test_evict_nonexistent_is_safe(self, cache):
         cache.evict_leave_config(GUILD_ID)  # must not raise
 
@@ -356,6 +368,24 @@ class TestLeaveMessages:
 
         cache.reload_leave_config(GUILD_ID, session_factory)
 
+        assert cache.is_leave_message_guild(GUILD_ID) is True
+
+    def test_reload_leave_config_db_error_evicts_and_marks_for_recheck(self, cache, session_factory, db_session):
+        # Warm the cache with a live guild so _leave_warmed=True.
+        db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye", Enabled=True))
+        db_session.commit()
+        cache.warm_leave_messages(session_factory)
+
+        def failing_factory():
+            raise OperationalError("DB down", None, None)
+
+        cache.reload_leave_config(GUILD_ID, failing_factory)
+
+        # Guild must be popped from _leave_configs
+        assert GUILD_ID not in cache._leave_configs
+        # Guild must be added to _leave_evicted so the next cold-miss path retries
+        assert GUILD_ID in cache._leave_evicted
+        # is_leave_message_guild must return True (conservative: state unknown, must re-check)
         assert cache.is_leave_message_guild(GUILD_ID) is True
 
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from utils.cache import GuildConfigCache
+from utils.cache import GuildConfigCache, build_name_choices
 
 
 GUILD_ID = 987654321
@@ -169,6 +169,26 @@ class TestReactionRoles:
         assert cache.is_reaction_role_message(99) is False
         assert cache.is_reaction_role_message(42) is True
 
+    def test_db_failure_leaves_flag_unset(self, cache):
+        def failing_factory():
+            raise Exception("DB down")
+
+        with pytest.raises(Exception, match="DB down"):
+            cache.warm_reaction_roles(failing_factory)
+
+        assert cache._rr_warmed is False
+        assert cache.is_reaction_role_message(99999) is True
+
+    def test_can_rewarm_after_failure(self, cache, session_factory):
+        def failing_factory():
+            raise Exception("DB down")
+
+        with pytest.raises(Exception):
+            cache.warm_reaction_roles(failing_factory)
+
+        cache.warm_reaction_roles(session_factory)
+        assert cache._rr_warmed is True
+
 
 # ── Leave messages ────────────────────────────────────────────────────────────
 
@@ -266,6 +286,26 @@ class TestLeaveMessages:
         with pytest.raises(ValueError, match="channel_id is required"):
             cache.set_leave_message_guild(GUILD_ID, True, channel_id=None)
 
+    def test_db_failure_leaves_flag_unset(self, cache):
+        def failing_factory():
+            raise Exception("DB down")
+
+        with pytest.raises(Exception, match="DB down"):
+            cache.warm_leave_messages(failing_factory)
+
+        assert cache._leave_warmed is False
+        assert cache.is_leave_message_guild(GUILD_ID) is True
+
+    def test_can_rewarm_after_failure(self, cache, session_factory):
+        def failing_factory():
+            raise Exception("DB down")
+
+        with pytest.raises(Exception):
+            cache.warm_leave_messages(failing_factory)
+
+        cache.warm_leave_messages(session_factory)
+        assert cache._leave_warmed is True
+
 
 # ── Eviction ──────────────────────────────────────────────────────────────────
 
@@ -307,3 +347,31 @@ class TestEviction:
         lang = cache.get_guild_language(GUILD_ID_2, session_factory)
         assert lang == "fr"
         session_factory.assert_not_called()
+
+
+# ── build_name_choices ────────────────────────────────────────────────────────
+
+
+class TestBuildNameChoices:
+    def test_empty_current_returns_all(self):
+        names = ["Alpha", "Beta", "Gamma"]
+        choices = build_name_choices(names, "")
+        assert [c.name for c in choices] == ["Alpha", "Beta", "Gamma"]
+        assert [c.value for c in choices] == ["Alpha", "Beta", "Gamma"]
+
+    def test_filters_case_insensitively(self):
+        names = ["Alpha", "ALPHA", "Beta"]
+        choices = build_name_choices(names, "alpha")
+        assert len(choices) == 2
+        assert all("alpha" in c.name.lower() for c in choices)
+
+    def test_returns_at_most_25(self):
+        names = [f"Item {i}" for i in range(30)]
+        choices = build_name_choices(names, "")
+        assert len(choices) == 25
+
+    def test_truncates_long_names_to_100_chars(self):
+        long_name = "x" * 150
+        choices = build_name_choices([long_name], "")
+        assert len(choices[0].name) == 100
+        assert len(choices[0].value) == 100

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -10,6 +10,7 @@ from models.admin import BotModeratorRole, GuildLanguageConfig
 from models.leavemsg import LeaveMessage
 from models.reactionrole import ReactionRoleEntry, ReactionRoleMessage
 from utils.cache import (
+    LEAVE_CONFIG_DB_ERROR,
     REACTION_ROLE_CACHE_MISS,
     GuildConfigCache,
     _autocomplete_cache,
@@ -84,6 +85,15 @@ class TestGuildLanguage:
         assert cache.get_guild_language(GUILD_ID, session_factory) == "de"
         assert cache.get_guild_language(GUILD_ID_2, session_factory) == "fr"
 
+    def test_db_failure_does_not_write_stale_value(self, cache):
+        def failing_factory():
+            raise OperationalError("DB down", None, None)
+
+        with pytest.raises(OperationalError):
+            cache.get_guild_language(GUILD_ID, failing_factory)
+
+        assert GUILD_ID not in cache._lang
+
 
 # ── Moderator role ────────────────────────────────────────────────────────────
 
@@ -122,6 +132,15 @@ class TestModrole:
 
     def test_delete_nonexistent_is_safe(self, cache):
         cache.delete_modrole(GUILD_ID)  # must not raise
+
+    def test_db_failure_does_not_write_stale_value(self, cache):
+        def failing_factory():
+            raise OperationalError("DB down", None, None)
+
+        with pytest.raises(OperationalError):
+            cache.get_modrole(GUILD_ID, failing_factory)
+
+        assert GUILD_ID not in cache._modrole
 
 
 # ── Reaction roles ────────────────────────────────────────────────────────────
@@ -297,7 +316,7 @@ class TestLeaveMessages:
         result = cache.get_leave_config(GUILD_ID, session_factory)
         assert result == (111, "bye")
 
-    def test_get_leave_config_sqlalchemy_error_returns_none_and_does_not_cache(self, cache, session_factory):
+    def test_get_leave_config_sqlalchemy_error_returns_sentinel_and_does_not_cache(self, cache, session_factory):
         # Evict so the cache is forced to hit the DB path.
         cache._leave_evicted.add(GUILD_ID)
 
@@ -306,7 +325,7 @@ class TestLeaveMessages:
 
         result = cache.get_leave_config(GUILD_ID, failing_factory)
 
-        assert result is None
+        assert result is LEAVE_CONFIG_DB_ERROR
         assert GUILD_ID not in cache._leave_configs  # must NOT be cached
 
     def test_evict_nonexistent_is_safe(self, cache):

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -226,13 +226,13 @@ class TestLeaveMessages:
 
     def test_set_enabled(self, cache, session_factory):
         cache.warm_leave_messages(session_factory)
-        cache.set_leave_message_guild(GUILD_ID, True, channel_id=111, message="bye")
+        cache.set_leave_config(GUILD_ID, 111, "bye")
         assert cache.is_leave_message_guild(GUILD_ID) is True
 
     def test_set_disabled(self, cache, session_factory):
         cache.warm_leave_messages(session_factory)
-        cache.set_leave_message_guild(GUILD_ID, True, channel_id=111, message="bye")
-        cache.set_leave_message_guild(GUILD_ID, False)
+        cache.set_leave_config(GUILD_ID, 111, "bye")
+        cache.evict_leave_config(GUILD_ID)
         assert cache.is_leave_message_guild(GUILD_ID) is False
 
     def test_warm_is_idempotent(self, cache, session_factory, db_session):
@@ -242,7 +242,7 @@ class TestLeaveMessages:
         db_session.commit()
 
         cache.warm_leave_messages(session_factory)
-        cache.set_leave_message_guild(GUILD_ID_2, True, channel_id=222, message="cya")  # local addition
+        cache.set_leave_config(GUILD_ID_2, 222, "cya")  # local addition
 
         cache.warm_leave_messages(session_factory)  # re-warm clears local addition
         assert cache.is_leave_message_guild(GUILD_ID_2) is False
@@ -287,9 +287,8 @@ class TestLeaveMessages:
         result = cache.get_leave_config(GUILD_ID, session_factory)
         assert result == (111, "bye")
 
-    def test_set_enabled_without_channel_raises(self, cache):
-        with pytest.raises(ValueError, match="channel_id is required"):
-            cache.set_leave_message_guild(GUILD_ID, True, channel_id=None)
+    def test_evict_nonexistent_is_safe(self, cache):
+        cache.evict_leave_config(GUILD_ID)  # must not raise
 
     def test_db_failure_leaves_flag_unset(self, cache):
         def failing_factory():
@@ -330,7 +329,7 @@ class TestEviction:
 
     def test_evict_removes_from_leave_guild_set(self, cache, session_factory):
         cache.warm_leave_messages(session_factory)
-        cache.set_leave_message_guild(GUILD_ID, True, channel_id=111, message="bye")
+        cache.set_leave_config(GUILD_ID, 111, "bye")
         cache.evict_guild(GUILD_ID)
         assert cache.is_leave_message_guild(GUILD_ID) is False
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -223,6 +223,36 @@ class TestLeaveMessages:
         assert cache.is_leave_message_guild(GUILD_ID_2) is False
         assert cache.is_leave_message_guild(GUILD_ID) is True
 
+    def test_get_leave_config_unwarmed_hits_db(self, cache, session_factory, db_session):
+        from models.leavemsg import LeaveMessage
+
+        db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye {member}", Enabled=True))
+        db_session.commit()
+
+        # cache is cold — should fall back to DB
+        result = cache.get_leave_config(GUILD_ID, session_factory)
+        assert result == (111, "bye {member}")
+
+    def test_get_leave_config_unwarmed_returns_none_when_absent(self, cache, session_factory):
+        result = cache.get_leave_config(GUILD_ID, session_factory)
+        assert result is None
+
+    def test_get_leave_config_warmed_uses_cache(self, cache, session_factory, db_session):
+        from models.leavemsg import LeaveMessage
+
+        db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye", Enabled=True))
+        db_session.commit()
+
+        cache.warm_leave_messages(session_factory)
+        result = cache.get_leave_config(GUILD_ID, session_factory)
+        assert result == (111, "bye")
+
+    def test_set_enabled_without_channel_raises(self, cache):
+        import pytest
+
+        with pytest.raises(ValueError, match="channel_id is required"):
+            cache.set_leave_message_guild(GUILD_ID, True, channel_id=None)
+
 
 # ── Eviction ──────────────────────────────────────────────────────────────────
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -310,6 +310,51 @@ class TestLeaveMessages:
         cache.warm_leave_messages(session_factory)
         assert cache._leave_warmed is True
 
+    def test_reload_leave_config_populates_when_enabled(self, cache, session_factory, db_session):
+        from models.leavemsg import LeaveMessage
+
+        db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye {member}", Enabled=True))
+        db_session.commit()
+
+        cache.warm_leave_messages(session_factory)  # warm — guild not yet in configs
+        # Simulate external enable: evict then reload
+        cache.evict_leave_config(GUILD_ID)
+        cache.reload_leave_config(GUILD_ID, session_factory)
+
+        assert cache.is_leave_message_guild(GUILD_ID) is True
+        assert cache.get_leave_config(GUILD_ID, session_factory) == (111, "bye {member}")
+
+    def test_reload_leave_config_evicts_when_disabled(self, cache, session_factory, db_session):
+        from models.leavemsg import LeaveMessage
+
+        db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye {member}", Enabled=True))
+        db_session.commit()
+        cache.warm_leave_messages(session_factory)
+
+        # Simulate disable via web: mark disabled in DB, then reload cache
+        db_session.query(LeaveMessage).filter_by(GuildId=GUILD_ID).update({"Enabled": False})
+        db_session.commit()
+        cache.reload_leave_config(GUILD_ID, session_factory)
+
+        assert cache.is_leave_message_guild(GUILD_ID) is False
+
+    def test_reload_leave_config_fixes_broken_eviction(self, cache, session_factory, db_session):
+        # Regression: after evict_leave_config with _leave_warmed=True, is_leave_message_guild
+        # returns False, so get_leave_config is never called to repopulate.
+        # reload_leave_config must restore the entry so is_leave_message_guild returns True.
+        from models.leavemsg import LeaveMessage
+
+        db_session.add(LeaveMessage(GuildId=GUILD_ID, ChannelId=111, Message="bye {member}", Enabled=True))
+        db_session.commit()
+        cache.warm_leave_messages(session_factory)
+        cache.evict_leave_config(GUILD_ID)
+
+        assert cache.is_leave_message_guild(GUILD_ID) is False  # broken state before fix
+
+        cache.reload_leave_config(GUILD_ID, session_factory)
+
+        assert cache.is_leave_message_guild(GUILD_ID) is True  # restored
+
 
 # ── Eviction ──────────────────────────────────────────────────────────────────
 

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -248,8 +248,6 @@ class TestLeaveMessages:
         assert result == (111, "bye")
 
     def test_set_enabled_without_channel_raises(self, cache):
-        import pytest
-
         with pytest.raises(ValueError, match="channel_id is required"):
             cache.set_leave_message_guild(GUILD_ID, True, channel_id=None)
 

--- a/tests/utils/test_strings.py
+++ b/tests/utils/test_strings.py
@@ -4,7 +4,6 @@
 import pytest
 import yaml
 
-from models.admin import GuildLanguageConfig
 from utils import strings
 
 
@@ -62,30 +61,4 @@ class TestGetString:
     def test_unknown_language_falls_back_to_english(self, locale_dir):
         strings.load_strings(locale_dir)
         result = strings.get_string("fr", "common.greeting", name="World")
-        assert result == "Hello World!"
-
-
-class TestGetGuildLanguage:
-    def test_default_when_no_config(self, db_session):
-        result = strings.get_guild_language(999, db_session)
-        assert result == "en"
-
-    def test_returns_configured_language(self, db_session):
-        db_session.add(GuildLanguageConfig(GuildId=123, Language="de"))
-        db_session.commit()
-        result = strings.get_guild_language(123, db_session)
-        assert result == "de"
-
-
-class TestGetLocalizedString:
-    def test_combines_guild_language_and_lookup(self, locale_dir, db_session):
-        strings.load_strings(locale_dir)
-        db_session.add(GuildLanguageConfig(GuildId=123, Language="de"))
-        db_session.commit()
-        result = strings.get_localized_string(123, "common.greeting", db_session, name="Welt")
-        assert result == "Hallo Welt!"
-
-    def test_defaults_to_english(self, locale_dir, db_session):
-        strings.load_strings(locale_dir)
-        result = strings.get_localized_string(999, "common.greeting", db_session, name="World")
         assert result == "Hello World!"

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -126,6 +126,24 @@ def make_auth_header(user_id: str = "123456", username: str = "TestUser", secret
     return {"Authorization": f"Bearer {token}"}
 
 
+@pytest.fixture(autouse=True)
+def clear_web_caches():
+    """Clear all web-side in-process TTL caches before each test.
+
+    Module-level TTLCache singletons survive across tests in the same process.
+    Without this, a cache warmed by test A leaks stale entries into test B's
+    fresh DB, causing spurious 403 / permission failures.
+    """
+    from web.dependencies import invalidate_premium_cache
+    from web.routes.auth import _bot_guild_ids_cache
+    from web.routes.guilds import _guild_lang_cache
+
+    invalidate_premium_cache()
+    _bot_guild_ids_cache.clear()
+    _guild_lang_cache.clear()
+    yield
+
+
 @pytest.fixture
 def auth_header():
     """Auth header for a regular user."""

--- a/tests/web/test_guild_routes.py
+++ b/tests/web/test_guild_routes.py
@@ -46,9 +46,10 @@ class TestLanguageEndpoints:
         response = client.get(f"/api/guilds/{GUILD_ID}/language", headers=auth_header)
         assert response.json()["language"] == "fr"
 
-    def test_put_language_write_through_and_notifies_bot(self, client, fake_valkey, auth_header):
-        """PUT language must populate _guild_lang_cache and publish set_guild_language to the bot."""
+    def test_put_language_write_through_and_notifies_bot(self, client, fake_valkey, auth_header, web_db_session):
+        """PUT language must populate _guild_lang_cache, persist to DB, and publish set_guild_language to the bot."""
         import json
+        from models.admin import GuildLanguageConfig
         from web.routes.guilds import _guild_lang_cache
 
         # Pre-populate cache with stale value to confirm write-through replaces it.
@@ -68,6 +69,9 @@ class TestLanguageEndpoints:
 
         assert response.status_code == 200
         assert _guild_lang_cache[GUILD_ID] == "de"
+        stored = GuildLanguageConfig.get(GUILD_ID, web_db_session)
+        assert stored is not None
+        assert stored.Language == "de"
         bot_cmds = [json.loads(msg) for ch, msg in published if ch == "nerpybot:cmd"]
         lang_cmds = [c for c in bot_cmds if c.get("command") == "set_guild_language"]
         assert len(lang_cmds) == 1
@@ -212,6 +216,23 @@ class TestLeaveMessageEndpoints:
         invalidations = [c for c in bot_cmds if c.get("command") == "invalidate_leave_config"]
         assert len(invalidations) == 1
         assert invalidations[0]["guild_id"] == GUILD_ID
+
+    def test_put_enabled_without_channel_id_returns_422(self, client, fake_valkey, auth_header):
+        """PUT leave-messages with enabled=True but no channel_id must return 422 and not notify the bot."""
+        published = []
+
+        def capture(channel, message):
+            published.append((channel, message))
+
+        with patch.object(fake_valkey._client, "publish", side_effect=capture):
+            response = client.put(
+                f"/api/guilds/{GUILD_ID}/leave-messages",
+                json={"message": "Bye {member}!", "enabled": True},
+                headers=auth_header,
+            )
+
+        assert response.status_code == 422
+        assert not any(ch == "nerpybot:cmd" for ch, _ in published)
 
 
 class TestAutoDeleteEndpoints:

--- a/tests/web/test_guild_routes.py
+++ b/tests/web/test_guild_routes.py
@@ -71,7 +71,7 @@ class TestLanguageEndpoints:
         bot_cmds = [json.loads(msg) for ch, msg in published if ch == "nerpybot:cmd"]
         lang_cmds = [c for c in bot_cmds if c.get("command") == "set_guild_language"]
         assert len(lang_cmds) == 1
-        assert lang_cmds[0]["guild_id"] == str(GUILD_ID)
+        assert lang_cmds[0]["guild_id"] == GUILD_ID
         assert lang_cmds[0]["language"] == "de"
 
 
@@ -125,7 +125,7 @@ class TestModeratorRoleEndpoints:
         bot_cmds = [json.loads(msg) for ch, msg in published if ch == "nerpybot:cmd"]
         invalidations = [c for c in bot_cmds if c.get("command") == "invalidate_modrole"]
         assert len(invalidations) == 1
-        assert invalidations[0]["guild_id"] == str(GUILD_ID)
+        assert invalidations[0]["guild_id"] == GUILD_ID
 
     def test_delete_notifies_bot_to_invalidate_cache(self, client, fake_valkey, auth_header):
         """DELETE moderator-roles must publish an invalidate_modrole command with null role_id."""
@@ -152,7 +152,7 @@ class TestModeratorRoleEndpoints:
         bot_cmds = [json.loads(msg) for ch, msg in published if ch == "nerpybot:cmd"]
         invalidations = [c for c in bot_cmds if c.get("command") == "invalidate_modrole"]
         assert len(invalidations) == 1
-        assert invalidations[0]["guild_id"] == str(GUILD_ID)
+        assert invalidations[0]["guild_id"] == GUILD_ID
 
 
 class TestLeaveMessageEndpoints:
@@ -211,7 +211,7 @@ class TestLeaveMessageEndpoints:
         bot_cmds = [json.loads(msg) for ch, msg in published if ch == "nerpybot:cmd"]
         invalidations = [c for c in bot_cmds if c.get("command") == "invalidate_leave_config"]
         assert len(invalidations) == 1
-        assert invalidations[0]["guild_id"] == str(GUILD_ID)
+        assert invalidations[0]["guild_id"] == GUILD_ID
 
 
 class TestAutoDeleteEndpoints:

--- a/tests/web/test_guild_routes.py
+++ b/tests/web/test_guild_routes.py
@@ -111,6 +111,29 @@ class TestLeaveMessageEndpoints:
         )
         assert response.status_code == 422
 
+    def test_put_notifies_bot_to_invalidate_cache(self, client, fake_valkey, auth_header):
+        """PUT leave-messages must publish an invalidate_leave_config command to the bot."""
+        import json
+        from unittest.mock import patch
+
+        published = []
+
+        def capture(channel, message):
+            published.append((channel, message))
+
+        with patch.object(fake_valkey._client, "publish", side_effect=capture):
+            response = client.put(
+                f"/api/guilds/{GUILD_ID}/leave-messages",
+                json={"channel_id": "111222333", "message": "Bye {member}!", "enabled": True},
+                headers=auth_header,
+            )
+
+        assert response.status_code == 200
+        bot_cmds = [json.loads(msg) for ch, msg in published if ch == "nerpybot:cmd"]
+        invalidations = [c for c in bot_cmds if c.get("command") == "invalidate_leave_config"]
+        assert len(invalidations) == 1
+        assert invalidations[0]["guild_id"] == str(GUILD_ID)
+
 
 class TestAutoDeleteEndpoints:
     def test_get_empty_list(self, client, auth_header):

--- a/tests/web/test_guild_routes.py
+++ b/tests/web/test_guild_routes.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 
 from tests.web.conftest import make_auth_header
 
@@ -801,3 +804,45 @@ class TestSupportModeRedactionAndWriteBlocking:
         )
         assert response.status_code == 200
         assert response.json()["language"] == "de"
+
+
+class TestPremiumCacheBehavior:
+    """Tests for the in-process premium user ID cache in web/dependencies.py."""
+
+    def test_get_premium_ids_db_failure_returns_503(self, client, auth_header):
+        """When PremiumUser.get_all raises SQLAlchemyError, guild routes must return 503."""
+        from web.dependencies import _premium_ids_cache
+
+        _premium_ids_cache.clear()  # force cache miss so DB is actually hit
+        with patch("models.admin.PremiumUser.get_all", side_effect=SQLAlchemyError("DB down")):
+            response = client.get(f"/api/guilds/{GUILD_ID}/language", headers=auth_header)
+        assert response.status_code == 503
+
+    def test_invalidate_premium_cache_forces_fresh_db_read(self, client, fake_valkey, web_db_session):
+        """invalidate_premium_cache forces the next request to reload from DB.
+
+        Flow: new user has no premium → 403; grant premium + invalidate → 200.
+        """
+        from models.admin import PremiumUser
+        from web.dependencies import _premium_ids_cache, invalidate_premium_cache
+
+        new_user_id = 555444333
+        fake_valkey.set_permissions(
+            str(new_user_id),
+            {str(GUILD_ID): {"level": "admin", "name": "Test Guild"}},
+            ttl=300,
+        )
+        new_header = make_auth_header(user_id=str(new_user_id), username="NewUser")
+
+        # Without premium — 403
+        _premium_ids_cache.clear()
+        response = client.get(f"/api/guilds/{GUILD_ID}/language", headers=new_header)
+        assert response.status_code == 403
+
+        # Grant premium and invalidate so the next request hits DB
+        PremiumUser.grant(new_user_id, 111222333, web_db_session)
+        web_db_session.commit()
+        invalidate_premium_cache()
+
+        response = client.get(f"/api/guilds/{GUILD_ID}/language", headers=new_header)
+        assert response.status_code == 200

--- a/tests/web/test_guild_routes.py
+++ b/tests/web/test_guild_routes.py
@@ -43,6 +43,35 @@ class TestLanguageEndpoints:
         response = client.get(f"/api/guilds/{GUILD_ID}/language", headers=auth_header)
         assert response.json()["language"] == "fr"
 
+    def test_put_language_write_through_and_notifies_bot(self, client, fake_valkey, auth_header):
+        """PUT language must populate _guild_lang_cache and publish set_guild_language to the bot."""
+        import json
+        from unittest.mock import patch
+        from web.routes.guilds import _guild_lang_cache
+
+        # Pre-populate cache with stale value to confirm write-through replaces it.
+        _guild_lang_cache[GUILD_ID] = "stale"
+
+        published = []
+
+        def capture(channel, message):
+            published.append((channel, message))
+
+        with patch.object(fake_valkey._client, "publish", side_effect=capture):
+            response = client.put(
+                f"/api/guilds/{GUILD_ID}/language",
+                json={"language": "de"},
+                headers=auth_header,
+            )
+
+        assert response.status_code == 200
+        assert _guild_lang_cache[GUILD_ID] == "de"
+        bot_cmds = [json.loads(msg) for ch, msg in published if ch == "nerpybot:cmd"]
+        lang_cmds = [c for c in bot_cmds if c.get("command") == "set_guild_language"]
+        assert len(lang_cmds) == 1
+        assert lang_cmds[0]["guild_id"] == str(GUILD_ID)
+        assert lang_cmds[0]["language"] == "de"
+
 
 class TestModeratorRoleEndpoints:
     def test_get_empty_roles(self, client, auth_header):

--- a/tests/web/test_guild_routes.py
+++ b/tests/web/test_guild_routes.py
@@ -49,7 +49,6 @@ class TestLanguageEndpoints:
     def test_put_language_write_through_and_notifies_bot(self, client, fake_valkey, auth_header):
         """PUT language must populate _guild_lang_cache and publish set_guild_language to the bot."""
         import json
-        from unittest.mock import patch
         from web.routes.guilds import _guild_lang_cache
 
         # Pre-populate cache with stale value to confirm write-through replaces it.
@@ -109,7 +108,6 @@ class TestModeratorRoleEndpoints:
     def test_post_notifies_bot_to_invalidate_cache(self, client, fake_valkey, auth_header):
         """POST moderator-roles must publish an invalidate_modrole command with the new role_id."""
         import json
-        from unittest.mock import patch
 
         published = []
 
@@ -132,7 +130,6 @@ class TestModeratorRoleEndpoints:
     def test_delete_notifies_bot_to_invalidate_cache(self, client, fake_valkey, auth_header):
         """DELETE moderator-roles must publish an invalidate_modrole command with null role_id."""
         import json
-        from unittest.mock import patch
 
         client.post(
             f"/api/guilds/{GUILD_ID}/moderator-roles",
@@ -197,7 +194,6 @@ class TestLeaveMessageEndpoints:
     def test_put_notifies_bot_to_invalidate_cache(self, client, fake_valkey, auth_header):
         """PUT leave-messages must publish an invalidate_leave_config command to the bot."""
         import json
-        from unittest.mock import patch
 
         published = []
 

--- a/tests/web/test_guild_routes.py
+++ b/tests/web/test_guild_routes.py
@@ -217,22 +217,14 @@ class TestLeaveMessageEndpoints:
         assert len(invalidations) == 1
         assert invalidations[0]["guild_id"] == GUILD_ID
 
-    def test_put_enabled_without_channel_id_returns_422(self, client, fake_valkey, auth_header):
-        """PUT leave-messages with enabled=True but no channel_id must return 422 and not notify the bot."""
-        published = []
-
-        def capture(channel, message):
-            published.append((channel, message))
-
-        with patch.object(fake_valkey._client, "publish", side_effect=capture):
-            response = client.put(
-                f"/api/guilds/{GUILD_ID}/leave-messages",
-                json={"message": "Bye {member}!", "enabled": True},
-                headers=auth_header,
-            )
-
+    def test_put_enabled_without_channel_id_returns_422(self, client, auth_header):
+        """PUT leave-messages with enabled=True but no channel_id must return 422."""
+        response = client.put(
+            f"/api/guilds/{GUILD_ID}/leave-messages",
+            json={"message": "Bye {member}!", "enabled": True},
+            headers=auth_header,
+        )
         assert response.status_code == 422
-        assert not any(ch == "nerpybot:cmd" for ch, _ in published)
 
 
 class TestAutoDeleteEndpoints:

--- a/tests/web/test_guild_routes.py
+++ b/tests/web/test_guild_routes.py
@@ -74,6 +74,57 @@ class TestModeratorRoleEndpoints:
         response = client.delete(f"/api/guilds/{GUILD_ID}/moderator-roles/999", headers=auth_header)
         assert response.status_code == 404
 
+    def test_post_notifies_bot_to_invalidate_cache(self, client, fake_valkey, auth_header):
+        """POST moderator-roles must publish an invalidate_modrole command with the new role_id."""
+        import json
+        from unittest.mock import patch
+
+        published = []
+
+        def capture(channel, message):
+            published.append((channel, message))
+
+        with patch.object(fake_valkey._client, "publish", side_effect=capture):
+            response = client.post(
+                f"/api/guilds/{GUILD_ID}/moderator-roles",
+                json={"role_id": "555666777"},
+                headers=auth_header,
+            )
+
+        assert response.status_code == 201
+        bot_cmds = [json.loads(msg) for ch, msg in published if ch == "nerpybot:cmd"]
+        invalidations = [c for c in bot_cmds if c.get("command") == "invalidate_modrole"]
+        assert len(invalidations) == 1
+        assert invalidations[0]["guild_id"] == str(GUILD_ID)
+
+    def test_delete_notifies_bot_to_invalidate_cache(self, client, fake_valkey, auth_header):
+        """DELETE moderator-roles must publish an invalidate_modrole command with null role_id."""
+        import json
+        from unittest.mock import patch
+
+        client.post(
+            f"/api/guilds/{GUILD_ID}/moderator-roles",
+            json={"role_id": "555666777"},
+            headers=auth_header,
+        )
+
+        published = []
+
+        def capture(channel, message):
+            published.append((channel, message))
+
+        with patch.object(fake_valkey._client, "publish", side_effect=capture):
+            response = client.delete(
+                f"/api/guilds/{GUILD_ID}/moderator-roles/555666777",
+                headers=auth_header,
+            )
+
+        assert response.status_code == 204
+        bot_cmds = [json.loads(msg) for ch, msg in published if ch == "nerpybot:cmd"]
+        invalidations = [c for c in bot_cmds if c.get("command") == "invalidate_modrole"]
+        assert len(invalidations) == 1
+        assert invalidations[0]["guild_id"] == str(GUILD_ID)
+
 
 class TestLeaveMessageEndpoints:
     def test_get_default(self, client, auth_header):

--- a/uv.lock
+++ b/uv.lock
@@ -1050,7 +1050,6 @@ test = [
     { name = "ruff" },
 ]
 web = [
-    { name = "cachetools" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "pyjwt" },
@@ -1089,7 +1088,6 @@ test = [
     { name = "ruff", specifier = "==0.15.7" },
 ]
 web = [
-    { name = "cachetools" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "pyjwt" },

--- a/uv.lock
+++ b/uv.lock
@@ -1050,6 +1050,7 @@ test = [
     { name = "ruff" },
 ]
 web = [
+    { name = "cachetools" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "pyjwt" },
@@ -1088,6 +1089,7 @@ test = [
     { name = "ruff", specifier = "==0.15.7" },
 ]
 web = [
+    { name = "cachetools" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "pyjwt" },

--- a/web/cache.py
+++ b/web/cache.py
@@ -134,7 +134,7 @@ class ValkeyClient:
         Failures are logged as errors — callers must not rely on delivery.
         """
         try:
-            message = json.dumps({"command": command, **payload})
+            message = json.dumps({**payload, "command": command})
             self._client.publish(self._key("cmd"), message)
         except Exception as exc:
             _log.error("notify_bot: failed to publish %r: %s", command, exc, exc_info=True)

--- a/web/cache.py
+++ b/web/cache.py
@@ -133,8 +133,6 @@ class ValkeyClient:
 
         Failures are logged as warnings — callers must not rely on delivery.
         """
-        import json
-
         message = json.dumps({"command": command, **payload})
         try:
             self._client.publish(self._key("cmd"), message)

--- a/web/cache.py
+++ b/web/cache.py
@@ -131,13 +131,13 @@ class ValkeyClient:
     def notify_bot(self, command: str, payload: dict) -> None:
         """Publish a fire-and-forget command to the bot (no reply expected).
 
-        Failures are logged as warnings — callers must not rely on delivery.
+        Failures are logged as errors — callers must not rely on delivery.
         """
         message = json.dumps({"command": command, **payload})
         try:
             self._client.publish(self._key("cmd"), message)
         except Exception as exc:
-            _log.error("notify_bot: failed to publish %r: %s", command, exc)
+            _log.error("notify_bot: failed to publish %r: %s", command, exc, exc_info=True)
 
     def push_reply(self, request_id: str, data: dict) -> None:
         """Push a reply to a waiting command (used by bot side)."""

--- a/web/cache.py
+++ b/web/cache.py
@@ -137,7 +137,7 @@ class ValkeyClient:
         try:
             self._client.publish(self._key("cmd"), message)
         except Exception as exc:
-            _log.warning("notify_bot: failed to publish %r: %s", command, exc)
+            _log.error("notify_bot: failed to publish %r: %s", command, exc)
 
     def push_reply(self, request_id: str, data: dict) -> None:
         """Push a reply to a waiting command (used by bot side)."""

--- a/web/cache.py
+++ b/web/cache.py
@@ -133,8 +133,8 @@ class ValkeyClient:
 
         Failures are logged as errors — callers must not rely on delivery.
         """
-        message = json.dumps({"command": command, **payload})
         try:
+            message = json.dumps({"command": command, **payload})
             self._client.publish(self._key("cmd"), message)
         except Exception as exc:
             _log.error("notify_bot: failed to publish %r: %s", command, exc, exc_info=True)

--- a/web/cache.py
+++ b/web/cache.py
@@ -128,6 +128,19 @@ class ValkeyClient:
             _log.warning("Unexpected error waiting for bot command reply: %s", exc)
         return None
 
+    def notify_bot(self, command: str, payload: dict) -> None:
+        """Publish a fire-and-forget command to the bot (no reply expected).
+
+        Failures are logged as warnings — callers must not rely on delivery.
+        """
+        import json
+
+        message = json.dumps({"command": command, **payload})
+        try:
+            self._client.publish(self._key("cmd"), message)
+        except Exception as exc:
+            _log.warning("notify_bot: failed to publish %r: %s", command, exc)
+
     def push_reply(self, request_id: str, data: dict) -> None:
         """Push a reply to a waiting command (used by bot side)."""
         key = self._key("reply", request_id)

--- a/web/dependencies.py
+++ b/web/dependencies.py
@@ -10,6 +10,7 @@ from cachetools import TTLCache
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jwt import PyJWTError as JWTError
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 if TYPE_CHECKING:
@@ -28,8 +29,6 @@ def _get_premium_ids(session: Session) -> set[int]:
     """Return the cached set of premium user IDs, loading from DB on miss."""
     if "ids" in _premium_ids_cache:
         return _premium_ids_cache["ids"]
-    from sqlalchemy.exc import SQLAlchemyError
-
     from models.admin import PremiumUser
 
     try:

--- a/web/dependencies.py
+++ b/web/dependencies.py
@@ -189,7 +189,13 @@ async def require_guild_access(
             if discord_token is not None:
                 try:
                     perms = await _refresh_guild_perms(vk, user["sub"], discord_token)
-                except HTTPException:
+                except HTTPException as exc:
+                    _log.warning(
+                        "require_guild_access: guild perm refresh failed for sub=%s guild_id=%s — degrading to support_mode: %s",
+                        user["sub"],
+                        guild_id,
+                        exc.detail,
+                    )
                     pass  # network/API failure → degrade to support_mode
         if _has_real_perms(perms):
             return user  # real guild permissions — normal access

--- a/web/dependencies.py
+++ b/web/dependencies.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+from cachetools import TTLCache
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jwt import PyJWTError as JWTError
@@ -13,6 +14,28 @@ from sqlalchemy.orm import Session
 if TYPE_CHECKING:
     from web.config import WebConfig
     from web.cache import ValkeyClient
+
+# ── PremiumUser in-process cache ──────────────────────────────────────────────
+# Caches the full set of premium user IDs for 5 minutes.
+# Tiny dataset (single-digit users); changes only on operator grant/revoke.
+_premium_ids_cache: TTLCache = TTLCache(maxsize=1, ttl=300)
+
+
+def _get_premium_ids(session: Session) -> set[int]:
+    """Return the cached set of premium user IDs, loading from DB on miss."""
+    if "ids" in _premium_ids_cache:
+        return _premium_ids_cache["ids"]
+    from models.admin import PremiumUser
+
+    ids = {u.UserId for u in PremiumUser.get_all(session)}
+    _premium_ids_cache["ids"] = ids
+    return ids
+
+
+def invalidate_premium_cache() -> None:
+    """Evict the premium user ID cache. Call after grant/revoke operations."""
+    _premium_ids_cache.clear()
+
 
 _TEST_MODE: bool = os.environ.get("NERPYBOT_TEST_MODE", "").lower() in {"1", "true", "yes", "y", "on"}
 _TEST_USER_ID = "999000000000000000"
@@ -87,9 +110,7 @@ def require_premium(
     user_id = int(user["sub"])
     if user_id in config.ops:
         return user
-    from models.admin import PremiumUser
-
-    if not PremiumUser.has(user_id, session):
+    if user_id not in _get_premium_ids(session):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Premium access required")
     return user
 

--- a/web/dependencies.py
+++ b/web/dependencies.py
@@ -27,8 +27,9 @@ _premium_ids_cache: TTLCache = TTLCache(maxsize=1, ttl=300)
 
 def _get_premium_ids(session: Session) -> set[int]:
     """Return the cached set of premium user IDs, loading from DB on miss."""
-    if "ids" in _premium_ids_cache:
-        return _premium_ids_cache["ids"]
+    ids = _premium_ids_cache.get("ids")
+    if ids is not None:
+        return ids
     from models.admin import PremiumUser
 
     try:

--- a/web/dependencies.py
+++ b/web/dependencies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING
 
@@ -15,6 +16,8 @@ if TYPE_CHECKING:
     from web.config import WebConfig
     from web.cache import ValkeyClient
 
+_log = logging.getLogger(__name__)
+
 # ── PremiumUser in-process cache ──────────────────────────────────────────────
 # Caches the full set of premium user IDs for 5 minutes.
 # Tiny dataset (single-digit users); changes only on operator grant/revoke.
@@ -25,9 +28,15 @@ def _get_premium_ids(session: Session) -> set[int]:
     """Return the cached set of premium user IDs, loading from DB on miss."""
     if "ids" in _premium_ids_cache:
         return _premium_ids_cache["ids"]
+    from sqlalchemy.exc import SQLAlchemyError
+
     from models.admin import PremiumUser
 
-    ids = {u.UserId for u in PremiumUser.get_all(session)}
+    try:
+        ids = {u.UserId for u in PremiumUser.get_all(session)}
+    except SQLAlchemyError:
+        _log.exception("_get_premium_ids: DB read failed")
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service temporarily unavailable")
     _premium_ids_cache["ids"] = ids
     return ids
 

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -9,6 +9,7 @@ import httpx
 from cachetools import TTLCache
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import RedirectResponse
+from sqlalchemy.exc import SQLAlchemyError
 
 from models.admin import BotGuild
 from web.auth.jwt import create_access_token
@@ -27,6 +28,8 @@ from web.dependencies import (
 )
 from web.schemas import GuildSummary, UserInfo
 
+_log = logging.getLogger(__name__)
+
 # Cache for the set of bot guild IDs. TTL of 2 minutes; guild join/leave is rare.
 _bot_guild_ids_cache: TTLCache = TTLCache(maxsize=1, ttl=120)
 
@@ -35,8 +38,6 @@ def _get_bot_guild_ids(session) -> set[str]:
     """Return the cached set of bot guild ID strings, loading from DB on miss."""
     if "ids" in _bot_guild_ids_cache:
         return _bot_guild_ids_cache["ids"]
-    from sqlalchemy.exc import SQLAlchemyError
-
     try:
         ids = BotGuild.get_ids(session)
     except SQLAlchemyError:
@@ -45,8 +46,6 @@ def _get_bot_guild_ids(session) -> set[str]:
     _bot_guild_ids_cache["ids"] = ids
     return ids
 
-
-_log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 _TEST_GUILDS = [

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -36,8 +36,9 @@ _bot_guild_ids_cache: TTLCache = TTLCache(maxsize=1, ttl=120)
 
 def _get_bot_guild_ids(session) -> set[str]:
     """Return the cached set of bot guild ID strings, loading from DB on miss."""
-    if "ids" in _bot_guild_ids_cache:
-        return _bot_guild_ids_cache["ids"]
+    ids = _bot_guild_ids_cache.get("ids")
+    if ids is not None:
+        return ids
     try:
         ids = BotGuild.get_ids(session)
     except SQLAlchemyError:

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -6,6 +6,7 @@ import logging
 import secrets
 
 import httpx
+from cachetools import TTLCache
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import RedirectResponse
 
@@ -15,8 +16,29 @@ from web.auth.oauth2 import build_authorize_url, exchange_code, fetch_discord_us
 from web.auth.permissions import resolve_guild_permissions
 from web.cache import PERM_CACHE_TTL, ValkeyClient
 from web.config import WebConfig
-from web.dependencies import _TEST_MODE, _TEST_USER_ID, get_config, get_current_user, get_db_session, get_valkey
+from web.dependencies import (
+    _TEST_MODE,
+    _TEST_USER_ID,
+    _get_premium_ids,
+    get_config,
+    get_current_user,
+    get_db_session,
+    get_valkey,
+)
 from web.schemas import GuildSummary, UserInfo
+
+# Cache for the set of bot guild IDs. TTL of 2 minutes; guild join/leave is rare.
+_bot_guild_ids_cache: TTLCache = TTLCache(maxsize=1, ttl=120)
+
+
+def _get_bot_guild_ids(session) -> set[str]:
+    """Return the cached set of bot guild ID strings, loading from DB on miss."""
+    if "ids" in _bot_guild_ids_cache:
+        return _bot_guild_ids_cache["ids"]
+    ids = BotGuild.get_ids(session)
+    _bot_guild_ids_cache["ids"] = ids
+    return ids
+
 
 _log = logging.getLogger(__name__)
 
@@ -182,8 +204,8 @@ async def me(
         perms = resolve_guild_permissions(guilds)
         vk.set_permissions(user_id, perms, ttl=PERM_CACHE_TTL)
         _log.debug("/me: rehydrated permissions for %d guilds after cache miss", len(perms))
-    bot_guilds = BotGuild.get_ids(session)
-    _log.debug("/me: bot_guilds from DB has %d entries", len(bot_guilds))
+    bot_guilds = _get_bot_guild_ids(session)
+    _log.debug("/me: bot_guilds (cached) has %d entries", len(bot_guilds))
 
     invite_base = (
         f"https://discord.com/oauth2/authorize"
@@ -206,13 +228,7 @@ async def me(
             )
 
     is_operator = int(user_id) in config.ops
-    is_premium: bool
-    if is_operator:
-        is_premium = True
-    else:
-        from models.admin import PremiumUser
-
-        is_premium = PremiumUser.has(int(user_id), session)
+    is_premium = is_operator or int(user_id) in _get_premium_ids(session)
 
     return UserInfo(
         id=user_id,

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -35,7 +35,13 @@ def _get_bot_guild_ids(session) -> set[str]:
     """Return the cached set of bot guild ID strings, loading from DB on miss."""
     if "ids" in _bot_guild_ids_cache:
         return _bot_guild_ids_cache["ids"]
-    ids = BotGuild.get_ids(session)
+    from sqlalchemy.exc import SQLAlchemyError
+
+    try:
+        ids = BotGuild.get_ids(session)
+    except SQLAlchemyError:
+        _log.exception("_get_bot_guild_ids: DB read failed")
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service temporarily unavailable")
     _bot_guild_ids_cache["ids"] = ids
     return ids
 

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -247,6 +247,11 @@ async def set_leave_message(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Message must contain {member} placeholder for the member name.",
         )
+    if "enabled" in body.model_fields_set and body.enabled is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="enabled cannot be null",
+        )
     from models.leavemsg import LeaveMessage
 
     cfg = LeaveMessage.get(guild_id, session)
@@ -258,11 +263,6 @@ async def set_leave_message(
     if "message" in body.model_fields_set:
         cfg.Message = body.message
     if "enabled" in body.model_fields_set:
-        if body.enabled is None:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="enabled cannot be null",
-            )
         cfg.Enabled = body.enabled
     if cfg.Enabled and cfg.ChannelId is None:
         raise HTTPException(

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -1293,7 +1293,10 @@ async def create_wow_news_config(
     if WowGuildNewsConfig.get_existing(guild_id, name_slug, body.wow_realm_slug, body.region, session):
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Already tracking this WoW guild")
 
-    lang = _get_guild_language_cached(guild_id, session)
+    from models.admin import GuildLanguageConfig
+
+    _lang_cfg = GuildLanguageConfig.get(guild_id, session)
+    lang = _lang_cfg.Language if _lang_cfg is not None else "en"
     cfg = WowGuildNewsConfig(
         GuildId=guild_id,
         ChannelId=int(body.channel_id),

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+from cachetools import TTLCache
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload, selectinload
@@ -56,6 +57,22 @@ from web.schemas import (
 
 _log = logging.getLogger(__name__)
 
+# Cache for per-guild language lookups (web-side only; bot side uses GuildConfigCache).
+# TTL of 5 minutes; guild language changes rarely.
+_guild_lang_cache: TTLCache = TTLCache(maxsize=100, ttl=300)
+
+
+def _get_guild_language_cached(guild_id: int, session) -> str:
+    """Return the guild's configured language, caching the result for 5 minutes."""
+    if guild_id in _guild_lang_cache:
+        return _guild_lang_cache[guild_id]
+    from utils.strings import get_guild_language
+
+    lang = get_guild_language(guild_id, session)
+    _guild_lang_cache[guild_id] = lang
+    return lang
+
+
 router = APIRouter(prefix="/guilds", tags=["guilds"], dependencies=[Depends(require_premium)])
 
 _REDACTED = "[redacted]"
@@ -91,12 +108,8 @@ async def get_language(
     response: Response = None,
 ):
     """Return the configured language for a guild (defaults to 'en')."""
-    from models.admin import GuildLanguageConfig
-
     _set_support_mode_header(user, response)
-    cfg = GuildLanguageConfig.get(guild_id, session)
-    lang = cfg.Language if cfg else "en"
-    return LanguageConfig(guild_id=str(guild_id), language=lang)
+    return LanguageConfig(guild_id=str(guild_id), language=_get_guild_language_cached(guild_id, session))
 
 
 @router.put("/{guild_id}/language", response_model=LanguageConfig)
@@ -116,6 +129,7 @@ async def set_language(
         session.add(cfg)
     else:
         cfg.Language = body.language
+    _guild_lang_cache.pop(guild_id, None)
     return LanguageConfig(guild_id=str(guild_id), language=cfg.Language)
 
 
@@ -1245,14 +1259,13 @@ async def create_wow_news_config(
     """Create a WoW guild news tracker for a Discord guild. Returns 409 if already tracked."""
     _deny_support_write(user)
     from models.wow import WowGuildNewsConfig
-    from utils.strings import get_guild_language
 
     normalized_name = " ".join(body.wow_guild_name.split())
     name_slug = normalized_name.lower().replace(" ", "-")
     if WowGuildNewsConfig.get_existing(guild_id, name_slug, body.wow_realm_slug, body.region, session):
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Already tracking this WoW guild")
 
-    lang = get_guild_language(guild_id, session)
+    lang = _get_guild_language_cached(guild_id, session)
     cfg = WowGuildNewsConfig(
         GuildId=guild_id,
         ChannelId=int(body.channel_id),

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -258,6 +258,11 @@ async def set_leave_message(
     if "message" in body.model_fields_set:
         cfg.Message = body.message
     if "enabled" in body.model_fields_set:
+        if body.enabled is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="enabled cannot be null",
+            )
         cfg.Enabled = body.enabled
     if cfg.Enabled and cfg.ChannelId is None:
         raise HTTPException(

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -1286,6 +1286,7 @@ async def create_wow_news_config(
 ):
     """Create a WoW guild news tracker for a Discord guild. Returns 409 if already tracked."""
     _deny_support_write(user)
+    from models.admin import GuildLanguageConfig
     from models.wow import WowGuildNewsConfig
 
     normalized_name = " ".join(body.wow_guild_name.split())
@@ -1293,10 +1294,8 @@ async def create_wow_news_config(
     if WowGuildNewsConfig.get_existing(guild_id, name_slug, body.wow_realm_slug, body.region, session):
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Already tracking this WoW guild")
 
-    from models.admin import GuildLanguageConfig
-
-    _lang_cfg = GuildLanguageConfig.get(guild_id, session)
-    lang = _lang_cfg.Language if _lang_cfg is not None else "en"
+    lang_cfg = GuildLanguageConfig.get(guild_id, session)
+    lang = lang_cfg.Language if lang_cfg is not None else "en"
     cfg = WowGuildNewsConfig(
         GuildId=guild_id,
         ChannelId=int(body.channel_id),

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -245,6 +245,7 @@ async def set_leave_message(
         cfg.Message = body.message
     if body.enabled is not None:
         cfg.Enabled = body.enabled
+    session.commit()  # commit before notifying bot so it re-reads the updated row
     vk.notify_bot("invalidate_leave_config", {"guild_id": str(guild_id)})
     return LeaveMessageConfig(
         guild_id=str(guild_id),

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -122,6 +122,7 @@ async def set_language(
     body: LanguageUpdate,
     user: dict = Depends(require_guild_access),
     session: Session = Depends(get_db_session),
+    vk: ValkeyClient = Depends(get_valkey),
 ):
     """Set or update the bot language for a guild."""
     _deny_support_write(user)
@@ -136,6 +137,7 @@ async def set_language(
     lang = cfg.Language
     session.commit()
     _guild_lang_cache[guild_id] = lang
+    vk.notify_bot("set_guild_language", {"guild_id": str(guild_id), "language": lang})
     return LanguageConfig(guild_id=str(guild_id), language=lang)
 
 
@@ -251,6 +253,11 @@ async def set_leave_message(
         cfg.Message = body.message
     if body.enabled is not None:
         cfg.Enabled = body.enabled
+    if cfg.Enabled and cfg.ChannelId is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="channel_id is required when leave messages are enabled",
+        )
     session.commit()  # commit before notifying bot so it re-reads the updated row
     vk.notify_bot("invalidate_leave_config", {"guild_id": str(guild_id)})
     return LeaveMessageConfig(
@@ -1280,7 +1287,10 @@ async def create_wow_news_config(
     if WowGuildNewsConfig.get_existing(guild_id, name_slug, body.wow_realm_slug, body.region, session):
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Already tracking this WoW guild")
 
-    lang = _get_guild_language_cached(guild_id, session)
+    from models.admin import GuildLanguageConfig
+
+    _lang_config = GuildLanguageConfig.get(guild_id, session)
+    lang = _lang_config.Language if _lang_config is not None else "en"
     cfg = WowGuildNewsConfig(
         GuildId=guild_id,
         ChannelId=int(body.channel_id),

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -66,9 +66,10 @@ def _get_guild_language_cached(guild_id: int, session) -> str:
     """Return the guild's configured language, caching the result for 5 minutes."""
     if guild_id in _guild_lang_cache:
         return _guild_lang_cache[guild_id]
-    from utils.strings import get_guild_language
+    from models.admin import GuildLanguageConfig
 
-    lang = get_guild_language(guild_id, session)
+    config = GuildLanguageConfig.get(guild_id, session)
+    lang = config.Language if config is not None else "en"
     _guild_lang_cache[guild_id] = lang
     return lang
 

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -130,8 +130,10 @@ async def set_language(
         session.add(cfg)
     else:
         cfg.Language = body.language
-    _guild_lang_cache.pop(guild_id, None)
-    return LanguageConfig(guild_id=str(guild_id), language=cfg.Language)
+    lang = cfg.Language
+    session.commit()
+    _guild_lang_cache[guild_id] = lang
+    return LanguageConfig(guild_id=str(guild_id), language=lang)
 
 
 # ── Moderator Roles ──

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -143,7 +143,7 @@ async def set_language(
     lang = cfg.Language
     session.commit()
     _guild_lang_cache[guild_id] = lang
-    vk.notify_bot("set_guild_language", {"guild_id": str(guild_id), "language": lang})
+    vk.notify_bot("set_guild_language", {"guild_id": guild_id, "language": lang})
     return LanguageConfig(guild_id=str(guild_id), language=lang)
 
 
@@ -184,7 +184,7 @@ async def add_moderator_role(
     else:
         session.add(BotModeratorRole(GuildId=guild_id, RoleId=new_role_id))
     session.commit()
-    vk.notify_bot("invalidate_modrole", {"guild_id": str(guild_id)})
+    vk.notify_bot("invalidate_modrole", {"guild_id": guild_id})
     return {"status": "created"}
 
 
@@ -205,7 +205,7 @@ async def delete_moderator_role(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
     BotModeratorRole.delete(guild_id, session)
     session.commit()
-    vk.notify_bot("invalidate_modrole", {"guild_id": str(guild_id)})
+    vk.notify_bot("invalidate_modrole", {"guild_id": guild_id})
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -265,7 +265,7 @@ async def set_leave_message(
             detail="channel_id is required when leave messages are enabled",
         )
     session.commit()  # commit before notifying bot so it re-reads the updated row
-    vk.notify_bot("invalidate_leave_config", {"guild_id": str(guild_id)})
+    vk.notify_bot("invalidate_leave_config", {"guild_id": guild_id})
     return LeaveMessageConfig(
         guild_id=str(guild_id),
         channel_id=str(cfg.ChannelId) if cfg.ChannelId else None,

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -6,7 +6,7 @@ import logging
 
 from cachetools import TTLCache
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response, status
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from web.cache import ValkeyClient
@@ -67,11 +67,17 @@ _guild_lang_cache: TTLCache = TTLCache(maxsize=100, ttl=300)
 
 def _get_guild_language_cached(guild_id: int, session) -> str:
     """Return the guild's configured language, caching the result for 5 minutes."""
-    if guild_id in _guild_lang_cache:
+    try:
         return _guild_lang_cache[guild_id]
+    except KeyError:
+        pass
     from models.admin import GuildLanguageConfig
 
-    config = GuildLanguageConfig.get(guild_id, session)
+    try:
+        config = GuildLanguageConfig.get(guild_id, session)
+    except SQLAlchemyError:
+        _log.exception("_get_guild_language_cached: DB read failed for guild_id=%d", guild_id)
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service temporarily unavailable")
     lang = config.Language if config is not None else "en"
     _guild_lang_cache[guild_id] = lang
     return lang

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -59,6 +59,9 @@ _log = logging.getLogger(__name__)
 
 # Cache for per-guild language lookups (web-side only; bot side uses GuildConfigCache).
 # TTL of 5 minutes; guild language changes rarely.
+# Cross-process note: this cache is NOT shared with the bot process. If the bot updates
+# the language via /language set, the web process will serve stale data for up to 5 minutes.
+# This is acceptable — language is low-frequency and the TTL is short.
 _guild_lang_cache: TTLCache = TTLCache(maxsize=100, ttl=300)
 
 
@@ -221,6 +224,7 @@ async def set_leave_message(
     body: LeaveMessageUpdate,
     user: dict = Depends(require_guild_access),
     session: Session = Depends(get_db_session),
+    vk: ValkeyClient = Depends(get_valkey),
 ):
     """Create or update the leave message configuration for a guild."""
     _deny_support_write(user)
@@ -241,6 +245,7 @@ async def set_leave_message(
         cfg.Message = body.message
     if body.enabled is not None:
         cfg.Enabled = body.enabled
+    vk.notify_bot("invalidate_leave_config", {"guild_id": str(guild_id)})
     return LeaveMessageConfig(
         guild_id=str(guild_id),
         channel_id=str(cfg.ChannelId) if cfg.ChannelId else None,

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -253,11 +253,11 @@ async def set_leave_message(
     if cfg is None:
         cfg = LeaveMessage(GuildId=guild_id)
         session.add(cfg)
-    if body.channel_id is not None:
-        cfg.ChannelId = int(body.channel_id)
-    if body.message is not None:
+    if "channel_id" in body.model_fields_set:
+        cfg.ChannelId = int(body.channel_id) if body.channel_id is not None else None
+    if "message" in body.model_fields_set:
         cfg.Message = body.message
-    if body.enabled is not None:
+    if "enabled" in body.model_fields_set:
         cfg.Enabled = body.enabled
     if cfg.Enabled and cfg.ChannelId is None:
         raise HTTPException(

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -163,17 +163,20 @@ async def add_moderator_role(
     body: ModeratorRoleCreate,
     user: dict = Depends(require_guild_access),
     session: Session = Depends(get_db_session),
+    vk: ValkeyClient = Depends(get_valkey),
 ):
     """Set or replace the moderator role for a guild."""
     _deny_support_write(user)
     from models.admin import BotModeratorRole
 
+    new_role_id = int(body.role_id)
     existing = BotModeratorRole.get(guild_id, session)
     if existing:
-        existing.RoleId = int(body.role_id)
+        existing.RoleId = new_role_id
     else:
-        role = BotModeratorRole(GuildId=guild_id, RoleId=int(body.role_id))
-        session.add(role)
+        session.add(BotModeratorRole(GuildId=guild_id, RoleId=new_role_id))
+    session.commit()
+    vk.notify_bot("invalidate_modrole", {"guild_id": str(guild_id)})
     return {"status": "created"}
 
 
@@ -183,6 +186,7 @@ async def delete_moderator_role(
     role_id: int,
     user: dict = Depends(require_guild_access),
     session: Session = Depends(get_db_session),
+    vk: ValkeyClient = Depends(get_valkey),
 ):
     """Remove the moderator role for a guild. Returns 404 if the role is not configured."""
     _deny_support_write(user)
@@ -192,6 +196,8 @@ async def delete_moderator_role(
     if existing is None or existing.RoleId != role_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
     BotModeratorRole.delete(guild_id, session)
+    session.commit()
+    vk.notify_bot("invalidate_modrole", {"guild_id": str(guild_id)})
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -1293,10 +1293,7 @@ async def create_wow_news_config(
     if WowGuildNewsConfig.get_existing(guild_id, name_slug, body.wow_realm_slug, body.region, session):
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Already tracking this WoW guild")
 
-    from models.admin import GuildLanguageConfig
-
-    _lang_config = GuildLanguageConfig.get(guild_id, session)
-    lang = _lang_config.Language if _lang_config is not None else "en"
+    lang = _get_guild_language_cached(guild_id, session)
     cfg = WowGuildNewsConfig(
         GuildId=guild_id,
         ChannelId=int(body.channel_id),

--- a/web/routes/guilds.py
+++ b/web/routes/guilds.py
@@ -261,7 +261,7 @@ async def set_leave_message(
         cfg.Enabled = body.enabled
     if cfg.Enabled and cfg.ChannelId is None:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="channel_id is required when leave messages are enabled",
         )
     session.commit()  # commit before notifying bot so it re-reads the updated row

--- a/web/routes/operator.py
+++ b/web/routes/operator.py
@@ -96,6 +96,7 @@ async def grant_premium(
             status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY, detail="user_id must be a valid integer"
         )
     entry = PremiumUser.grant(target_user_id, int(user["sub"]), session)
+    session.commit()  # commit before cache eviction so refills see the new row
     invalidate_premium_cache()
     return _premium_to_schema(entry)
 
@@ -111,6 +112,7 @@ async def revoke_premium(
 
     if not PremiumUser.revoke(user_id, session):
         raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail="User not found in premium list")
+    session.commit()  # commit before cache eviction so refills see the updated rows
     invalidate_premium_cache()
 
 

--- a/web/routes/operator.py
+++ b/web/routes/operator.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends
 from fastapi import HTTPException, status as http_status
 from sqlalchemy.orm import Session
 
-from web.dependencies import get_db_session, get_valkey, require_operator
+from web.dependencies import get_db_session, get_valkey, invalidate_premium_cache, require_operator
 from web.schemas import (
     BotGuildInfo,
     BotGuildListResponse,
@@ -96,6 +96,7 @@ async def grant_premium(
             status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY, detail="user_id must be a valid integer"
         )
     entry = PremiumUser.grant(target_user_id, int(user["sub"]), session)
+    invalidate_premium_cache()
     return _premium_to_schema(entry)
 
 
@@ -110,6 +111,7 @@ async def revoke_premium(
 
     if not PremiumUser.revoke(user_id, session):
         raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail="User not found in premium list")
+    invalidate_premium_cache()
 
 
 # ── Bot health and modules ──


### PR DESCRIPTION
## Summary

Extends the existing `GuildConfigCache` pattern and adds TTL-based caches across bot and web to eliminate redundant DB round-trips on hot paths.

### Bot side

- **Reaction role mappings** — `GuildConfigCache` now holds the full `message_id → {emoji: role_id}` mapping. `_get_role_for_reaction()` hits the cache first; DB is only consulted on a true miss, and the result is backfilled. Admin commands (`_reactionrole_add/remove`) keep the cache in sync.
- **Leave message config** — Removed the redundant `_leave_guild_ids` set; `_leave_configs` dict (`guild_id → (channel_id, message)`) is the single source of truth. `on_member_remove` reads directly from the cache — no DB session opened for the happy path.
- **Crafting recipe queries** — `_cache_recipe_query` decorator wraps all 16 read-only `CraftingRecipeCache` classmethods with a 1-hour `TTLCache`. Cache is explicitly cleared after each recipe sync in `blizzard.py`.
- **Autocomplete handlers** — Shared `TTLCache(maxsize=500, ttl=30)` via `cached_autocomplete()` helper applied to all 6 autocomplete methods across `roles`, `tagging`, `application`, and `music` modules.

### Web side

- **Premium user checks** — `require_premium` and `/me` use a 5-minute TTL cache for the premium user ID set; cleared explicitly on grant/revoke in `operator.py`.
- **Bot guild IDs** — `/me` caches `BotGuild.get_ids()` with a 2-minute TTL instead of a full table scan on every auth check.
- **Guild language** — The single `strings.get_guild_language()` call in `guilds.py` is wrapped in a 5-minute TTL cache.

### Test isolation

Added autouse fixtures to clear all module-level caches between tests (bot: `tests/conftest.py`, models: `tests/models/conftest.py`, web: `tests/web/conftest.py`).

## Test plan

- [ ] `uv run python -m pytest` — all 1111 tests pass
- [ ] `uv run ruff check` — no lint errors
- [ ] Reaction roles: add a reaction role, react to message, verify role assignment
- [ ] Leave messages: enable leave message, member leaves, verify message sent
- [ ] Crafting orders: open wizard, click through selections, verify no regressions
- [ ] Dashboard: log in as premium user, verify guild access still works

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * /playlist now guild-only; in-process caches added for recipes, autocompletes, premium status, guild language, reaction-roles, modroles, and leave-message configs.

* **Performance Improvements**
  * Fewer database queries via cached autocompletes and guild-level caches with targeted invalidation.

* **Reliability / Bug Fixes**
  * Better DB-error handling, stricter logging, conservative cache rewarm/eviction, and hidden replies for moderation leave-message commands.

* **Tests**
  * New and expanded tests plus autouse fixtures to validate cache behavior, invalidation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->