### PR TITLE
perf(operator): parallelize guild syncs in !sync command

### DIFF
--- a/NerdyPy/modules/operator.py
+++ b/NerdyPy/modules/operator.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import asyncio
 import logging
 from datetime import UTC, datetime
 from importlib.metadata import version as pkg_version
@@ -185,17 +186,24 @@ class Operator(NerpyBotCog, Cog):
             await ctx.send(f"Synced {len(synced)} commands {'globally' if spec is None else 'to the current guild.'}")
             return
 
-        ret = 0
-        for guild in guilds:
+        async def _sync_one(g):
             try:
-                await self.bot.tree.sync(guild=guild)
+                await self.bot.tree.sync(guild=g)
+                return True
             except HTTPException:
-                pass
+                return False
             except (CommandSyncFailure, Forbidden, MissingApplicationID, TranslationError) as ex:
                 self.bot.log.debug(ex)
                 raise NerpyInfraException("Could not sync commands to Discord API.")
-            else:
-                ret += 1
+
+        results = await asyncio.gather(*(_sync_one(g) for g in guilds), return_exceptions=True)
+        ret = sum(1 for r in results if r is True)
+
+        for r in results:
+            if isinstance(r, NerpyInfraException):
+                raise r
+            if isinstance(r, BaseException):
+                raise NerpyInfraException("Could not sync commands to Discord API.") from r
 
         await ctx.send(f"Synced the tree to {ret}/{len(guilds)}.")
 

--- a/NerdyPy/modules/operator.py
+++ b/NerdyPy/modules/operator.py
@@ -202,7 +202,7 @@ class Operator(NerpyBotCog, Cog):
         for r in results:
             if isinstance(r, NerpyInfraException):
                 raise r
-            if isinstance(r, BaseException):
+            elif isinstance(r, BaseException):
                 raise NerpyInfraException("Could not sync commands to Discord API.") from r
 
         await ctx.send(f"Synced the tree to {ret}/{len(guilds)}.")

--- a/NerdyPy/modules/operator.py
+++ b/NerdyPy/modules/operator.py
@@ -190,11 +190,11 @@ class Operator(NerpyBotCog, Cog):
             try:
                 await self.bot.tree.sync(guild=g)
                 return True
-            except HTTPException:
-                return False
             except (CommandSyncFailure, Forbidden, MissingApplicationID, TranslationError) as ex:
                 self.bot.log.debug(ex)
                 raise NerpyInfraException("Could not sync commands to Discord API.") from ex
+            except HTTPException:
+                return False
 
         results = await asyncio.gather(*(_sync_one(g) for g in guilds), return_exceptions=True)
         ret = sum(1 for r in results if r is True)

--- a/NerdyPy/modules/operator.py
+++ b/NerdyPy/modules/operator.py
@@ -202,8 +202,10 @@ class Operator(NerpyBotCog, Cog):
         for r in results:
             if isinstance(r, NerpyInfraException):
                 raise r
-            elif isinstance(r, BaseException):
+            elif isinstance(r, Exception):
                 raise NerpyInfraException("Could not sync commands to Discord API.") from r
+            elif isinstance(r, BaseException):
+                raise r
 
         await ctx.send(f"Synced the tree to {ret}/{len(guilds)}.")
 

--- a/NerdyPy/modules/operator.py
+++ b/NerdyPy/modules/operator.py
@@ -194,7 +194,7 @@ class Operator(NerpyBotCog, Cog):
                 return False
             except (CommandSyncFailure, Forbidden, MissingApplicationID, TranslationError) as ex:
                 self.bot.log.debug(ex)
-                raise NerpyInfraException("Could not sync commands to Discord API.")
+                raise NerpyInfraException("Could not sync commands to Discord API.") from ex
 
         results = await asyncio.gather(*(_sync_one(g) for g in guilds), return_exceptions=True)
         ret = sum(1 for r in results if r is True)

--- a/tests/modules/test_operator.py
+++ b/tests/modules/test_operator.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for Operator cog: botpermissions, !disable/!enable/!disabled/!help/!errors commands."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -452,6 +453,30 @@ class TestSyncGuilds:
 
         with pytest.raises(NerpyInfraException):
             await cog.sync.callback(cog, operator_ctx, guilds=guilds, spec=None)
