### PR TITLE
fix+refactor: housekeeping bundle (#409, #419, #426, #427)

### DIFF
--- a/NerdyPy/modules/conversations/application.py
+++ b/NerdyPy/modules/conversations/application.py
@@ -12,6 +12,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from functools import partial
 
+from sqlalchemy import update
+
 import discord
 from discord import Embed
 
@@ -878,13 +880,7 @@ class ApplicationSubmitConversation(Conversation):
                         exc,
                     )
                     await self._notify_responsible(review_channel_id)
-                    _c = "application.conversation.submit"
-                    emb = Embed(
-                        title=get_string(self.lang, f"{_c}.error_title"),
-                        description=get_string(self.lang, f"{_c}.error_description"),
-                    )
-                    await self.send_ns(emb)
-                    await self.close()
+                    await self._abort_with_submit_error()
                     return
 
         # Channel is accessible — save the submission and answers.
@@ -930,17 +926,21 @@ class ApplicationSubmitConversation(Conversation):
                         mention_ids.add(gr.RoleId)
                     submission_user_name = submission.UserName
 
-            if embed is not None:
-                view = ApplicationReviewView(bot=self.bot, lang=self.lang)
-                _normalize_review_view(
-                    view,
-                    total_pages=total_pages,
-                    current_page=1,
-                    status=SubmissionStatus.PENDING,
-                    applicant_notified=False,
-                )
-                mention_content = " ".join(f"<@&{rid}>" for rid in sorted(mention_ids)) or None
+            if embed is None:
+                await self._abort_with_submit_error()
+                return
 
