### PR TITLE
perf(application): migrate votes lazy=subquery to selectinload at call sites

### DIFF
--- a/NerdyPy/models/application.py
+++ b/NerdyPy/models/application.py
@@ -213,25 +213,25 @@ class ApplicationSubmission(db.BASE):
         "ApplicationVote",
         back_populates="submission",
         cascade="all, delete, delete-orphan",
-        lazy="subquery",
+        lazy="select",
     )
 
     @classmethod
     def get_by_id(cls, submission_id, session):
-        """Returns a submission by its primary key."""
-        return session.query(cls).filter(cls.Id == submission_id).first()
+        """Returns a submission by its primary key, with votes eager-loaded."""
+        return session.query(cls).options(selectinload(cls.votes)).filter(cls.Id == submission_id).first()
 
     @classmethod
     def get_by_review_message(cls, message_id, session):
-        """Returns a submission by its review message ID."""
-        return session.query(cls).filter(cls.ReviewMessageId == message_id).first()
+        """Returns a submission by its review message ID, with votes eager-loaded."""
+        return session.query(cls).options(selectinload(cls.votes)).filter(cls.ReviewMessageId == message_id).first()
 
     @classmethod
     def get_by_guild(cls, guild_id, session):
-        """Returns all submissions for a guild, with the form relationship eager-loaded."""
+        """Returns all submissions for a guild, with form and votes eager-loaded."""
         return (
             session.query(cls)
-            .options(selectinload(cls.form).lazyload(ApplicationForm.questions))
+            .options(selectinload(cls.form).lazyload(ApplicationForm.questions), selectinload(cls.votes))
             .filter(cls.GuildId == guild_id)
             .all()
         )

--- a/tests/models/test_application.py
+++ b/tests/models/test_application.py
@@ -14,6 +14,7 @@ from models.application import (
     ApplicationSubmission,
     ApplicationTemplate,
     ApplicationVote,
+    VoteType,
     seed_built_in_templates,
 )
 
@@ -130,7 +131,7 @@ class TestCascadeDeletes:
         db_session.add(sub)
         db_session.commit()
 
-        vote = ApplicationVote(SubmissionId=sub.Id, UserId=99, Vote="approve")
+        vote = ApplicationVote(SubmissionId=sub.Id, UserId=99, Vote=VoteType.APPROVE)
         db_session.add(vote)
         db_session.commit()
         vote_id = vote.Id
@@ -162,7 +163,7 @@ class TestCascadeDeletes:
         db_session.commit()
 
         ans = ApplicationAnswer(SubmissionId=sub.Id, QuestionId=q.Id, AnswerText="A!")
-        vote = ApplicationVote(SubmissionId=sub.Id, UserId=99, Vote="approve")
+        vote = ApplicationVote(SubmissionId=sub.Id, UserId=99, Vote=VoteType.APPROVE)
         db_session.add_all([ans, vote])
         db_session.commit()
 
@@ -174,6 +175,95 @@ class TestCascadeDeletes:
         assert db_session.query(ApplicationQuestion).filter(ApplicationQuestion.Id == q_id).first() is None
         assert db_session.query(ApplicationAnswer).filter(ApplicationAnswer.Id == ans_id).first() is None
         assert db_session.query(ApplicationVote).filter(ApplicationVote.Id == vote_id).first() is None
