### PR TITLE
config(ci): trigger PR Agent review on label + subsequent pushes

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -2,7 +2,7 @@ name: PR Agent
 
 on:
   pull_request:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened, labeled, synchronize]
   issue_comment:
     types: [created]
 

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -50,3 +50,6 @@ Rules for .github/workflows/**/*.yml:
 
 [github_pr_description]
 publish_labels = false
+
+[github_action_config]
+pr_actions = ["opened", "reopened", "ready_for_review", "review_requested", "labeled", "synchronize"]


### PR DESCRIPTION
PR Agent was silently skipping `labeled` events because its internal `PR_ACTIONS` allowlist doesn't include it by default. Adding `review` label ran the job but produced no review.

This adds `[github_action_config]` to `.pr_agent.toml` with both `labeled` and `synchronize` in `pr_actions`, and adds `synchronize` to the workflow triggers. The existing label gate in the `if` condition ensures pushes only trigger a review when the `review` label is already set — no label, no review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)