+
+    @pytest.mark.asyncio
+    async def test_guild_syncs_run_concurrently(self, cog, operator_ctx):
+        # Proves asyncio.gather runs all coroutines in parallel: none can
+        # complete until all have started, because each waits on a shared event.
+        started = set()
+        release = asyncio.Event()
+        all_started = asyncio.Event()
+
+        async def side_effect(guild):
+            started.add(guild.id)
+            if len(started) == 3:
+                all_started.set()
+            await release.wait()
+            return []
+
+        cog.bot.tree.sync = side_effect
+        guilds = self._make_guilds(1, 2, 3)
+
+        task = asyncio.create_task(cog.sync.callback(cog, operator_ctx, guilds=guilds, spec=None))
+        await all_started.wait()
+        assert started == {1, 2, 3}
+        release.set()
+        await task
 
     @pytest.mark.asyncio
     async def test_single_guild_succeeds(self, cog, operator_ctx):

--- a/tests/modules/test_operator.py
+++ b/tests/modules/test_operator.py
@@ -458,12 +458,12 @@ class TestSyncGuilds:
     async def test_guild_syncs_run_concurrently(self, cog, operator_ctx):
         # Proves asyncio.gather runs all coroutines in parallel: none can
         # complete until all have started, because each waits on a shared event.
-        started = set()
+        started = []
         release = asyncio.Event()
         all_started = asyncio.Event()
 
         async def side_effect(guild):
-            started.add(guild.id)
+            started.append(guild.id)
             if len(started) == 3:
                 all_started.set()
             await release.wait()
@@ -473,8 +473,8 @@ class TestSyncGuilds:
         guilds = self._make_guilds(1, 2, 3)
 
         task = asyncio.create_task(cog.sync.callback(cog, operator_ctx, guilds=guilds, spec=None))
-        await all_started.wait()
-        assert started == {1, 2, 3}
+        await asyncio.wait_for(all_started.wait(), timeout=1.0)
+        assert sorted(started) == [1, 2, 3]
         release.set()
         await task
 

--- a/tests/modules/test_operator.py
+++ b/tests/modules/test_operator.py
@@ -4,8 +4,11 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from discord import HTTPException, Object
+from discord.app_commands import MissingApplicationID
 from models.admin import PermissionSubscriber
 from modules.operator import Operator, _format_remaining
+from utils.errors import NerpyInfraException
 from utils.strings import load_strings
 
 
@@ -359,6 +362,85 @@ class TestErrorsUnknownAction:
         await cog._errors.callback(cog, operator_ctx, action="foobar")
         msg = operator_ctx.send.call_args[0][0]
         assert "Unknown action" in msg
+
+
+# ---------------------------------------------------------------------------
+# !sync (multi-guild path)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncGuilds:
+    def _make_guilds(self, *ids):
+        return [Object(id=i) for i in ids]
+
+    @pytest.mark.asyncio
+    async def test_all_guilds_succeed(self, cog, operator_ctx):
+        cog.bot.tree.sync = AsyncMock(return_value=[])
+        guilds = self._make_guilds(1, 2, 3)
+
+        await cog.sync.callback(cog, operator_ctx, guilds=guilds, spec=None)
+
+        msg = operator_ctx.send.call_args[0][0]
+        assert "3/3" in msg
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_http_exception(self, cog, operator_ctx):
+        http_err = HTTPException(MagicMock(status=429), "rate limited")
+
+        async def side_effect(guild):
+            if guild.id == 2:
+                raise http_err
+            return []
+
+        cog.bot.tree.sync = side_effect
+        guilds = self._make_guilds(1, 2, 3)
+
+        await cog.sync.callback(cog, operator_ctx, guilds=guilds, spec=None)
+
+        msg = operator_ctx.send.call_args[0][0]
+        assert "2/3" in msg
+
+    @pytest.mark.asyncio
+    async def test_hard_error_raises_infra_exception_after_all_complete(self, cog, operator_ctx):
+        sync_calls = []
+
+        async def side_effect(guild):
+            sync_calls.append(guild)
+            if guild.id == 2:
+                raise MissingApplicationID("boom")
+            return []
+
+        cog.bot.tree.sync = side_effect
+        guilds = self._make_guilds(1, 2, 3)
+
+        with pytest.raises(NerpyInfraException):
+            await cog.sync.callback(cog, operator_ctx, guilds=guilds, spec=None)
+
+        # All three guilds must have been attempted before the exception propagated
+        assert len(sync_calls) == 3
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_raises_infra_exception(self, cog, operator_ctx):
+        async def side_effect(guild):
+            if guild.id == 2:
+                raise RuntimeError("unexpected")
+            return []
+
+        cog.bot.tree.sync = side_effect
+        guilds = self._make_guilds(1, 2, 3)
+
+        with pytest.raises(NerpyInfraException):
+            await cog.sync.callback(cog, operator_ctx, guilds=guilds, spec=None)
+
+    @pytest.mark.asyncio
+    async def test_single_guild_succeeds(self, cog, operator_ctx):
+        cog.bot.tree.sync = AsyncMock(return_value=[])
+        guilds = self._make_guilds(42)
+
+        await cog.sync.callback(cog, operator_ctx, guilds=guilds, spec=None)
+
+        msg = operator_ctx.send.call_args[0][0]
+        assert "1/1" in msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/modules/test_operator.py
+++ b/tests/modules/test_operator.py
@@ -416,12 +416,14 @@ class TestSyncGuilds:
         with pytest.raises(NerpyInfraException):
             await cog.sync.callback(cog, operator_ctx, guilds=guilds, spec=None)
 