+            view = ApplicationReviewView(bot=self.bot, lang=self.lang)
+            _normalize_review_view(
+                view,
+                total_pages=total_pages,
+                current_page=1,
+                status=SubmissionStatus.PENDING,
+                applicant_notified=False,
+            )
+            mention_content = " ".join(f"<@&{rid}>" for rid in sorted(mention_ids)) or None
+
+            try:
                 msg = await channel.send(embed=embed, view=view)
 
                 thread_name = submission_user_name or get_string(
@@ -952,21 +952,43 @@ class ApplicationSubmitConversation(Conversation):
                         await thread.send(mention_content)
                 except discord.HTTPException:
                     self.bot.log.warning("application: failed to create review thread for msg %d", msg.id)
+            except discord.HTTPException as exc:
+                self.bot.log.error(
+                    "application: failed to post review embed to channel %d: %s",
+                    review_channel_id,
+                    exc,
+                )
+                await self._abort_with_submit_error()
+                return
 
-                with self.bot.session_scope() as session:
-                    submission = ApplicationSubmission.get_by_id(self.submission_id, session)
-                    if submission is not None:
-                        submission.ReviewMessageId = msg.id
-                    else:
-                        self.bot.log.warning(
-                            "application: submission %d deleted before ReviewMessageId could be persisted",
-                            self.submission_id,
-                        )
+            rows_updated = 0
+            with self.bot.session_scope() as session:
+                rows_updated = session.execute(
+                    update(ApplicationSubmission)
+                    .where(ApplicationSubmission.Id == self.submission_id)
+                    .values(ReviewMessageId=msg.id)
+                ).rowcount
+
+            if rows_updated == 0:
+                self.bot.log.warning(
+                    "application: submission %d deleted before ReviewMessageId could be persisted",
+                    self.submission_id,
+                )
+                await self._abort_with_submit_error()
+                return
 
         _c = "application.conversation.submit"
         emb = Embed(
             title=get_string(self.lang, f"{_c}.submitted_title"),
             description=get_string(self.lang, f"{_c}.submitted_description"),
+        )
+        await self.send_ns(emb)
+        await self.close()
+
+    async def _abort_with_submit_error(self) -> None:
+        emb = Embed(
+            title=get_string(self.lang, "application.conversation.submit.error_title"),
+            description=get_string(self.lang, "application.conversation.submit.error_description"),
         )
         await self.send_ns(emb)
         await self.close()

--- a/NerdyPy/modules/conversations/application.py
+++ b/NerdyPy/modules/conversations/application.py
@@ -906,49 +906,62 @@ class ApplicationSubmitConversation(Conversation):
 
         # Post review embed to the review channel.
         if channel is not None:
+            embed = None
+            total_pages = 1
+            mention_ids: set[int] = set()
+            submission_user_name = None
             with self.bot.session_scope() as session:
                 submission = ApplicationSubmission.get_by_id(self.submission_id, session)
-                form = ApplicationForm.get_by_id(self.form_id, session)
-                lang = self.lang
-                all_answers = _extract_answers(submission.answers)
-                total_pages = max(1, math.ceil(len(all_answers) / _ANSWERS_PER_PAGE))
-                embed = build_review_embed(submission, form, session, lang, answers=all_answers)
-                # Collect role IDs to mention: non-managed admin roles + all configured manager/reviewer roles
-                mention_ids: set[int] = {
-                    r.id for r in self.guild.roles if r.permissions.administrator and not r.managed
-                }
-                guild_roles = (
-                    session.query(ApplicationGuildRole).filter(ApplicationGuildRole.GuildId == self.guild.id).all()
+                if submission is None:
+                    self.bot.log.warning(
+                        "application: submission %d vanished before review embed could be posted", self.submission_id
+                    )
+                else:
+                    form = ApplicationForm.get_by_id(self.form_id, session)
+                    lang = self.lang
+                    all_answers = _extract_answers(submission.answers)
+                    total_pages = max(1, math.ceil(len(all_answers) / _ANSWERS_PER_PAGE))
+                    embed = build_review_embed(submission, form, session, lang, answers=all_answers)
+                    mention_ids = {r.id for r in self.guild.roles if r.permissions.administrator and not r.managed}
+                    guild_roles = (
+                        session.query(ApplicationGuildRole).filter(ApplicationGuildRole.GuildId == self.guild.id).all()
+                    )
+                    for gr in guild_roles:
+                        mention_ids.add(gr.RoleId)
+                    submission_user_name = submission.UserName
+
+            if embed is not None:
+                view = ApplicationReviewView(bot=self.bot, lang=self.lang)
+                _normalize_review_view(
+                    view,
+                    total_pages=total_pages,
+                    current_page=1,
+                    status=SubmissionStatus.PENDING,
+                    applicant_notified=False,
                 )
-                for gr in guild_roles:
-                    mention_ids.add(gr.RoleId)
-                submission_user_name = submission.UserName
+                mention_content = " ".join(f"<@&{rid}>" for rid in sorted(mention_ids)) or None
 
-            view = ApplicationReviewView(bot=self.bot, lang=self.lang)
-            _normalize_review_view(
-                view,
-                total_pages=total_pages,
-                current_page=1,
-                status=SubmissionStatus.PENDING,
-                applicant_notified=False,
-            )
-            mention_content = " ".join(f"<@&{rid}>" for rid in sorted(mention_ids)) or None
+                msg = await channel.send(embed=embed, view=view)
 
-            msg = await channel.send(embed=embed, view=view)
+                thread_name = submission_user_name or get_string(
+                    self.lang, "application.conversation.submit.review_thread_name"
+                )
+                try:
+                    thread = await msg.create_thread(name=thread_name)
+                    if mention_content:
+                        await thread.send(mention_content)
+                except discord.HTTPException:
+                    self.bot.log.warning("application: failed to create review thread for msg %d", msg.id)
 
-            thread_name = submission_user_name or get_string(
-                self.lang, "application.conversation.submit.review_thread_name"
-            )
-            try:
-                thread = await msg.create_thread(name=thread_name)
-                if mention_content:
-                    await thread.send(mention_content)
-            except discord.HTTPException:
-                self.bot.log.warning("application: failed to create review thread for msg %d", msg.id)
-
-            with self.bot.session_scope() as session:
-                submission = ApplicationSubmission.get_by_id(self.submission_id, session)
-                submission.ReviewMessageId = msg.id
+                with self.bot.session_scope() as session:
+                    submission = ApplicationSubmission.get_by_id(self.submission_id, session)
+                    if submission is not None:
+                        submission.ReviewMessageId = msg.id
+                    else:
+                        self.bot.log.warning(
+                            "application: submission %d deleted before ReviewMessageId could be persisted",
+                            self.submission_id,
+                        )
 
         _c = "application.conversation.submit"
         emb = Embed(

--- a/NerdyPy/modules/moderation.py
+++ b/NerdyPy/modules/moderation.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from datetime import UTC, datetime, time, timedelta
-from typing import Optional
 
 import discord
 from discord import Color, Embed, HTTPException, Interaction, Member, TextChannel, app_commands
@@ -255,8 +254,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         interaction: Interaction,
         enable: bool,
         kick_after: str,
-        kick_reminder_message: Optional[str] = None,
-        reminder_message_source: Optional[str] = None,
+        kick_reminder_message: str | None = None,
+        reminder_message_source: str | None = None,
     ):
         """Activates the AutoKicker. [bot-moderator]"""
         lang = self._lang(interaction.guild_id)
@@ -304,8 +303,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         self,
         interaction: Interaction,
         channel: TextChannel,
-        delete_older_than: Optional[str] = None,
-        keep_messages: Optional[int] = None,
+        delete_older_than: str | None = None,
+        keep_messages: int | None = None,
         delete_pinned_message: bool = False,
     ) -> None:
         """
@@ -315,10 +314,10 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         ----------
         interaction
         channel: discord.TextChannel
-        delete_older_than: Optional[str]
+        delete_older_than: str | None
             Time after messages get deleted, like "1 day", "1 week" or "5 minutes".
             Supports also abbreviations like "min" and "h".
-        keep_messages: Optional[int]
+        keep_messages: int | None
             Messages to keep after deletion. Can be used in combination with "delete_older_than".
         delete_pinned_message: bool
         """
@@ -500,8 +499,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         self,
         interaction: Interaction,
         channel: TextChannel,
-        delete_older_than: Optional[str] = None,
-        keep_messages: Optional[int] = None,
+        delete_older_than: str | None = None,
+        keep_messages: int | None = None,
         delete_pinned_message: bool = False,
     ):
         """
@@ -511,10 +510,10 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
         ----------
         interaction
         channel: discord.TextChannel
-        delete_older_than: Optional[str]
+        delete_older_than: str | None
             Time after messages get deleted, like "1 day", "1 week" or "5 minutes".
             Supports also abbreviations like "min" and "h".
-        keep_messages: Optional[int]
+        keep_messages: int | None
             Messages to keep after deletion. Can be used in combination with "delete_older_than".
         delete_pinned_message: bool
         """
