### PR TITLE
fix(ci): add push-to-main trigger to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,8 @@
 name: CodeQL
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled, ready_for_review]
@@ -9,7 +11,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'review')
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'review')
 
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

- Adds a `push: branches: [main]` trigger to the CodeQL workflow so GitHub can establish a baseline scan on `main` after every merge
- Updates the job `if` condition to always run on `push` events, while keeping the `review`-label gate for PRs
- Fixes the recurring "1 configuration not found" warning on PR code scanning diff analysis

## Why this was needed

GitHub's PR diff analysis compares CodeQL alerts found on the PR branch against a baseline from the target branch (`main`). Without a push trigger, no baseline scan ever ran on `main`, so GitHub had nothing to compare against and reported "configuration not found" on every labeled PR.

## Test plan

- [ ] Merge this PR — verify a CodeQL run triggers on `main`
- [ ] Open a new labeled PR — verify the "configuration not found" warning is gone and alerts are diffed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)