### PR TITLE
fix(ci): fix PR Agent auth + enable inline code suggestions

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -28,9 +28,10 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC.KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: dummy
           CONFIG.AI_PROVIDER: anthropic
           CONFIG.MODEL: anthropic/claude-haiku-4-5-20251001
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "false"
-          github_action_config.auto_improve: "false"
+          github_action_config.auto_improve: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR Agent was silently sending `\"dummy_key\"` as the Anthropic API key on every run. Root cause traced through the litellm call stack: when `OPENAI_API_KEY` is absent, `LiteLLMAIHandler.__init__` sets `litellm.api_key = \"dummy_key\"`. That value is then explicitly passed as `kwargs[\"api_key\"]` to every completion call. Since litellm's Anthropic key resolution is a Python `or` chain, the truthy `\"dummy_key\"` short-circuits before `litellm.anthropic_key` (the real key) is ever reached.

Fix: set `OPENAI_API_KEY=dummy` so the guard branch is skipped and `litellm.api_key` stays `None`, allowing the fallback to use `litellm.anthropic_key` set from `ANTHROPIC.KEY`.

Also enables `auto_improve` to post inline code suggestion comments on the diff alongside the review summary.

Verified end-to-end locally using `codiumai/pr-agent:github_action` (same image as CI) — without the fix the `\"dummy_key\"` error reproduces, with it a full review is generated and posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)