### PR TITLE
fix(ci): fix PR Agent auth and align with CodeRabbit behavior

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -16,15 +16,17 @@ jobs:
       (github.event_name == 'pull_request' &&
        contains(github.event.pull_request.labels.*.name, 'review')) ||
       (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request != null)
+       github.event.issue.pull_request != null &&
+       github.event.sender.type != 'Bot')
     permissions:
       contents: read
       pull-requests: write
       issues: write
     steps:
       - name: Run PR Agent
-        uses: Codium-ai/pr-agent@main
+        uses: qodo-ai/pr-agent@main
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC.KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CONFIG.AI_PROVIDER: anthropic
           CONFIG.MODEL: anthropic/claude-haiku-4-5-20251001

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -5,7 +5,6 @@ fallback_models = ["anthropic/claude-3-5-haiku-20241022", "anthropic/claude-3-5-
 log_level = "INFO"
 
 [pr_reviewer]
-require_focused_review = true
 extra_instructions = """
 You are reviewing a Discord bot (discord.py, Python 3.13) with a FastAPI web component and SQLAlchemy ORM.
 Be direct and concise. Focus on bugs, correctness, and architectural issues.


### PR DESCRIPTION
`ANTHROPIC_API_KEY` was never set — only `ANTHROPIC.KEY` was, which reaches PR Agent's dynaconf settings but not litellm's direct key lookup. litellm reads `ANTHROPIC_API_KEY` from the environment (documented in litellm's Anthropic provider docs). Without it, every model attempt failed with `authentication_error: invalid x-api-key`.

Also adds three smaller correctness fixes while in the file:
- `qodo-ai/pr-agent@main` — canonical action ref post-rebranding
- `sender.type != 'Bot'` guard on `issue_comment` — prevents PR Agent's own review comments from re-triggering the workflow
- Remove `require_focused_review = true` — this setting silently aborted reviews on multi-issue PRs (CodeRabbit reviews everything)

---

$(~/.claude/get-flair.sh --dir /home/dennis/workspace/git/nerdycraft/NerpyBot --mr fix)