+
+
+# ---------------------------------------------------------------------------
+# ApplicationSubmission — votes eager-loading contract
+# ---------------------------------------------------------------------------
+class TestApplicationSubmissionVotesEagerLoading:
+    """Verify votes are accessible after session detachment (selectinload contract).
+
+    Each test loads a submission via a query classmethod, then calls expunge_all()
+    to detach all objects from the session.  Accessing .votes on a detached object
+    raises DetachedInstanceError if the collection was not eager-loaded — so a
+    passing test proves selectinload fired correctly.
+    """
+
+    def _make_submission_with_votes(self, db_session, *, review_message_id=None, guild_id=111):
+        form = ApplicationForm(GuildId=guild_id, Name=f"EagerForm-{guild_id}")
+        db_session.add(form)
+        db_session.flush()
+        sub = ApplicationSubmission(
+            FormId=form.Id,
+            GuildId=guild_id,
+            UserId=1,
+            UserName="Tester",
+            Status="pending",
+            SubmittedAt=datetime.now(UTC),
+            ReviewMessageId=review_message_id,
+        )
+        db_session.add(sub)
+        db_session.flush()
+        db_session.add(ApplicationVote(SubmissionId=sub.Id, UserId=10, Vote=VoteType.APPROVE))
+        db_session.add(ApplicationVote(SubmissionId=sub.Id, UserId=20, Vote=VoteType.DENY))
+        db_session.commit()
+        return sub
+
+    def test_get_by_id_votes_accessible_after_detach(self, db_session):
+        sub = self._make_submission_with_votes(db_session)
+        result = ApplicationSubmission.get_by_id(sub.Id, db_session)
+        db_session.expunge_all()
+        assert len(result.votes) == 2
+
+    def test_get_by_review_message_votes_accessible_after_detach(self, db_session):
+        self._make_submission_with_votes(db_session, review_message_id=999)
+        result = ApplicationSubmission.get_by_review_message(999, db_session)
+        db_session.expunge_all()
+        assert len(result.votes) == 2
+
+    def test_get_by_guild_votes_accessible_after_detach(self, db_session):
+        self._make_submission_with_votes(db_session, guild_id=333)
+        results = ApplicationSubmission.get_by_guild(333, db_session)
+        assert len(results) == 1
+        db_session.expunge_all()
+        assert len(results[0].votes) == 2
+
+    def test_get_by_guild_votes_scoped_per_submission(self, db_session):
+        """Votes from one submission must not appear on another after detach."""
+        form = ApplicationForm(GuildId=444, Name="EagerForm-444")
+        db_session.add(form)
+        db_session.flush()
+
+        sub_a = ApplicationSubmission(
+            FormId=form.Id,
+            GuildId=444,
+            UserId=1,
+            UserName="A",
+            Status="pending",
+            SubmittedAt=datetime.now(UTC),
+        )
+        sub_b = ApplicationSubmission(
+            FormId=form.Id,
+            GuildId=444,
+            UserId=2,
+            UserName="B",
+            Status="pending",
+            SubmittedAt=datetime.now(UTC),
+        )
+        db_session.add_all([sub_a, sub_b])
+        db_session.flush()
+
+        db_session.add(ApplicationVote(SubmissionId=sub_a.Id, UserId=10, Vote=VoteType.APPROVE))
+        db_session.add(ApplicationVote(SubmissionId=sub_b.Id, UserId=20, Vote=VoteType.DENY))
+        db_session.add(ApplicationVote(SubmissionId=sub_b.Id, UserId=30, Vote=VoteType.DENY))
+        db_session.commit()
+
+        results = ApplicationSubmission.get_by_guild(444, db_session)
+        by_user = {r.UserId: r for r in results}
+        db_session.expunge_all()
+
+        assert len(by_user[1].votes) == 1
+        assert len(by_user[2].votes) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Switch `ApplicationSubmission.votes` from `lazy="subquery"` to `lazy="select"` — votes are no longer automatically loaded on every submission query
- Add explicit `selectinload(votes)` to `get_by_id`, `get_by_review_message`, and `get_by_guild` — the three methods whose callers render vote counts
- Sites that never touch `.votes` (`_record_first_vote`, `_record_edit_vote`, `OverrideModal`, `get_by_user_and_form`) no longer load the collection

## Test plan

- [ ] Existing 1112 tests pass
- [ ] New `TestApplicationSubmissionVotesEagerLoading` class (4 tests) verifies votes are accessible after `expunge_all()` — would raise `DetachedInstanceError` if `selectinload` were ever dropped
- [ ] Pre-existing `Vote="approve"` string literals in cascade tests migrated to `VoteType.APPROVE`

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized application submission queries to load votes more efficiently, reducing redundant database calls and improving performance.

* **Tests**
  * Added test coverage to validate that votes are properly loaded when retrieving application submissions through various query methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->