@@ -545,7 +544,7 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
 
     @user_group.command(name="info")
     @checks.has_permissions(moderate_members=True)
-    async def _get_user_info(self, interaction: Interaction, member: Optional[Member] = None):
+    async def _get_user_info(self, interaction: Interaction, member: Member | None = None):
         """displays information about given user [bot-moderator]"""
         lang = self._lang(interaction.guild_id)
         member = member or interaction.user
@@ -571,14 +570,14 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
     @user_group.command(name="list")
     @checks.has_permissions(moderate_members=True)
     async def _list_user_info_from_guild(
-        self, interaction: Interaction, show_only_users_without_roles: Optional[bool] = None
+        self, interaction: Interaction, show_only_users_without_roles: bool | None = None
     ):
         """displays a list of users on your server [bot-moderator]
 
         Parameters
         ----------
         interaction
-        show_only_users_without_roles: Optional[bool]
+        show_only_users_without_roles: bool | None
             If True shows only Users without a Role. (The role everyone is not considered a given role)
         """
         lang = self._lang(interaction.guild_id)
@@ -750,8 +749,8 @@ class Moderation(NerpyBotCog, GroupCog, group_name="moderation"):
     async def _leavemsg_message(
         self,
         interaction: Interaction,
-        message: Optional[str] = None,
-        message_source: Optional[str] = None,
+        message: str | None = None,
+        message_source: str | None = None,
     ) -> None:
         """Set a custom leave message. Use {member} as placeholder. [administrator]"""
         lang = self._lang(interaction.guild_id)

--- a/NerdyPy/utils/format.py
+++ b/NerdyPy/utils/format.py
@@ -4,36 +4,6 @@
 from collections.abc import Generator
 
 
-def box(text: str, lang: str = "") -> str:
-    """discord format for box with optional language highlighting"""
-    return f"```{lang}\n{text}\n```"
-
-
-def inline(text: str) -> str:
-    """discord format for inline box"""
-    return f"`{text}`"
-
-
-def italics(text: str) -> str:
-    """discord format for italic text"""
-    return f"*{text}*"
-
-
-def bold(text: str) -> str:
-    """discord format for bold text"""
-    return f"**{text}**"
-
-
-def strikethrough(text: str) -> str:
-    """discord format for strikethrough text"""
-    return f"~~{text}~~"
-
-
-def underline(text: str) -> str:
-    """discord format for underlining"""
-    return f"__{text}__"
-
-
 def pagify(text: str, delims: list[str] | None = None, page_length: int = 2000) -> Generator[str, None, None]:
     """DOES NOT RESPECT MARKDOWN BOXES OR INLINE CODE"""
     if delims is None:

--- a/web/frontend/src/dev/fixtures.ts
+++ b/web/frontend/src/dev/fixtures.ts
@@ -319,7 +319,7 @@ export const guild1CraftingOrders: CraftingOrderSchema[] = [
     item_name: "Weathered Harbinger Axe",
     icon_url: null,
     notes: null,
-    status: "claimed",
+    status: "in_progress",
     creator_id: "111000000000000002",
     creator_name: "StargazerX",
     crafter_id: "111000000000000099",


### PR DESCRIPTION
Four small independent fixes and cleanups that accumulated in the issue tracker without warranting individual PRs.

- **#409** Remove 6 dead formatting helpers from `utils/format.py` (`box`, `inline`, `italics`, `bold`, `strikethrough`, `underline`) — zero call sites anywhere in the codebase. Only `pagify` remains.
- **#427** Guard `ReviewMessageId` write in the application submit conversation against concurrent deletion. First session now returns early with a warning if the submission vanished before the review embed could be posted; second session uses `is not None` guard with a warning on miss. Pre-initialized sentinels prevent `UnboundLocalError` on the embed-building path.
- **#426** Fix frontend dev fixture status `"claimed"` → `"in_progress"` — `"claimed"` is not a valid backend status value and the fixture was never exercising the `in_progress` UI path.
- **#419** Modernize `Optional[T]` → `T | None` throughout `moderation.py` and drop the `from typing import Optional` import.

Closes #409, #427, #426, #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application submission flow to better detect missing submissions, log issues, and abort gracefully when review posting fails.

* **Refactor**
  * Modernized moderation command type annotations to use current union syntax.
  * Removed legacy text-formatting helper functions that are no longer used.

* **Tests**
  * Adjusted a development fixture’s crafting status from "claimed" to "in_progress".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->