-        # All three guilds must have been attempted before the exception propagated
-        assert len(sync_calls) == 3
+        assert {g.id for g in sync_calls} == {1, 2, 3}
 
     @pytest.mark.asyncio
     async def test_unexpected_exception_raises_infra_exception(self, cog, operator_ctx):
+        sync_calls = []
+
         async def side_effect(guild):
+            sync_calls.append(guild)
             if guild.id == 2:
                 raise RuntimeError("unexpected")
             return []
@@ -431,6 +433,8 @@ class TestSyncGuilds:
 
         with pytest.raises(NerpyInfraException):
             await cog.sync.callback(cog, operator_ctx, guilds=guilds, spec=None)
+
+        assert {g.id for g in sync_calls} == {1, 2, 3}
 
     @pytest.mark.asyncio
     async def test_forbidden_is_hard_error_not_soft_failure(self, cog, operator_ctx):

--- a/tests/modules/test_operator.py
+++ b/tests/modules/test_operator.py
@@ -4,7 +4,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from discord import HTTPException, Object
+from discord import Forbidden, HTTPException, Object
 from discord.app_commands import MissingApplicationID
 from models.admin import PermissionSubscriber
 from modules.operator import Operator, _format_remaining
@@ -424,6 +424,23 @@ class TestSyncGuilds:
         async def side_effect(guild):
             if guild.id == 2:
                 raise RuntimeError("unexpected")
+            return []
+
+        cog.bot.tree.sync = side_effect
+        guilds = self._make_guilds(1, 2, 3)
+
+        with pytest.raises(NerpyInfraException):
+            await cog.sync.callback(cog, operator_ctx, guilds=guilds, spec=None)
+
+    @pytest.mark.asyncio
+    async def test_forbidden_is_hard_error_not_soft_failure(self, cog, operator_ctx):
+        # Forbidden is a subclass of HTTPException; must be caught by the specific
+        # handler first, not the broad HTTPException fallback.
+        forbidden_err = Forbidden(MagicMock(status=403), "missing permissions")
+
+        async def side_effect(guild):
+            if guild.id == 2:
+                raise forbidden_err
             return []
 
         cog.bot.tree.sync = side_effect


### PR DESCRIPTION
Closes #356.

The multi-guild path of `!sync` was sequential — each `tree.sync(guild=guild)` round-trip blocked the next. Since Discord enforces rate limits per-guild independently, there's no reason to wait. This replaces the loop with `asyncio.gather(..., return_exceptions=True)` so all guilds are attempted concurrently.

Error handling adapts accordingly: `HTTPException` per guild still counts as a soft failure (excluded from the success count), hard Discord errors still raise `NerpyInfraException`, and any unexpected exception escaping the closure is now wrapped rather than silently swallowed — a gap that only became visible with `return_exceptions=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Multi-guild command sync now runs per-guild concurrently, reporting accurate per-guild success counts; HTTP errors count as partial failures while sync-related/fatal errors are surfaced as infrastructure-level errors.

* **Tests**
  * Added tests for full success, partial HTTP failures, fatal error propagation, unexpected exceptions, single-guild reporting, and verification of concurrent execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->