### PR TITLE
config(ci): add Anthropic fallback models and fix log level for PR Agent

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,8 @@
 [config]
 model = "anthropic/claude-haiku-4-5-20251001"
 ai_provider = "anthropic"
+fallback_models = ["anthropic/claude-3-5-haiku-20241022", "anthropic/claude-3-5-sonnet-20241022"]
+log_level = "INFO"
 
 [pr_reviewer]
 require_focused_review = true


### PR DESCRIPTION
Replaces the default `o4-mini` fallback (which has no key configured) with Anthropic models, and sets `log_level = "INFO"` to prevent the full diff debug line from truncating log output mid-execution.

Closes no issue — discovered while debugging #450 not receiving a PR Agent review.